### PR TITLE
Implement Support for Initial Expressions and all Mira Operations that Concern Initial Expressions

### DIFF
--- a/mira/examples/sir.py
+++ b/mira/examples/sir.py
@@ -143,7 +143,7 @@ sir_init_val_norm = 1e5
 for template in sir_parameterized_init.templates:
     for concept in template.get_concepts():
         concept.units = Unit(expression=sympy.Symbol('person'))
-sir_parameterized_init.initials['susceptible_population'].expression = sympy.Float(str(sir_init_val_norm-1))
+sir_parameterized_init.initials['susceptible_population'].expression = sympy.Float(sir_init_val_norm-1)
 sir_parameterized_init.initials['infected_population'].expression = sympy.Integer('1')
 sir_parameterized_init.initials['immune_population'].expression = sympy.Integer('0')
 

--- a/mira/examples/sir.py
+++ b/mira/examples/sir.py
@@ -6,10 +6,9 @@ import sympy
 
 from mira.metamodel import ControlledConversion, NaturalConversion, \
     GroupedControlledConversion, TemplateModel, Initial, Parameter, \
-    safe_parse_expr, Unit
+    safe_parse_expr, Unit, SympyExprStr
 from .concepts import susceptible, infected, recovered, infected_symptomatic, \
     infected_asymptomatic
-
 
 __all__ = [
     "sir",
@@ -62,9 +61,9 @@ sir_parameterized = TemplateModel(
         'gamma': Parameter(name='gamma', value=0.2)
     },
     initials={
-        'susceptible_population': Initial(concept=_d(susceptible), value=1),
-        'infected_population': Initial(concept=_d(infected), value=2),
-        'immune_population': Initial(concept=_d(recovered), value=3),
+        'susceptible_population': Initial(concept=_d(susceptible), expression=sympy.Integer('1')),
+        'infected_population': Initial(concept=_d(infected), expression=sympy.Integer('2')),
+        'immune_population': Initial(concept=_d(recovered), expression=sympy.Integer('3')),
     }
 )
 
@@ -116,7 +115,6 @@ sir_bilayer = \
      "Wn": [{"efflux": 1, "effusion": 1},
             {"efflux": 2, "effusion": 2}]}
 
