### PR TITLE
Properly set sympy strings for Initial.expression

### DIFF
--- a/mira/examples/sir.py
+++ b/mira/examples/sir.py
@@ -143,9 +143,9 @@ sir_init_val_norm = 1e5
 for template in sir_parameterized_init.templates:
     for concept in template.get_concepts():
         concept.units = Unit(expression=sympy.Symbol('person'))
-sir_parameterized_init.initials['susceptible_population'].expression = sympy.Float(sir_init_val_norm-1)
-sir_parameterized_init.initials['infected_population'].expression = sympy.Integer('1')
-sir_parameterized_init.initials['immune_population'].expression = sympy.Integer('0')
+sir_parameterized_init.initials['susceptible_population'].expression = SympyExprStr(sympy.Float(sir_init_val_norm-1))
+sir_parameterized_init.initials['infected_population'].expression = SympyExprStr(sympy.Integer('1'))
+sir_parameterized_init.initials['immune_population'].expression = SympyExprStr(sympy.Integer('0'))
 
 sir_parameterized_init.parameters['beta'].units = \
     Unit(expression=1 / (sympy.Symbol('person') * sympy.Symbol('day')))


### PR DESCRIPTION
This PR fixes an example that previously cause an error when loading the api docs page for the rest api.