### PR TITLE
Minor refactor of amr loading utilities

### DIFF
--- a/mira/sources/amr/__init__.py
+++ b/mira/sources/amr/__init__.py
@@ -6,6 +6,7 @@ import jsonschema
 import requests
 import mira.sources.amr.petrinet as petrinet
 import mira.sources.amr.regnet as regnet
+import mira.sources.amr.stockflow as stockflow
 
 
 def model_from_url(url):
@@ -66,6 +67,8 @@ def model_from_json(model_json):
         return petrinet.template_model_from_amr_json(model_json)
     elif 'regnet' in header['schema']:
         return regnet.template_model_from_amr_json(model_json)
+    elif 'stockflow' in header['schema']:
+        return stockflow.template_model_from_amr_json(model_json)
     else:
         raise ValueError(f'Unknown schema: {header["schema"]}')
     

--- a/mira/sources/amr/__init__.py
+++ b/mira/sources/amr/__init__.py
@@ -45,7 +45,7 @@ def model_from_json_file(fname):
 
 
 def model_from_json(model_json):
-    """Return a model from a file, handling multiple frameworks.
+    """Return a model from a JSON object, handling multiple frameworks.
 
     Parameters
     ----------

--- a/mira/sources/amr/__init__.py
+++ b/mira/sources/amr/__init__.py
@@ -1,4 +1,4 @@
-__all__ = ['model_from_url', 'model_from_json_file', 'sanity_check_amr']
+__all__ = ['model_from_url', 'model_from_json_file', 'model_from_json', 'sanity_check_amr']
 
 import json
 
@@ -23,17 +23,7 @@ def model_from_url(url):
     """
     res = requests.get(url)
     model_json = res.json()
-    header = model_json.get('header', {})
-    if 'schema' not in header:
-        raise ValueError(f'No "schema" defined in the AMR at {url}. '
-                         f'The schema has to be a URL pointing to a '
-                         f'JSON schema against which the AMR is validated.')
-    if 'petrinet' in header['schema']:
-        return petrinet.template_model_from_amr_json(model_json)
-    elif 'regnet' in header['schema']:
-        return regnet.template_model_from_amr_json(model_json)
-    else:
-        raise ValueError(f'Unknown schema: {header["schema"]}')
+    return model_from_json(model_json)
 
 
 def model_from_json_file(fname):
@@ -51,6 +41,22 @@ def model_from_json_file(fname):
     """
     with open(fname) as fh:
         model_json = json.load(fh)
+    return model_from_json(model_json)
+
+
+def model_from_json(model_json):
+    """Return a model from a file, handling multiple frameworks.
+
+    Parameters
+    ----------
+    model_json :
+        The JSON object containing the model information.
+
+    Returns
+    -------
+    :
+        A TemplateModel object.
+    """
     header = model_json.get('header', {})
     if 'schema' not in header:
         raise ValueError(f'No schema defined in the AMR in {fname}. '
@@ -62,7 +68,7 @@ def model_from_json_file(fname):
         return regnet.template_model_from_amr_json(model_json)
     else:
         raise ValueError(f'Unknown schema: {header["schema"]}')
-
+    
 
 def sanity_check_amr(amr_json):
     assert 'header' in amr_json


### PR DESCRIPTION
This small refactoring PR extracts out `model_from_json` from the existing `model_from_url` and `model_from_json_file`. The primary reason for this change is to expose `model_from_json` as a standalone loading utility if an AMR is previously loaded into memory and then manipulated without being saved again as a new file. A secondary benefit is a minor reduction in code duplication.