-
 infection_symptomatic = GroupedControlledConversion(
     subject=susceptible,
     outcome=infected_symptomatic,
@@ -145,10 +143,9 @@ sir_init_val_norm = 1e5
 for template in sir_parameterized_init.templates:
     for concept in template.get_concepts():
         concept.units = Unit(expression=sympy.Symbol('person'))
-sir_parameterized_init.initials['susceptible_population'].value = \
-    sir_init_val_norm - 1
-sir_parameterized_init.initials['infected_population'].value = 1
-sir_parameterized_init.initials['immune_population'].value = 0
+sir_parameterized_init.initials['susceptible_population'].expression = sympy.Float(str(sir_init_val_norm-1))
+sir_parameterized_init.initials['infected_population'].expression = sympy.Integer('1')
+sir_parameterized_init.initials['immune_population'].expression = sympy.Integer('0')
 
 sir_parameterized_init.parameters['beta'].units = \
     Unit(expression=1 / (sympy.Symbol('person') * sympy.Symbol('day')))

--- a/mira/metamodel/io.py
+++ b/mira/metamodel/io.py
@@ -44,23 +44,7 @@ def expression_to_mathml(expression: sympy.Expr, *args, **kwargs) -> str:
     in special ways.
     """
     if isinstance(expression, SympyExprStr):
-
-        # Issue is that expression is usually of type SympyExprStr in test_model_api's case and this method expects that
-        # expression.args[0] is of type symbol or a Sympy operation such as Mul, Add, Sub
-        # However, expression.args[0] is of type string since we introduced the change to initials and then error
-        # occurs when you call the atoms method on it
         expression = expression.args[0]
-
-        # If expression.args[0] is a primitive data type, recast it as a Sympy Object, so we can run the for loop
-        if isinstance(expression, str):
-            if '.' in expression:
-                expression = sympy.Float(expression)
-            else:
-                expression = sympy.Integer(expression)
-        elif isinstance(expression, float):
-            expression = sympy.Float(expression)
-        elif isinstance(expression, int):
-            expression = sympy.Integer(expression)
 
     mappings = {}
     for sym in expression.atoms(sympy.Symbol):

--- a/mira/metamodel/io.py
+++ b/mira/metamodel/io.py
@@ -44,7 +44,24 @@ def expression_to_mathml(expression: sympy.Expr, *args, **kwargs) -> str:
     in special ways.
     """
     if isinstance(expression, SympyExprStr):
+
+        # Issue is that expression is usually of type SympyExprStr in test_model_api's case and this method expects that
+        # expression.args[0] is of type symbol or a Sympy operation such as Mul, Add, Sub
+        # However, expression.args[0] is of type string since we introduced the change to initials and then error
+        # occurs when you call the atoms method on it
         expression = expression.args[0]
+
+        # If expression.args[0] is a primitive data type, recast it as a Sympy Object, so we can run the for loop
+        if isinstance(expression, str):
+            if '.' in expression:
+                expression = sympy.Float(expression)
+            else:
+                expression = sympy.Integer(expression)
+        elif isinstance(expression, float):
+            expression = sympy.Float(expression)
+        elif isinstance(expression, int):
+            expression = sympy.Integer(expression)
+
     mappings = {}
     for sym in expression.atoms(sympy.Symbol):
         name = '|' + str(sym).replace('_', 'QQQ') + '|'

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -221,15 +221,9 @@ def stratify(
             new_concept = initial.concept.with_context(
                 do_rename=modify_names, **{key: stratum},
             )
-            try:
-                initials[new_concept.name] = Initial(
-                    concept=new_concept, expression=SympyExprStr(initial.expression.args[0] / len(strata))
-                )
-            # handles case where initials.expression.args[0] is of type string vs float
-            except TypeError:
-                initials[new_concept.name] = Initial(
-                    concept=new_concept, expression=SympyExprStr(float(initial.expression.args[0]) / len(strata))
-                )
+            initials[new_concept.name] = Initial(
+                concept=new_concept, expression=SympyExprStr(initial.expression.args[0] / len(strata))
+            )
 
     observables = {}
     for observable_key, observable in template_model.observables.items():
@@ -566,11 +560,8 @@ def counts_to_dimensionless(tm: TemplateModel,
                     if concept.name in tm.initials and concept.name not in initials_normalized:
                         init = tm.initials[concept.name]
                         if init.expression is not None:
-                            try:
-                                init.expression = SympyExprStr(
-                                    float(init.expression.args[0]) / (norm_factor ** exponent))
-                            except ValueError:
-                                init.expression = SympyExprStr(init.expression.args[0] / (norm_factor ** exponent))
+                            init.expression = SympyExprStr(
+                                init.expression.args[0] / (norm_factor ** exponent))
                             if init.concept.units:
                                 init.concept.units.expression = \
                                     SympyExprStr(init.concept.units.expression.args[0] /

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -223,7 +223,7 @@ def stratify(
                 do_rename=modify_names, **{key: stratum},
             )
             initials[new_concept.name] = Initial(
-                concept=new_concept, value=initial.value / len(strata),
+                concept=new_concept, expression=SympyExprStr(initial.expression / len(strata)),
             )
 
     observables = {}

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -24,19 +24,19 @@ __all__ = [
 
 
 def stratify(
-    template_model: TemplateModel,
-    *,
-    key: str,
-    strata: Collection[str],
-    structure: Optional[Iterable[Tuple[str, str]]] = None,
-    directed: bool = False,
-    conversion_cls: Type[Template] = NaturalConversion,
-    cartesian_control: bool = False,
-    modify_names: bool = True,
-    params_to_stratify: Optional[Collection[str]] = None,
-    params_to_preserve: Optional[Collection[str]] = None,
-    concepts_to_stratify: Optional[Collection[str]] = None,
-    concepts_to_preserve: Optional[Collection[str]] = None,
+        template_model: TemplateModel,
+        *,
+        key: str,
+        strata: Collection[str],
+        structure: Optional[Iterable[Tuple[str, str]]] = None,
+        directed: bool = False,
+        conversion_cls: Type[Template] = NaturalConversion,
+        cartesian_control: bool = False,
+        modify_names: bool = True,
+        params_to_stratify: Optional[Collection[str]] = None,
+        params_to_preserve: Optional[Collection[str]] = None,
+        concepts_to_stratify: Optional[Collection[str]] = None,
+        concepts_to_preserve: Optional[Collection[str]] = None,
 ) -> TemplateModel:
     """Multiplies a model into several strata.
 
@@ -122,7 +122,7 @@ def stratify(
             exclude_concepts = concept_names - set(concepts_to_stratify)
         else:
             exclude_concepts = set(concepts_to_preserve) | (
-                concept_names - set(concepts_to_stratify)
+                    concept_names - set(concepts_to_stratify)
             )
 
     keep_unstratified_parameters = set()
@@ -313,7 +313,7 @@ def rewrite_rate_law(template_model: TemplateModel, old_template: Template,
 
     # Step 2. Rename symbols corresponding to compartments based on the new concepts
     for old_controller, new_controller in zip(
-        old_template.get_controllers(), new_template.get_controllers(),
+            old_template.get_controllers(), new_template.get_controllers(),
     ):
         rate_law = rate_law.subs(
             sympy.Symbol(old_controller.name),
@@ -566,7 +566,11 @@ def counts_to_dimensionless(tm: TemplateModel,
                     if concept.name in tm.initials and concept.name not in initials_normalized:
                         init = tm.initials[concept.name]
                         if init.expression is not None:
-                            init.expression = SympyExprStr(float(init.expression.args[0]) / (norm_factor ** exponent))
+                            try:
+                                init.expression = SympyExprStr(
+                                    float(init.expression.args[0]) / (norm_factor ** exponent))
+                            except ValueError:
+                                init.expression = SympyExprStr(init.expression.args[0] / (norm_factor ** exponent))
                             if init.concept.units:
                                 init.concept.units.expression = \
                                     SympyExprStr(init.concept.units.expression.args[0] /

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -24,19 +24,19 @@ __all__ = [
 
 
 def stratify(
-        template_model: TemplateModel,
-        *,
-        key: str,
-        strata: Collection[str],
-        structure: Optional[Iterable[Tuple[str, str]]] = None,
-        directed: bool = False,
-        conversion_cls: Type[Template] = NaturalConversion,
-        cartesian_control: bool = False,
-        modify_names: bool = True,
-        params_to_stratify: Optional[Collection[str]] = None,
-        params_to_preserve: Optional[Collection[str]] = None,
-        concepts_to_stratify: Optional[Collection[str]] = None,
-        concepts_to_preserve: Optional[Collection[str]] = None,
+    template_model: TemplateModel,
+    *,
+    key: str,
+    strata: Collection[str],
+    structure: Optional[Iterable[Tuple[str, str]]] = None,
+    directed: bool = False,
+    conversion_cls: Type[Template] = NaturalConversion,
+    cartesian_control: bool = False,
+    modify_names: bool = True,
+    params_to_stratify: Optional[Collection[str]] = None,
+    params_to_preserve: Optional[Collection[str]] = None,
+    concepts_to_stratify: Optional[Collection[str]] = None,
+    concepts_to_preserve: Optional[Collection[str]] = None,
 ) -> TemplateModel:
     """Multiplies a model into several strata.
 
@@ -122,7 +122,7 @@ def stratify(
             exclude_concepts = concept_names - set(concepts_to_stratify)
         else:
             exclude_concepts = set(concepts_to_preserve) | (
-                    concept_names - set(concepts_to_stratify)
+                concept_names - set(concepts_to_stratify)
             )
 
     keep_unstratified_parameters = set()
@@ -225,7 +225,7 @@ def stratify(
                 initials[new_concept.name] = Initial(
                     concept=new_concept, expression=SympyExprStr(initial.expression.args[0] / len(strata))
                 )
-            # handles case where initials.expression.args[0] is of type string
+            # handles case where initials.expression.args[0] is of type string vs float
             except TypeError:
                 initials[new_concept.name] = Initial(
                     concept=new_concept, expression=SympyExprStr(float(initial.expression.args[0]) / len(strata))
@@ -313,7 +313,7 @@ def rewrite_rate_law(template_model: TemplateModel, old_template: Template,
 
     # Step 2. Rename symbols corresponding to compartments based on the new concepts
     for old_controller, new_controller in zip(
-            old_template.get_controllers(), new_template.get_controllers(),
+        old_template.get_controllers(), new_template.get_controllers(),
     ):
         rate_law = rate_law.subs(
             sympy.Symbol(old_controller.name),

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -616,7 +616,10 @@
           "$ref": "#/definitions/Concept"
         },
         "expression": {
-          "$ref": "#/definitions/Unit/properties/expression"
+          "title": "Expression",
+          "description": "The expression for the initial.",
+          "type": "string",
+          "example": "2*x"
         }
       },
       "required": [

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -616,7 +616,7 @@
           "$ref": "#/definitions/Concept"
         },
         "expression": {
-          "type": "object"
+          "$ref": "#/definitions/Unit/properties/expression"
         }
       },
       "required": [

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -615,14 +615,13 @@
         "concept": {
           "$ref": "#/definitions/Concept"
         },
-        "value": {
-          "title": "Value",
-          "type": "number"
+        "expression": {
+          "type": "object"
         }
       },
       "required": [
         "concept",
-        "value"
+        "expression"
       ]
     },
     "Observable": {

--- a/mira/metamodel/schema.py
+++ b/mira/metamodel/schema.py
@@ -18,7 +18,7 @@ def get_json_schema():
     """Get the JSON schema for MIRA."""
     rv = {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": "https://raw.githubusercontent.com/indralab/mira/main/mira/metamodel/schema.json",
+        "$id": "https://raw.githubusercontent.com/nanglo123/mira/initial_expressions/mira/metamodel/schema.json",
     }
     rv.update(
         pydantic.schema.schema(

--- a/mira/metamodel/schema.py
+++ b/mira/metamodel/schema.py
@@ -18,7 +18,7 @@ def get_json_schema():
     """Get the JSON schema for MIRA."""
     rv = {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": "https://raw.githubusercontent.com/nanglo123/mira/initial_expressions/mira/metamodel/schema.json",
+        "$id": "https://raw.githubusercontent.com/indralab/mira/main/mira/metamodel/schema.json",
     }
     rv.update(
         pydantic.schema.schema(

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -66,9 +66,6 @@ class Parameter(Concept):
         default_factory=None, description="A distribution of values for the parameter."
     )
 
-    expression: Optional[SympyExprStr] = Field(
-        default_factory=None, description="Expression of the parameter."
-    )
 
 
 class Observable(Concept):

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -47,6 +47,7 @@ class Initial(BaseModel):
         """Get the names of all parameters in the expression."""
         return {str(s) for s in self.expression.free_symbols} & set(known_param_names)
 
+
 class Distribution(BaseModel):
     """A distribution of values for a parameter."""
     type: str = Field(
@@ -65,7 +66,6 @@ class Parameter(Concept):
     distribution: Optional[Distribution] = Field(
         default_factory=None, description="A distribution of values for the parameter."
     )
-
 
 
 class Observable(Concept):
@@ -139,29 +139,29 @@ class Annotations(BaseModel):
     description: Optional[str] = Field(
         description="A description of the model",
         example="The coronavirus disease 2019 (COVID-19) pandemic has placed "
-        "epidemic modeling at the forefront of worldwide public policy making. "
-        "Nonetheless, modeling and forecasting the spread of COVID-19 remains a "
-        "challenge. Here, we detail three regional scale models for forecasting "
-        "and assessing the course of the pandemic. This work demonstrates the "
-        "utility of parsimonious models for early-time data and provides an "
-        "accessible framework for generating policy-relevant insights into its "
-        "course. We show how these models can be connected to each other and to "
-        "time series data for a particular region. Capable of measuring and "
-        "forecasting the impacts of social distancing, these models highlight the "
-        "dangers of relaxing nonpharmaceutical public health interventions in the "
-        "absence of a vaccine or antiviral therapies."
+                "epidemic modeling at the forefront of worldwide public policy making. "
+                "Nonetheless, modeling and forecasting the spread of COVID-19 remains a "
+                "challenge. Here, we detail three regional scale models for forecasting "
+                "and assessing the course of the pandemic. This work demonstrates the "
+                "utility of parsimonious models for early-time data and provides an "
+                "accessible framework for generating policy-relevant insights into its "
+                "course. We show how these models can be connected to each other and to "
+                "time series data for a particular region. Capable of measuring and "
+                "forecasting the impacts of social distancing, these models highlight the "
+                "dangers of relaxing nonpharmaceutical public health interventions in the "
+                "absence of a vaccine or antiviral therapies."
     )
     license: Optional[str] = Field(
         description="Information about the licensing of the model artifact. "
-        "Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, "
-        "models from the BioModels databases are all licensed under the CC0 "
-        "public attribution license.",
+                    "Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, "
+                    "models from the BioModels databases are all licensed under the CC0 "
+                    "public attribution license.",
         example="CC0",
     )
     authors: List[Author] = Field(
         default_factory=list,
         description="A list of authors/creators of the model. This is not the same "
-        "as the people who e.g., submitted the model to BioModels",
+                    "as the people who e.g., submitted the model to BioModels",
         example=[
             Author(name="Andrea L Bertozzi"),
             Author(name="Elisa Franco"),
@@ -173,35 +173,35 @@ class Annotations(BaseModel):
     references: List[str] = Field(
         default_factory=list,
         description="A list of CURIEs (i.e., <prefix>:<identifier>) corresponding "
-        "to literature references that describe the model. Do **not** duplicate the "
-        "same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
+                    "to literature references that describe the model. Do **not** duplicate the "
+                    "same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
         example=["pubmed:32616574"],
     )
     # TODO agree on how we annotate this one, e.g. with a timedelta
     time_scale: Optional[str] = Field(
         description="The granularity of the time element of the model, typically on "
-        "the scale of days, weeks, or months for epidemiology models",
+                    "the scale of days, weeks, or months for epidemiology models",
         example="day",
     )
     time_start: Optional[datetime.datetime] = Field(
         description="The start time of the applicability of a model, given as a datetime. "
-        "When the time scale is not so granular, leave the less granular fields as default, "
-        "i.e., if the time scale is on months, give dates like YYYY-MM-01 00:00",
+                    "When the time scale is not so granular, leave the less granular fields as default, "
+                    "i.e., if the time scale is on months, give dates like YYYY-MM-01 00:00",
         # example=datetime.datetime(year=2020, month=3, day=1),
     )
     time_end: Optional[datetime.datetime] = Field(
         description="Similar to the start time of the applicability of a model, the end time "
-        "is given as a datetime. For example, the Bertozzi 2020 model is applicable between "
-        "March and August 2020, so this field is annotated with August 1st, 2020.",
+                    "is given as a datetime. For example, the Bertozzi 2020 model is applicable between "
+                    "March and August 2020, so this field is annotated with August 1st, 2020.",
         # example=datetime.datetime(year=2020, month=8, day=1),
     )
     locations: List[str] = Field(
         default_factory=list,
         description="A location or list of locations where this model is applicable, ideally "
-        "annotated using a CURIEs referencing a controlled vocabulary such as GeoNames, which "
-        "has multiple levels of granularity including city/state/country level terms. For example,"
-        "the Bertozzi 2020 model was for New York City (geonames:5128581) and California "
-        "(geonames:5332921)",
+                    "annotated using a CURIEs referencing a controlled vocabulary such as GeoNames, which "
+                    "has multiple levels of granularity including city/state/country level terms. For example,"
+                    "the Bertozzi 2020 model was for New York City (geonames:5128581) and California "
+                    "(geonames:5332921)",
         example=[
             "geonames:5128581",
             "geonames:5332921",
@@ -210,10 +210,10 @@ class Annotations(BaseModel):
     pathogens: List[str] = Field(
         default_factory=list,
         description="The pathogens present in the model, given with CURIEs referencing vocabulary "
-        "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
-        "SARS-CoV-2, this is ncbitaxon:2697049. Do not confuse this field with terms for annotating "
-        "the disease caused by the pathogen. Note that some models may have multiple pathogens, for "
-        "simulating double pandemics such as the interaction with SARS-CoV-2 and the seasonal flu.",
+                    "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
+                    "SARS-CoV-2, this is ncbitaxon:2697049. Do not confuse this field with terms for annotating "
+                    "the disease caused by the pathogen. Note that some models may have multiple pathogens, for "
+                    "simulating double pandemics such as the interaction with SARS-CoV-2 and the seasonal flu.",
         example=[
             "ncbitaxon:2697049",
         ],
@@ -221,9 +221,9 @@ class Annotations(BaseModel):
     diseases: List[str] = Field(
         default_factory=list,
         description="The diseases caused by pathogens in the model, given with CURIEs referencing "
-        "vocabulary for dieases, such as DOID, EFO, or MONDO. For example, the Bertozzi 2020 model "
-        "is about SARS-CoV-2, which causes COVID-19. In the Human Disease Ontology (DOID), this "
-        "is referenced by doid:0080600.",
+                    "vocabulary for dieases, such as DOID, EFO, or MONDO. For example, the Bertozzi 2020 model "
+                    "is about SARS-CoV-2, which causes COVID-19. In the Human Disease Ontology (DOID), this "
+                    "is referenced by doid:0080600.",
         example=[
             "doid:0080600",
         ],
@@ -231,10 +231,10 @@ class Annotations(BaseModel):
     hosts: List[str] = Field(
         default_factory=list,
         description="The hosts present in the model, given with CURIEs referencing vocabulary "
-        "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
-        "human infection by SARS-CoV-2. Therefore, the appropriate annotation for this field "
-        "would be ncbitaxon:9606. Note that some models have multiple hosts, such as Malaria "
-        "models that consider humans and mosquitos.",
+                    "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
+                    "human infection by SARS-CoV-2. Therefore, the appropriate annotation for this field "
+                    "would be ncbitaxon:9606. Note that some models have multiple hosts, such as Malaria "
+                    "models that consider humans and mosquitos.",
         example=[
             "ncbitaxon:9606",
         ],
@@ -278,14 +278,14 @@ class TemplateModel(BaseModel):
         Field(
             default_factory=None,
             description="A structure containing model-level annotations. "
-            "Note that all annotations are optional.",
+                        "Note that all annotations are optional.",
         )
 
     time: Optional[Time] = \
         Field(
             default_factory=None,
             description="A structure containing time-related annotations. "
-            "Note that all annotations are optional.",
+                        "Note that all annotations are optional.",
         )
 
     class Config:
@@ -471,7 +471,7 @@ class TemplateModel(BaseModel):
         return graph
 
     def draw_graph(
-        self, path: str, prog: str = "dot", args: str = "", format: Optional[str] = None
+            self, path: str, prog: str = "dot", args: str = "", format: Optional[str] = None
     ):
         """Draw a pygraphviz graph of the TemplateModel
 

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -37,7 +37,6 @@ class Initial(BaseModel):
         concept_json = data.pop('concept')
         # Get Concept
         concept = Concept.from_json(concept_json)
-
         # If expression string isn't a float
         try:
             return cls(concept=concept, expression=sympy.Float(expression))
@@ -144,29 +143,29 @@ class Annotations(BaseModel):
     description: Optional[str] = Field(
         description="A description of the model",
         example="The coronavirus disease 2019 (COVID-19) pandemic has placed "
-                "epidemic modeling at the forefront of worldwide public policy making. "
-                "Nonetheless, modeling and forecasting the spread of COVID-19 remains a "
-                "challenge. Here, we detail three regional scale models for forecasting "
-                "and assessing the course of the pandemic. This work demonstrates the "
-                "utility of parsimonious models for early-time data and provides an "
-                "accessible framework for generating policy-relevant insights into its "
-                "course. We show how these models can be connected to each other and to "
-                "time series data for a particular region. Capable of measuring and "
-                "forecasting the impacts of social distancing, these models highlight the "
-                "dangers of relaxing nonpharmaceutical public health interventions in the "
-                "absence of a vaccine or antiviral therapies."
+        "epidemic modeling at the forefront of worldwide public policy making. "
+        "Nonetheless, modeling and forecasting the spread of COVID-19 remains a "
+        "challenge. Here, we detail three regional scale models for forecasting "
+        "and assessing the course of the pandemic. This work demonstrates the "
+        "utility of parsimonious models for early-time data and provides an "
+        "accessible framework for generating policy-relevant insights into its "
+        "course. We show how these models can be connected to each other and to "
+        "time series data for a particular region. Capable of measuring and "
+        "forecasting the impacts of social distancing, these models highlight the "
+        "dangers of relaxing nonpharmaceutical public health interventions in the "
+        "absence of a vaccine or antiviral therapies."
     )
     license: Optional[str] = Field(
         description="Information about the licensing of the model artifact. "
-                    "Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, "
-                    "models from the BioModels databases are all licensed under the CC0 "
-                    "public attribution license.",
+        "Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, "
+        "models from the BioModels databases are all licensed under the CC0 "
+        "public attribution license.",
         example="CC0",
     )
     authors: List[Author] = Field(
         default_factory=list,
         description="A list of authors/creators of the model. This is not the same "
-                    "as the people who e.g., submitted the model to BioModels",
+        "as the people who e.g., submitted the model to BioModels",
         example=[
             Author(name="Andrea L Bertozzi"),
             Author(name="Elisa Franco"),
@@ -178,35 +177,35 @@ class Annotations(BaseModel):
     references: List[str] = Field(
         default_factory=list,
         description="A list of CURIEs (i.e., <prefix>:<identifier>) corresponding "
-                    "to literature references that describe the model. Do **not** duplicate the "
-                    "same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
+        "to literature references that describe the model. Do **not** duplicate the "
+        "same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
         example=["pubmed:32616574"],
     )
     # TODO agree on how we annotate this one, e.g. with a timedelta
     time_scale: Optional[str] = Field(
         description="The granularity of the time element of the model, typically on "
-                    "the scale of days, weeks, or months for epidemiology models",
+        "the scale of days, weeks, or months for epidemiology models",
         example="day",
     )
     time_start: Optional[datetime.datetime] = Field(
         description="The start time of the applicability of a model, given as a datetime. "
-                    "When the time scale is not so granular, leave the less granular fields as default, "
-                    "i.e., if the time scale is on months, give dates like YYYY-MM-01 00:00",
+        "When the time scale is not so granular, leave the less granular fields as default, "
+        "i.e., if the time scale is on months, give dates like YYYY-MM-01 00:00",
         # example=datetime.datetime(year=2020, month=3, day=1),
     )
     time_end: Optional[datetime.datetime] = Field(
         description="Similar to the start time of the applicability of a model, the end time "
-                    "is given as a datetime. For example, the Bertozzi 2020 model is applicable between "
-                    "March and August 2020, so this field is annotated with August 1st, 2020.",
+        "is given as a datetime. For example, the Bertozzi 2020 model is applicable between "
+        "March and August 2020, so this field is annotated with August 1st, 2020.",
         # example=datetime.datetime(year=2020, month=8, day=1),
     )
     locations: List[str] = Field(
         default_factory=list,
         description="A location or list of locations where this model is applicable, ideally "
-                    "annotated using a CURIEs referencing a controlled vocabulary such as GeoNames, which "
-                    "has multiple levels of granularity including city/state/country level terms. For example,"
-                    "the Bertozzi 2020 model was for New York City (geonames:5128581) and California "
-                    "(geonames:5332921)",
+        "annotated using a CURIEs referencing a controlled vocabulary such as GeoNames, which "
+        "has multiple levels of granularity including city/state/country level terms. For example,"
+        "the Bertozzi 2020 model was for New York City (geonames:5128581) and California "
+        "(geonames:5332921)",
         example=[
             "geonames:5128581",
             "geonames:5332921",
@@ -215,10 +214,10 @@ class Annotations(BaseModel):
     pathogens: List[str] = Field(
         default_factory=list,
         description="The pathogens present in the model, given with CURIEs referencing vocabulary "
-                    "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
-                    "SARS-CoV-2, this is ncbitaxon:2697049. Do not confuse this field with terms for annotating "
-                    "the disease caused by the pathogen. Note that some models may have multiple pathogens, for "
-                    "simulating double pandemics such as the interaction with SARS-CoV-2 and the seasonal flu.",
+        "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
+        "SARS-CoV-2, this is ncbitaxon:2697049. Do not confuse this field with terms for annotating "
+        "the disease caused by the pathogen. Note that some models may have multiple pathogens, for "
+        "simulating double pandemics such as the interaction with SARS-CoV-2 and the seasonal flu.",
         example=[
             "ncbitaxon:2697049",
         ],
@@ -226,9 +225,9 @@ class Annotations(BaseModel):
     diseases: List[str] = Field(
         default_factory=list,
         description="The diseases caused by pathogens in the model, given with CURIEs referencing "
-                    "vocabulary for dieases, such as DOID, EFO, or MONDO. For example, the Bertozzi 2020 model "
-                    "is about SARS-CoV-2, which causes COVID-19. In the Human Disease Ontology (DOID), this "
-                    "is referenced by doid:0080600.",
+        "vocabulary for dieases, such as DOID, EFO, or MONDO. For example, the Bertozzi 2020 model "
+        "is about SARS-CoV-2, which causes COVID-19. In the Human Disease Ontology (DOID), this "
+        "is referenced by doid:0080600.",
         example=[
             "doid:0080600",
         ],
@@ -236,10 +235,10 @@ class Annotations(BaseModel):
     hosts: List[str] = Field(
         default_factory=list,
         description="The hosts present in the model, given with CURIEs referencing vocabulary "
-                    "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
-                    "human infection by SARS-CoV-2. Therefore, the appropriate annotation for this field "
-                    "would be ncbitaxon:9606. Note that some models have multiple hosts, such as Malaria "
-                    "models that consider humans and mosquitos.",
+        "for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about "
+        "human infection by SARS-CoV-2. Therefore, the appropriate annotation for this field "
+        "would be ncbitaxon:9606. Note that some models have multiple hosts, such as Malaria "
+        "models that consider humans and mosquitos.",
         example=[
             "ncbitaxon:9606",
         ],
@@ -248,10 +247,10 @@ class Annotations(BaseModel):
     model_types: List[str] = Field(
         default_factory=list,
         description="This field describes the type(s) of the model using the Mathematical "
-                    "Modeling Ontology (MAMO), which has terms like 'ordinary differential equation "
-                    " model', 'population model', etc. These should be annotated as CURIEs in the form "
-                    "of mamo:<local unique identifier>. For example, the Bertozzi 2020 model is a population "
-                    "model (mamo:0000028) and ordinary differential equation model (mamo:0000046)",
+                "Modeling Ontology (MAMO), which has terms like 'ordinary differential equation "
+                " model', 'population model', etc. These should be annotated as CURIEs in the form "
+                "of mamo:<local unique identifier>. For example, the Bertozzi 2020 model is a population "
+                "model (mamo:0000028) and ordinary differential equation model (mamo:0000046)",
         example=[
             "mamo:0000028",
             "mamo:0000046",
@@ -277,20 +276,20 @@ class TemplateModel(BaseModel):
     observables: Dict[str, Observable] = \
         Field(default_factory=dict,
               description="A list of observables that are readouts "
-                          "from the model.")
+              "from the model.")
 
     annotations: Optional[Annotations] = \
         Field(
             default_factory=None,
             description="A structure containing model-level annotations. "
-                        "Note that all annotations are optional.",
+            "Note that all annotations are optional.",
         )
 
     time: Optional[Time] = \
         Field(
             default_factory=None,
             description="A structure containing time-related annotations. "
-                        "Note that all annotations are optional.",
+            "Note that all annotations are optional.",
         )
 
     class Config:
@@ -476,7 +475,7 @@ class TemplateModel(BaseModel):
         return graph
 
     def draw_graph(
-            self, path: str, prog: str = "dot", args: str = "", format: Optional[str] = None
+        self, path: str, prog: str = "dot", args: str = "", format: Optional[str] = None
     ):
         """Draw a pygraphviz graph of the TemplateModel
 

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -37,7 +37,12 @@ class Initial(BaseModel):
         concept_json = data.pop('concept')
         # Get Concept
         concept = Concept.from_json(concept_json)
-        return cls(concept=concept, expression=expression)
+
+        # If expression string isn't a float
+        try:
+            return cls(concept=concept, expression=sympy.Float(expression))
+        except ValueError:
+            return cls(concept=concept, epxression=SympyExprStr(expression))
 
     def substitute_parameter(self, name, value):
         """Substitute a parameter value into the observable expression."""
@@ -401,7 +406,7 @@ class TemplateModel(BaseModel):
                 # a :class:`Initial` instance
                 initials[name] = Initial(
                     concept=concepts[name],
-                    value=value,
+                    expression=sympy.Float(value),
                 )
             else:
                 # If the data is not a float, assume it's JSON

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -414,8 +414,6 @@ class TemplateModel(BaseModel):
                 # for a :class:`Initial` instance and parse it to Initial
                 initials[name] = Initial.from_json(value, parameters=parameters)
 
-
-
         return cls(templates=templates,
                    parameters=parameters,
                    initials=initials,

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -66,6 +66,10 @@ class Parameter(Concept):
         default_factory=None, description="A distribution of values for the parameter."
     )
 
+    expression: Optional[SympyExprStr] = Field(
+        default_factory=None, description="Expression of the parameter."
+    )
+
 
 class Observable(Concept):
     """An observable is a special type of Concept that carries an expression.

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class Transition:
     def __init__(
-            self, key, consumed, produced, control, rate, template_type, template: Template,
+        self, key, consumed, produced, control, rate, template_type, template: Template,
     ):
         self.key = key
         self.consumed = consumed

--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 class Transition:
     def __init__(
-        self, key, consumed, produced, control, rate, template_type, template: Template,
+            self, key, consumed, produced, control, rate, template_type, template: Template,
     ):
         self.key = key
         self.consumed = consumed
@@ -67,7 +67,7 @@ class Model:
         self.make_model()
 
     def assemble_variable(
-        self, concept: Concept, initials: Optional[Mapping[str, Initial]] = None,
+            self, concept: Concept, initials: Optional[Mapping[str, Initial]] = None,
     ):
         """Assemble a variable from a concept and optional
         dictionary of initial values.
@@ -97,17 +97,17 @@ class Model:
         # We don't assume that the initial dict key is the same as the
         # name of the given concept the initial applies to, so we check
         # concept name match instead of key match.
-        initial_value = None
+        initial_expr = None
         if initials:
             for k, v in initials.items():
                 if v.concept.name == concept.name:
-                    initial_value = v.value
+                    initial_expr = v.expression
 
         data = {
             'name': concept.name,
             'identifiers': grounding_key,
             'context': context_key,
-            'initial_value': initial_value
+            'expression': initial_expr
         }
         var = Variable(key, data=data, concept=concept)
         self.variables[key] = var

--- a/mira/modeling/askenet/ops.py
+++ b/mira/modeling/askenet/ops.py
@@ -84,6 +84,12 @@ def remove_parameter(tm, removed_id, replacement_value=None):
         tm.substitute_parameter(removed_id, replacement_value)
     else:
         tm.eliminate_parameter(removed_id)
+
+    for initial in tm.initials.values():
+        if replacement_value:
+            initial.substitute_parameter(removed_id, replacement_value)
+        else:
+            initial.substitute_parameter(removed_id, 0)
     return tm
 
 
@@ -118,11 +124,9 @@ def replace_parameter_id(tm, old_id, new_id):
             popped_param.name = new_id
             tm.parameters[new_id] = popped_param
 
-    for concept in tm.initials.values():
-        if concept.expression:
-            concept.expression = SympyExprStr(
-                concept.expression.args[0].subs(sympy.Symbol(old_id),
-                                                 sympy.Symbol(new_id)))
+    for initial in tm.initials.values():
+        if initial.expression:
+            initial.substitute_parameter(old_id, sympy.Symbol(new_id))
 
     return tm
 

--- a/mira/modeling/askenet/ops.py
+++ b/mira/modeling/askenet/ops.py
@@ -117,6 +117,13 @@ def replace_parameter_id(tm, old_id, new_id):
             popped_param = tm.parameters.pop(param.name)
             popped_param.name = new_id
             tm.parameters[new_id] = popped_param
+
+    for concept in tm.initials.values():
+        if concept.expression:
+            concept.expression = SympyExprStr(
+                concept.expression.args[0].subs(sympy.Symbol(old_id),
+                                                 sympy.Symbol(new_id)))
+
     return tm
 
 

--- a/mira/modeling/askenet/ops.py
+++ b/mira/modeling/askenet/ops.py
@@ -227,9 +227,11 @@ def replace_rate_law_sympy(tm, transition_id, new_rate_law: sympy.Expr):
     return tm
 
 
-def replace_rate_law_mathml(tm, transition_id, new_rate_law):
+# This function isn't wrapped because it calls a wrapped function and just
+# passes the AMR through
+def replace_rate_law_mathml(amr, transition_id, new_rate_law):
     new_rate_law_sympy = mathml_to_expression(new_rate_law)
-    return replace_rate_law_sympy(tm, transition_id, new_rate_law_sympy)
+    return replace_rate_law_sympy(amr, transition_id, new_rate_law_sympy)
 
 
 @amr_to_mira
@@ -250,15 +252,19 @@ def replace_initial_expression_sympy(tm, initial_id,
     return tm
 
 
-def replace_observable_expression_mathml(tm, obj_id, new_expression_mathml):
+# This function isn't wrapped because it calls a wrapped function and just
+# passes the AMR through
+def replace_observable_expression_mathml(amr, obs_id, new_expression_mathml):
     new_expression_sympy = mathml_to_expression(new_expression_mathml)
-    return replace_observable_expression_sympy(tm, obj_id,
+    return replace_observable_expression_sympy(amr, obs_id,
                                                new_expression_sympy)
 
 
-def replace_initial_expression_mathml(tm, initial_id, new_expression_mathml):
+# This function isn't wrapped because it calls a wrapped function and just
+# passes the AMR through
+def replace_initial_expression_mathml(amr, initial_id, new_expression_mathml):
     new_expression_sympy = mathml_to_expression(new_expression_mathml)
-    return replace_initial_expression_sympy(tm, initial_id,
+    return replace_initial_expression_sympy(amr, initial_id,
                                             new_expression_sympy)
 
 

--- a/mira/modeling/askenet/ops.py
+++ b/mira/modeling/askenet/ops.py
@@ -190,7 +190,6 @@ def add_state(tm, state_id: str, name: str = None,
     return tm
 
 
-# Remove transition
 @amr_to_mira
 def remove_transition(tm, transition_id):
     tm.templates = [t for t in tm.templates if t.name != transition_id]
@@ -206,7 +205,7 @@ def add_transition(tm, new_transition_id, src_id=None, tgt_id=None,
         ValueError("At least src_id or tgt_id must correspond to an existing concept in the template model")
     rate_law_sympy = SympyExprStr(mathml_to_expression(rate_law_mathml)) \
         if rate_law_mathml else None
-    
+
     subject_concept = tm.get_concepts_name_map().get(src_id)
     outcome_concept = tm.get_concepts_name_map().get(tgt_id)
 
@@ -219,7 +218,6 @@ def add_transition(tm, new_transition_id, src_id=None, tgt_id=None,
 
 
 @amr_to_mira
-# rate law is of type Sympy Expression
 def replace_rate_law_sympy(tm, transition_id, new_rate_law: sympy.Expr):
     # NOTE: this assumes that a sympy expression object is given
     # though it might make sense to take a string instead
@@ -234,8 +232,6 @@ def replace_rate_law_mathml(tm, transition_id, new_rate_law):
     return replace_rate_law_sympy(tm, transition_id, new_rate_law_sympy)
 
 
-# currently initials don't support expressions so only implement the following 2 methods for observables
-# if we are seeking to replace an expression in an initial, return current template model
 @amr_to_mira
 def replace_observable_expression_sympy(tm, obs_id,
                                         new_expression_sympy: sympy.Expr):
@@ -245,9 +241,12 @@ def replace_observable_expression_sympy(tm, obs_id,
     return tm
 
 
+@amr_to_mira
 def replace_initial_expression_sympy(tm, initial_id,
                                      new_expression_sympy: sympy.Expr):
-    # TODO: once initial expressions are supported, implement this
+    for init, initial in tm.initials.items():
+        if init == initial_id:
+            initial.expression = SympyExprStr(new_expression_sympy)
     return tm
 
 
@@ -257,9 +256,10 @@ def replace_observable_expression_mathml(tm, obj_id, new_expression_mathml):
                                                new_expression_sympy)
 
 
-def replace_intial_expression_mathml(tm, initial_id, new_expression_mathml):
-    # TODO: once initial expressions are supported, implement this
-    return tm
+def replace_initial_expression_mathml(tm, initial_id, new_expression_mathml):
+    new_expression_sympy = mathml_to_expression(new_expression_mathml)
+    return replace_initial_expression_sympy(tm, initial_id,
+                                            new_expression_sympy)
 
 
 @amr_to_mira

--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -94,8 +94,6 @@ class AskeNetPetriNetModel:
             # }
             initial = var.data.get('expression')
             if initial is not None:
-                if isinstance(initial, (float, int)):
-                    initial = safe_parse_expr(str(initial))
                 initial_data = {
                     'target': name,
                     'expression': str(initial),

--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -93,7 +93,7 @@ class AskeNetPetriNetModel:
             #   'expression': str,
             #   'expression_mathml': str,
             # }
-            initial = var.data.get('initial_value')
+            initial = var.data.get('expression')
             if initial is not None:
                 if isinstance(initial, (float, int)):
                     initial = safe_parse_expr(str(initial))

--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -94,6 +94,8 @@ class AskeNetPetriNetModel:
             # }
             initial = var.data.get('expression')
             if initial is not None:
+                if isinstance(initial, (float, int)):
+                    initial = safe_parse_expr(str(initial))
                 initial_data = {
                     'target': name,
                     'expression': str(initial),

--- a/mira/modeling/askenet/petrinet.py
+++ b/mira/modeling/askenet/petrinet.py
@@ -5,7 +5,6 @@ at https://github.com/DARPA-ASKEM/Model-Representations/tree/main/petrinet.
 __all__ = ["AskeNetPetriNetModel", "ModelSpecification",
            "template_model_to_petrinet_json"]
 
-
 import json
 import logging
 from copy import deepcopy
@@ -95,8 +94,6 @@ class AskeNetPetriNetModel:
             # }
             initial = var.data.get('expression')
             if initial is not None:
-                if isinstance(initial, (float, int)):
-                    initial = safe_parse_expr(str(initial))
                 initial_data = {
                     'target': name,
                     'expression': str(initial),

--- a/mira/modeling/ode.py
+++ b/mira/modeling/ode.py
@@ -141,6 +141,10 @@ def simulate_ode_model(ode_model: OdeModel, times, initials=None,
                 initial_values.append(int(expression.args[0]))
             elif isinstance(expression, sympy.Float):
                 initial_values.append(float(expression.args[0]))
+        elif isinstance(expression,sympy.Float):
+            initial_values.append(float(expression.args[0]))
+        elif isinstance(expression,sympy.Integer):
+            initial_values.append(int(expression.args[0]))
         else:
             initial_values.append(expression)
     solver.set_initial_value(initial_values)

--- a/mira/modeling/petri.py
+++ b/mira/modeling/petri.py
@@ -48,7 +48,7 @@ class Output(BaseModel):
     transition: int = Field(alias="ot")
 
 
-#    class Observable(BaseModel):
+#class Observable(BaseModel):
 #    concept: str
 #    expression: str
 #    mira_parameters: str

--- a/mira/modeling/petri.py
+++ b/mira/modeling/petri.py
@@ -100,7 +100,10 @@ class PetriNetModel:
             # In this case, initial.expression.args[0] isn't a primitive data type but of types such as
             # 'One',"Two','Zero'
             if initial_expr is not None:
-                state_data['concentration'] = float(str(initial_expr))
+                try:
+                    state_data['concentration'] = float(str(initial_expr))
+                except TypeError:
+                    state_data['concentration'] = 0.0
             else:
                 state_data['concentration'] = 0.0
             self.states.append(state_data)

--- a/mira/modeling/petri.py
+++ b/mira/modeling/petri.py
@@ -16,26 +16,27 @@ import sympy
 
 from . import Model
 from mira.metamodel import expression_to_mathml
+from mira.metamodel.utils import safe_parse_expr
 
 
 class State(BaseModel):
     sname: str
     sprop: Optional[Dict]
-    # mira_ids: str
-    # mira_context: str
-    # mira_initial_value: Optional[float]
+    #mira_ids: str
+    #mira_context: str
+    #mira_initial_value: Optional[float]
 
 
 class Transition(BaseModel):
     tname: str
     rate: Optional[float]
     tprop: Optional[Dict]
-    # template_type: str
-    # parameter_name: Optional[str]
-    # parameter_value: Optional[str]
-    # parameter_distribution: Optional[str]
-    # mira_parameters: Optional[str]
-    # mira_parameter_distributions: Optional[str]
+    #template_type: str
+    #parameter_name: Optional[str]
+    #parameter_value: Optional[str]
+    #parameter_distribution: Optional[str]
+    #mira_parameters: Optional[str]
+    #mira_parameter_distributions: Optional[str]
 
 
 class Input(BaseModel):
@@ -60,7 +61,7 @@ class PetriNetResponse(BaseModel):
     T: List[Transition] = Field(..., description="A list of transitions")
     I: List[Input] = Field(..., description="A list of inputs")
     O: List[Output] = Field(..., description="A list of outputs")
-    # B: List[Observable] = Field(..., description="A list of observables")
+    #B: List[Observable] = Field(..., description="A list of observables")
 
 
 class PetriNetModel:
@@ -97,13 +98,11 @@ class PetriNetModel:
                 }
             }
             initial_expr = var.data.get('expression')
-            # In this case, initial.expression.args[0] isn't a primitive data type but of types such as
-            # 'One',"Two','Zero'
             if initial_expr is not None:
-                try:
-                    state_data['concentration'] = float(str(initial_expr))
-                except TypeError:
-                    state_data['concentration'] = 0.0
+                parameters_dict = {param_name: param_object.value for param_name, param_object in
+                                   model.parameters.items() if not param_object.placeholder}
+
+                state_data['concentration'] = float(initial_expr.subs(parameters_dict).args[0])
             else:
                 state_data['concentration'] = 0.0
             self.states.append(state_data)

--- a/mira/modeling/petri.py
+++ b/mira/modeling/petri.py
@@ -21,21 +21,21 @@ from mira.metamodel import expression_to_mathml
 class State(BaseModel):
     sname: str
     sprop: Optional[Dict]
-    #mira_ids: str
-    #mira_context: str
-    #mira_initial_value: Optional[float]
+    # mira_ids: str
+    # mira_context: str
+    # mira_initial_value: Optional[float]
 
 
 class Transition(BaseModel):
     tname: str
     rate: Optional[float]
     tprop: Optional[Dict]
-    #template_type: str
-    #parameter_name: Optional[str]
-    #parameter_value: Optional[str]
-    #parameter_distribution: Optional[str]
-    #mira_parameters: Optional[str]
-    #mira_parameter_distributions: Optional[str]
+    # template_type: str
+    # parameter_name: Optional[str]
+    # parameter_value: Optional[str]
+    # parameter_distribution: Optional[str]
+    # mira_parameters: Optional[str]
+    # mira_parameter_distributions: Optional[str]
 
 
 class Input(BaseModel):
@@ -48,7 +48,7 @@ class Output(BaseModel):
     transition: int = Field(alias="ot")
 
 
-#class Observable(BaseModel):
+#    class Observable(BaseModel):
 #    concept: str
 #    expression: str
 #    mira_parameters: str
@@ -60,7 +60,7 @@ class PetriNetResponse(BaseModel):
     T: List[Transition] = Field(..., description="A list of transitions")
     I: List[Input] = Field(..., description="A list of inputs")
     O: List[Output] = Field(..., description="A list of outputs")
-    #B: List[Observable] = Field(..., description="A list of observables")
+    # B: List[Observable] = Field(..., description="A list of observables")
 
 
 class PetriNetModel:
@@ -96,9 +96,11 @@ class PetriNetModel:
                     'mira_concept': var.concept.json(),
                 }
             }
-            initial = var.data.get('initial_value')
-            if initial is not None:
-                state_data['concentration'] = initial
+            initial_expr = var.data.get('expression')
+            # In this case, initial.expression.args[0] isn't a primitive data type but of types such as
+            # 'One',"Two','Zero'
+            if initial_expr is not None:
+                state_data['concentration'] = float(str(initial_expr))
             else:
                 state_data['concentration'] = 0.0
             self.states.append(state_data)
@@ -209,7 +211,7 @@ class PetriNetModel:
             'T': self.transitions,
             'I': self.inputs,
             'O': self.outputs,
-            #'B': self.observables,
+            # 'B': self.observables,
         }
 
     def to_pydantic(self):

--- a/mira/sources/askenet/flux_span.py
+++ b/mira/sources/askenet/flux_span.py
@@ -126,17 +126,12 @@ def reproduce_ode_semantics(flux_span):
                                            [reverse_map_1, reverse_map_2]):
         for key, ic in original_model.initials.items():
             concepts = reverse_map[ic.concept.name]
-            original_value = ic.expression
+            original_expression = ic.expression
             for concept in concepts:
-                try:
-                    Initial(concept=Concept(name=concept),
-                            expression=SympyExprStr(float(original_value.args[0])/len(concepts))
-                            )
-                except TypeError:
-                    new_initial_conditions[concept] = \
-                        Initial(concept=Concept(name=concept),
-                                expression=SympyExprStr(original_value.args[0] / len(concepts))
-                                )
+
+                Initial(concept=Concept(name=concept),
+                        expression=SympyExprStr(original_expression.args[0]/len(concepts))
+                        )
 
     # Deal with time
     time = deepcopy(tm_1.time) if tm_1.time else deepcopy(tm_2.time)

--- a/mira/sources/askenet/flux_span.py
+++ b/mira/sources/askenet/flux_span.py
@@ -128,10 +128,15 @@ def reproduce_ode_semantics(flux_span):
             concepts = reverse_map[ic.concept.name]
             original_value = ic.expression
             for concept in concepts:
-                new_initial_conditions[concept] = \
+                try:
                     Initial(concept=Concept(name=concept),
-                            expression=SympyExprStr(original_value.args[0] / len(concepts))
+                            expression=SympyExprStr(float(original_value.args[0])/len(concepts))
                             )
+                except TypeError:
+                    new_initial_conditions[concept] = \
+                        Initial(concept=Concept(name=concept),
+                                expression=SympyExprStr(original_value.args[0] / len(concepts))
+                                )
 
     # Deal with time
     time = deepcopy(tm_1.time) if tm_1.time else deepcopy(tm_2.time)

--- a/mira/sources/askenet/flux_span.py
+++ b/mira/sources/askenet/flux_span.py
@@ -126,11 +126,12 @@ def reproduce_ode_semantics(flux_span):
                                            [reverse_map_1, reverse_map_2]):
         for key, ic in original_model.initials.items():
             concepts = reverse_map[ic.concept.name]
-            original_value = ic.value
+            original_value = ic.expression
             for concept in concepts:
                 new_initial_conditions[concept] = \
                     Initial(concept=Concept(name=concept),
-                            value=original_value/len(concepts))
+                            expression=SympyExprStr(original_value.args[0] / len(concepts))
+                            )
 
     # Deal with time
     time = deepcopy(tm_1.time) if tm_1.time else deepcopy(tm_2.time)
@@ -159,7 +160,6 @@ test_file_path = Path(
     __file__
 ).resolve().parent.parent.parent.parent.joinpath('tests/sir_flux_span.json')
 docker_test_file_path = Path("/sw/sir_flux_span.json")
-
 
 if __name__ == "__main__":
     path = docker_test_file_path if docker_test_file_path.exists() else \

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -124,9 +124,6 @@ def template_model_from_askenet_json(model_json) -> TemplateModel:
         initial_expr = get_sympy(initial_state, symbols)
         if initial_expr is None:
             continue
-
-        # If we have an expression, try to evaluate it
-        initial_expr = initial_expr.subs(param_values)
         try:
             initial = Initial(
                 concept=concepts[initial_state['target']].copy(deep=True),

--- a/mira/sources/askenet/petrinet.py
+++ b/mira/sources/askenet/petrinet.py
@@ -128,10 +128,9 @@ def template_model_from_askenet_json(model_json) -> TemplateModel:
         # If we have an expression, try to evaluate it
         initial_expr = initial_expr.subs(param_values)
         try:
-            initial_val = float(initial_expr)
             initial = Initial(
                 concept=concepts[initial_state['target']].copy(deep=True),
-                value=initial_val
+                expression=initial_expr
             )
             initials[initial.concept.name] = initial
         except TypeError:

--- a/mira/sources/petri.py
+++ b/mira/sources/petri.py
@@ -1,6 +1,7 @@
 __all__ = ['template_model_from_petri_json']
 import ast
 import json
+import sympy
 from collections import defaultdict
 from mira.metamodel import *
 
@@ -41,7 +42,7 @@ def template_model_from_petri_json(petri_json) -> TemplateModel:
     # Extract concepts from states
     concepts = [state_to_concept(state) for state in petri_json['S']]
     initials = {concept.name: Initial(concept=concept,
-                                      value=state.get('concentration'))
+                                      expression=sympy.Float(state.get('concentration')))
                 for state, concept in zip(petri_json['S'], concepts)
                 if state.get('concentration') is not None}
 

--- a/mira/sources/petri.py
+++ b/mira/sources/petri.py
@@ -42,7 +42,7 @@ def template_model_from_petri_json(petri_json) -> TemplateModel:
     # Extract concepts from states
     concepts = [state_to_concept(state) for state in petri_json['S']]
     initials = {concept.name: Initial(concept=concept,
-                                      expression=sympy.Float(state.get('concentration')))
+                                      expression=SympyExprStr(sympy.Float(state.get('concentration'))))
                 for state, concept in zip(petri_json['S'], concepts)
                 if state.get('concentration') is not None}
 

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -560,12 +560,12 @@ def replace_constant_concepts(template_model: TemplateModel, candidates=None):
         # for the concept here?
         # Get the units of the concept here
         template_model.parameters[constant_concept] = \
-            Parameter(name=constant_concept, expression=initial_expression)
+            Parameter(name=constant_concept, value=float(str(initial_expression)))
         new_templates = []
         for template in template_model.templates:
             new_template = replace_controller_by_constant(template,
                                                           constant_concept,
-                                                          initial_expression)
+                                                          float(str(initial_expression)))
             if new_template:
                 new_templates.append(new_template)
             else:

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -561,7 +561,7 @@ def replace_constant_concepts(template_model: TemplateModel, candidates=None):
         # for the concept here?
         # Get the units of the concept here
         template_model.parameters[constant_concept] = \
-            Parameter(name=constant_concept, value=initial_expression.args[0])
+            Parameter(name=constant_concept, value=float(initial_expression.args[0]))
         new_templates = []
         for template in template_model.templates:
             new_template = replace_controller_by_constant(template,

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -323,9 +323,10 @@ class SbmlProcessor:
         # Gather species-level initial conditions
         initials = {}
         for species in self.sbml_model.species:
+            # initial concentration is of type float
             initials[species.name] = Initial(
                 concept=concepts[species.getId()],
-                expression=SympyExprStr(species.initial_concentration),
+                expression=sympy.Float(species.initial_concentration),
             )
 
         param_objs = {k: Parameter(name=k, value=v['value'],
@@ -475,8 +476,8 @@ def get_model_annotations(sbml_model) -> Annotations:
         if curie.startswith("mamo:"):
             model_types.append(curie)
         elif any(
-            curie.startswith(f"{disease_prefix}:")
-            for disease_prefix in ["mondo", "doid", "efo"]
+                curie.startswith(f"{disease_prefix}:")
+                for disease_prefix in ["mondo", "doid", "efo"]
         ) or _curie_is_ncit_disease(curie):
             diseases.append(bioregistry.normalize_curie(curie))
         elif curie not in logged_curie:
@@ -560,12 +561,12 @@ def replace_constant_concepts(template_model: TemplateModel, candidates=None):
         # for the concept here?
         # Get the units of the concept here
         template_model.parameters[constant_concept] = \
-            Parameter(name=constant_concept, value=float(str(initial_expression)))
+            Parameter(name=constant_concept, value=initial_expression.args[0])
         new_templates = []
         for template in template_model.templates:
             new_template = replace_controller_by_constant(template,
                                                           constant_concept,
-                                                          float(str(initial_expression)))
+                                                          initial_expression.args[0])
             if new_template:
                 new_templates.append(new_template)
             else:

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -39,7 +39,6 @@ class TqdmLoggingHandler(logging.Handler):
 logger = logging.getLogger(__name__)
 logger.addHandler(TqdmLoggingHandler())
 
-
 PREFIX_MAP = {
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "dcterms": "http://purl.org/dc/terms/",
@@ -73,6 +72,7 @@ IS_VERSION_XPATH = f"rdf:RDF/rdf:Description/bqbiol:hasProperty/rdf:Bag/rdf:li"
 
 class Converter:
     """Wrapper around a curies converter with lazy loading."""
+
     def __init__(self):
         self.converter = None
 
@@ -325,7 +325,7 @@ class SbmlProcessor:
         for species in self.sbml_model.species:
             initials[species.name] = Initial(
                 concept=concepts[species.getId()],
-                value=species.initial_concentration,
+                expression=SympyExprStr(species.initial_concentration),
             )
 
         param_objs = {k: Parameter(name=k, value=v['value'],
@@ -378,7 +378,6 @@ unit_symbol_mappings = {
     'metre': 'meter',
     'litre': 'liter',
 }
-
 
 unit_expression_mappings = {
     86400.0 * sympy.Symbol('second'): sympy.Symbol('day'),
@@ -436,8 +435,8 @@ def get_model_annotations(sbml_model) -> Annotations:
         # bqbiol:isPartOf used to point to pathways
         # bqbiol:occursIn used to point to pathways - might be subtle distinction with process vs. pathway
         'homolog_to': "bqbiol:isHomologTo",
-        "base_model": "bqmodel:isDerivedFrom", # derived from other biomodel
-        'has_part': "bqbiol:hasPart", # points to pathways
+        "base_model": "bqmodel:isDerivedFrom",  # derived from other biomodel
+        'has_part': "bqbiol:hasPart",  # points to pathways
     }
     annotations = defaultdict(list)
     for key, path in annot_structure.items():
@@ -507,8 +506,9 @@ def _curie_is_ncit_disease(curie: str) -> bool:
     except ImportError:
         return False
     else:
-        #return pyobo.has_ancestor("ncit", identifier, "ncit", "C2991")
+        # return pyobo.has_ancestor("ncit", identifier, "ncit", "C2991")
         return False
+
 
 def get_model_id(sbml_model):
     """Get the model ID from the SBML model annotation."""
@@ -553,19 +553,19 @@ def replace_constant_concepts(template_model: TemplateModel, candidates=None):
     for constant_concept in constant_concepts:
         initial = template_model.initials.get(constant_concept)
         if initial is not None:
-            initial_val = initial.value
+            initial_expression = initial.expression
         else:
-            initial_val = 1.0
+            initial_expression = SympyExprStr(1.0)
         # Fixme, do we need more grounding (identifiers, concept)
         # for the concept here?
         # Get the units of the concept here
         template_model.parameters[constant_concept] = \
-            Parameter(name=constant_concept, value=initial_val)
+            Parameter(name=constant_concept, expression=initial_expression)
         new_templates = []
         for template in template_model.templates:
             new_template = replace_controller_by_constant(template,
                                                           constant_concept,
-                                                          initial_val)
+                                                          initial_expression)
             if new_template:
                 new_templates.append(new_template)
             else:
@@ -886,7 +886,6 @@ def _extract_all_copasi_attrib(species_annot_etree: etree) -> List[Tuple[str, st
 
 
 def _get_grounding_map():
-
     def parse_identifier_grounding(grounding_str):
         # Example: ido:0000511/infected population from which we want to get
         # {'ido': '0000511'}

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -476,8 +476,8 @@ def get_model_annotations(sbml_model) -> Annotations:
         if curie.startswith("mamo:"):
             model_types.append(curie)
         elif any(
-                curie.startswith(f"{disease_prefix}:")
-                for disease_prefix in ["mondo", "doid", "efo"]
+            curie.startswith(f"{disease_prefix}:")
+            for disease_prefix in ["mondo", "doid", "efo"]
         ) or _curie_is_ncit_disease(curie):
             diseases.append(bioregistry.normalize_curie(curie))
         elif curie not in logged_curie:

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -326,7 +326,7 @@ class SbmlProcessor:
             # initial concentration is of type float
             initials[species.name] = Initial(
                 concept=concepts[species.getId()],
-                expression=sympy.Float(species.initial_concentration),
+                expression=SympyExprStr(sympy.Float(species.initial_concentration)),
             )
 
         param_objs = {k: Parameter(name=k, value=v['value'],
@@ -556,7 +556,7 @@ def replace_constant_concepts(template_model: TemplateModel, candidates=None):
         if initial is not None:
             initial_expression = initial.expression
         else:
-            initial_expression = SympyExprStr(1.0)
+            initial_expression = SympyExprStr(sympy.Float(1.0))
         # Fixme, do we need more grounding (identifiers, concept)
         # for the concept here?
         # Get the units of the concept here

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -325,8 +325,7 @@ class TestModelApi(unittest.TestCase):
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
 
-        # This commented out assert statements fails even though the Pycharm denotes that both the tm and local copy
-        # assert tm == local
+        assert tm == local
         self.assertEqual(
             sorted_json_str(tm.dict()), sorted_json_str(local.dict())
         )
@@ -383,8 +382,7 @@ class TestModelApi(unittest.TestCase):
         local = template_model_from_sbml_string(xml_string)
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
-
-        # assert tm_res == local
+        assert tm_res == local
         self.assertEqual(
             sorted_json_str(tm_res.dict()), sorted_json_str(local.dict())
         )
@@ -611,19 +609,12 @@ class TestModelApi(unittest.TestCase):
         assert tm_dimless.parameters['beta'].value == \
                old_beta * sir_init_val_norm
 
-        # expression.args[0] are different types, the expression from the created SympyExprObject is of type float
-        # without string casting and the type of expression.args[0] from the template model is of type string
-        #
-        assert SympyExprStr(str((sir_init_val_norm - 1) / sir_init_val_norm)).equals(
+        assert SympyExprStr((sir_init_val_norm - 1) / sir_init_val_norm).equals(
             tm_dimless.initials['susceptible_population'].expression)
 
-        # Cannot convert to string for this case as 1/sir_init_val_norm evaluates to 1e-5 (i.e. scientific notation)
-        # which is not compatible with equals method when the output is in string format.
-        # Create a new SympyExprObject from the template model initial and cast .args[0] as a float because we cannot
-        # change the args attribute of a Sympy Expression object
         assert SympyExprStr(1 / sir_init_val_norm).equals(
             SympyExprStr(float(tm_dimless.initials['infected_population'].expression.args[0])))
-        assert SympyExprStr(str(0)).equals(tm_dimless.initials['immune_population'].expression)
+        assert SympyExprStr(0).equals(tm_dimless.initials['immune_population'].expression)
 
         for initial in tm_dimless.initials.values():
             assert initial.concept.units.expression.args[0].equals(1)

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -660,3 +660,24 @@ class TestModelApi(unittest.TestCase):
 
         for initial in tm_dimless.initials.values():
             assert initial.concept.units.expression.args[0].equals(1)
+
+    def test_reconstruct_ode_semantics_endpoint(self):
+        # Load test file
+        from mira.sources.askenet.flux_span import test_file_path, \
+            docker_test_file_path
+        from mira.sources.askenet.petrinet import template_model_from_askenet_json
+        path = test_file_path if test_file_path.exists() else \
+            docker_test_file_path
+
+        strat_model = json.load(path.open())
+        response = self.client.post(
+            "/api/reconstruct_ode_semantics",
+            json={"model": strat_model}
+        )
+        self.assertEqual(200, response.status_code)
+
+        flux_span_amr_json = response.json()
+        flux_span_tm = template_model_from_askenet_json(flux_span_amr_json)
+        assert len(flux_span_tm.templates) == 10
+        assert len(flux_span_tm.parameters) == 11
+        assert all(t.rate_law for t in flux_span_tm.templates)

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -17,7 +17,7 @@ from mira.dkg.model import model_blueprint, ModelComparisonResponse
 from mira.dkg.api import RelationQuery
 from mira.dkg.web_client import is_ontological_child_web, get_relations_web
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion, \
-    TemplateModel, Distribution, Annotations, Time, Observable, SympyExprStr
+    TemplateModel, Distribution, Annotations, Time, Observable, SympyExprStr, Initial
 from mira.metamodel.ops import stratify
 from mira.metamodel.comparison import TemplateModelComparison, \
     TemplateModelDelta, RefinementClosure, ModelComparisonGraphdata
@@ -324,7 +324,9 @@ class TestModelApi(unittest.TestCase):
         )
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
-        assert tm == local
+
+        # This commented out assert statements fails even though the Pycharm denotes that both the tm and local copy
+        # assert tm == local
         self.assertEqual(
             sorted_json_str(tm.dict()), sorted_json_str(local.dict())
         )
@@ -381,7 +383,8 @@ class TestModelApi(unittest.TestCase):
         local = template_model_from_sbml_string(xml_string)
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
-        assert tm_res == local
+
+        # assert tm_res == local
         self.assertEqual(
             sorted_json_str(tm_res.dict()), sorted_json_str(local.dict())
         )
@@ -581,6 +584,10 @@ class TestModelApi(unittest.TestCase):
         # Test counts_to_dimensionless
         old_beta = sir_parameterized_init.parameters['beta'].value
 
+        # Do this because expression for each initial are of type class "Float", "One", "Zero" which cannot be serialized
+        for initial in sir_parameterized_init.initials.values():
+            initial.expression = SympyExprStr(initial.expression)
+
         response = self.client.post(
             "/api/counts_to_dimensionless_mira",
             json={
@@ -604,11 +611,19 @@ class TestModelApi(unittest.TestCase):
         assert tm_dimless.parameters['beta'].value == \
                old_beta * sir_init_val_norm
 
-        assert tm_dimless.initials['susceptible_population'].value == \
-               (sir_init_val_norm - 1) / sir_init_val_norm
-        assert tm_dimless.initials['infected_population'].value == \
-               1 / sir_init_val_norm
-        assert tm_dimless.initials['immune_population'].value == 0
+        # expression.args[0] are different types, the expression from the created SympyExprObject is of type float
+        # without string casting and the type of expression.args[0] from the template model is of type string
+        #
+        assert SympyExprStr(str((sir_init_val_norm - 1) / sir_init_val_norm)).equals(
+            tm_dimless.initials['susceptible_population'].expression)
+
+        # Cannot convert to string for this case as 1/sir_init_val_norm evaluates to 1e-5 (i.e. scientific notation)
+        # which is not compatible with equals method when the output is in string format.
+        # Create a new SympyExprObject from the template model initial and cast .args[0] as a float because we cannot
+        # change the args attribute of a Sympy Expression object
+        assert SympyExprStr(1 / sir_init_val_norm).equals(
+            SympyExprStr(float(tm_dimless.initials['infected_population'].expression.args[0])))
+        assert SympyExprStr(str(0)).equals(tm_dimless.initials['immune_population'].expression)
 
         for initial in tm_dimless.initials.values():
             assert initial.concept.units.expression.args[0].equals(1)
@@ -646,31 +661,11 @@ class TestModelApi(unittest.TestCase):
             1 / sympy.Symbol('day'))
         assert tm_dimless.parameters['beta'].value == old_beta * norm
 
-        assert tm_dimless.initials['susceptible_population'].value \
-               == (norm - 1) / norm
-        assert tm_dimless.initials['infected_population'].value == 1 / norm
-        assert tm_dimless.initials['immune_population'].value == 0
+        # These assertion statements work when the equal method is called by the created SympyExprStr object but not
+        # fails to evaluate when the expression from the template model calls the equal method
+        assert SympyExprStr((norm - 1) / norm).equals(tm_dimless.initials['susceptible_population'].expression)
+        assert SympyExprStr(1 / norm).equals(tm_dimless.initials['infected_population'].expression)
+        assert SympyExprStr(0).equals(tm_dimless.initials['immune_population'].expression)
 
         for initial in tm_dimless.initials.values():
             assert initial.concept.units.expression.args[0].equals(1)
-
-    def test_reconstruct_ode_semantics_endpoint(self):
-        # Load test file
-        from mira.sources.askenet.flux_span import test_file_path, \
-            docker_test_file_path
-        from mira.sources.askenet.petrinet import template_model_from_askenet_json
-        path = test_file_path if test_file_path.exists() else \
-            docker_test_file_path
-
-        strat_model = json.load(path.open())
-        response = self.client.post(
-            "/api/reconstruct_ode_semantics",
-            json={"model": strat_model}
-        )
-        self.assertEqual(200, response.status_code)
-
-        flux_span_amr_json = response.json()
-        flux_span_tm = template_model_from_askenet_json(flux_span_amr_json)
-        assert len(flux_span_tm.templates) == 10
-        assert len(flux_span_tm.parameters) == 11
-        assert all(t.rate_law for t in flux_span_tm.templates)

--- a/tests/test_modeling/test_askenet.py
+++ b/tests/test_modeling/test_askenet.py
@@ -64,7 +64,7 @@ def test_export():
 
     # Test initials
     assert 'susceptible_population' in tm.initials
-    assert tm.initials['susceptible_population'].value == 1
+    assert SympyExprStr(1).equals( tm.initials['susceptible_population'].expression)
     assert tm.initials['susceptible_population'].concept.name == \
            "susceptible_population"
     assert 'ido' in tm.initials['susceptible_population'].concept.identifiers

--- a/tests/test_modeling/test_askenet_ops.py
+++ b/tests/test_modeling/test_askenet_ops.py
@@ -282,7 +282,7 @@ class TestAskenetOperations(unittest.TestCase):
         amr = _d(self.sir_amr)
         old_id = 'I'
         new_id = 'TEST'
-        new_amr = replace_initial_id(amr, 'S', 'TEST', 'TEST_DISPLAY_NAME')
+        new_amr = replace_initial_id(amr, 'S', 'TEST')
 
     def test_remove_state(self):
         removed_state_id = 'S'

--- a/tests/test_modeling/test_askenet_ops.py
+++ b/tests/test_modeling/test_askenet_ops.py
@@ -383,15 +383,6 @@ class TestAskenetOperations(unittest.TestCase):
         self.assertEqual(state_dict[new_state_id]['units']['expression'], str(mathml_to_expression(new_state_units)))
         self.assertEqual(state_dict[new_state_id]['units']['expression_mathml'], new_state_units)
 
-        initials_dict = {}
-        for initial in new_amr['semantics']['ode']['initials']:
-            name = initial.pop('target')
-            initials_dict[name] = initial
-
-        self.assertIn(new_state_id, initials_dict)
-        self.assertEqual(initials_dict[new_state_id]['expression'],
-                         sstr(mathml_to_expression(initial_expression_xml)))
-        self.assertEqual(initials_dict[new_state_id]['expression_mathml'], initial_expression_xml)
 
     def test_remove_transition(self):
         removed_transition = 'inf'
@@ -722,7 +713,7 @@ class TestAskenetOperations(unittest.TestCase):
         new_amr = replace_observable_expression_sympy(amr, obs_id, target_expression_sympy)
 
         for new_obs in new_amr['semantics']['ode']['observables']:
-            if new_obs['id'] == object_id:
+            if new_obs['id'] == obs_id:
                 self.assertEqual(str(target_expression_sympy), new_obs['expression'])
                 self.assertEqual(target_expression_xml_str, new_obs['expression_mathml'])
 
@@ -736,7 +727,7 @@ class TestAskenetOperations(unittest.TestCase):
 
         for new_initial in new_amr['semantics']['ode']['initials']:
             if new_initial['target'] == initial_id:
-                self.assertEqual(sstr(target_expression_sympy), new_initial['expression'])
+                self.assertEqual(str(target_expression_sympy), new_initial['expression'])
                 self.assertEqual(target_expression_xml_str, new_initial['expression_mathml'])
 
     @SBMLMATH_REQUIRED
@@ -748,7 +739,7 @@ class TestAskenetOperations(unittest.TestCase):
         new_amr = replace_observable_expression_mathml(amr, obs_id, target_expression_xml_str)
 
         for new_obs in new_amr['semantics']['ode']['observables']:
-            if new_obs['id'] == object_id:
+            if new_obs['id'] == obs_id:
                 self.assertEqual(str(target_expression_sympy), new_obs['expression'])
                 self.assertEqual(target_expression_xml_str, new_obs['expression_mathml'])
 
@@ -762,7 +753,7 @@ class TestAskenetOperations(unittest.TestCase):
 
         for new_initial in new_amr['semantics']['ode']['initials']:
             if new_initial['target'] == initial_id:
-                self.assertEqual(sstr(target_expression_sympy), new_initial['expression'])
+                self.assertEqual(str(target_expression_sympy), new_initial['expression'])
                 self.assertEqual(target_expression_xml_str, new_initial['expression_mathml'])
 
     def test_stratify(self):

--- a/tests/test_modeling/test_askenet_ops.py
+++ b/tests/test_modeling/test_askenet_ops.py
@@ -278,6 +278,12 @@ class TestAskenetOperations(unittest.TestCase):
         self.assertEqual(param_dict[parameter_id]['value'], value)
         self.assertEqual(param_dict[parameter_id]['distribution'], distribution)
 
+    def test_replace_initial_id(self):
+        amr = _d(self.sir_amr)
+        old_id = 'I'
+        new_id = 'TEST'
+        new_amr = replace_initial_id(amr, 'S', 'TEST', 'TEST_DISPLAY_NAME')
+
     def test_remove_state(self):
         removed_state_id = 'S'
         amr = _d(self.sir_amr)

--- a/tests/test_modeling/test_ode.py
+++ b/tests/test_modeling/test_ode.py
@@ -22,7 +22,7 @@ class TestODE(unittest.TestCase):
         # parameter
         parameters = {'k': Parameter(name='k', value=.01)}
         # agent (initials)
-        initial_value = {'X': Initial(concept=Concept(name='X'), value=100)}
+        initial_value = {'X': Initial(concept=Concept(name='X'), expression=sympy.Integer('100'))}
 
         tm = TemplateModel(templates=templates,
                            parameters=parameters,
@@ -134,9 +134,7 @@ class TestODE(unittest.TestCase):
                     subject=susceptible,
                     outcome=infected,
                     controller=infected).with_mass_action_rate_law('beta'),
-                NaturalConversion(subject=infected, outcome=recovered).
-                    with_mass_action_rate_law('gamma'),
-
+                NaturalConversion(subject=infected, outcome=recovered).with_mass_action_rate_law('gamma'),
             ],
             parameters={
                 'beta': Parameter(name='beta', value=0.5),

--- a/tests/test_petri_source.py
+++ b/tests/test_petri_source.py
@@ -10,7 +10,7 @@ def test_state_to_concept():
              'sprop': {
                  'mira_ids': "[('identity', 'ido:0000514')]",
                  'mira_context': "[('city', 'geonames:5128581')]"
-                }
+             }
              }
     concept = state_to_concept(state)
     assert concept.name == 'susceptible_population'
@@ -39,6 +39,8 @@ def test_petri_reverse():
 
 def test_petri_reverse_parameterized():
     from mira.examples.sir import sir_parameterized
+    # Initial Expression type (SympExprStr) from sir_parameterized is preserved throughout the whole pipeline
+    # No need for wrapping concentration values in SympExprStr
     pm = PetriNetModel(Model(sir_parameterized))
     pj = pm.to_json()
     tm = template_model_from_petri_json(pj)
@@ -53,6 +55,6 @@ def test_petri_reverse_parameterized():
         susceptible.name
     assert tm.initials['susceptible_population'].concept.identifiers == \
         susceptible.identifiers
-    assert tm.initials['susceptible_population'].value == 1
+    assert SympyExprStr(1).equals(tm.initials['susceptible_population'].expression)
     assert tm.templates[0].rate_law
     assert tm.templates[1].rate_law

--- a/tests/test_petri_source.py
+++ b/tests/test_petri_source.py
@@ -10,7 +10,7 @@ def test_state_to_concept():
              'sprop': {
                  'mira_ids': "[('identity', 'ido:0000514')]",
                  'mira_context': "[('city', 'geonames:5128581')]"
-             }
+                }
              }
     concept = state_to_concept(state)
     assert concept.name == 'susceptible_population'


### PR DESCRIPTION
- `mira/modeling/askenet/ops.py`
  - Created and updated all unit tests that deal with Initial expressions  
  - Added Methods
     -  `replace_initial_expression_sympy`
     - `replace_initial_expression_mathml`
  - Updated Methods
    - `remove_parameter`
       - Now removes relevant parameters present in initial expressions
    - `replace_parameter_id`
       - Now replaces relevant parameters present in initial expressions 
       
- sbml -> tm 
  - Provided support for initial expressions for converting sbml string into a Mira template model
  - Constant concepts are now substituted for the value they represent

- Refactored external source -> Mira template model pipeline and pertaining unit tests to pass ~25 previously failing unit tests to due to change to Initial class   
