### PR TITLE
Use grounded names when renaming in stratification

### DIFF
--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -189,6 +189,14 @@ class StratificationQuery(BaseModel):
         description="A list of the values for stratification",
         example=["boston", "nyc"]
     )
+    strata_name_map: Union[Dict[str, str], None] = Field(
+        None,
+        description="A mapping of the strata values to names. If none given, "
+                    "will try to get the name from the client.",
+        example={
+            "geonames:4930956": "Boston", "geonames:5128581": "New York City"
+        },
+    )
     structure: Union[List[List[str]], None] = Field(
         None,
         description="An iterable of pairs corresponding to a directed network "

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -292,8 +292,7 @@ def model_stratification(
             "template_model": template_model_example,
             "key": "city",
             "strata": ["geonames:4930956", "geonames:5128581"],
-            "strata_name_map": {"geonames:4930956": "Boston",
-                                "geonames:5128581": "New York City"},
+            "strata_name_lookup": True,
             "params_to_stratify": ["beta"],
         },
     )

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -295,8 +295,12 @@ def model_stratification(
     if stratification_query.strata_name_map is None:
         strata_name_map = {}
         for sn in strata:
-            res = request.app.state.client.get_entity(sn)
-            strata_name_map[sn] = res.name if res is not None else sn
+            if ":" in sn:
+                res = request.app.state.client.get_entity(sn)
+                mapped_name = res.name if res is not None else sn
+            else:
+                mapped_name = sn
+            strata_name_map[sn] = mapped_name
     else:
         strata_name_map = stratification_query.strata_name_map
 

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -545,16 +545,6 @@ def _generate_template_model_delta(
     template_model1: TemplateModel,
     template_model2: TemplateModel,
 ) -> TemplateModelDelta:
-    # def _is_ontological_child(child_curie: str, parent_curie: str) -> bool:
-    #     res = request.app.state.client.query_relations(
-    #         source_curie=child_curie,
-    #         relation_type=DKG_REFINER_RELS,
-    #         target_curie=parent_curie,
-    #     )
-    #     # res is a list of lists, so check that there is at least one
-    #     # element in the outer list and that the first element/list contains
-    #     # something
-    #    return len(res) > 0 and len(res[0]) > 0
     tmd = TemplateModelDelta(
         template_model1=template_model1,
         template_model2=template_model2,

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -320,7 +320,7 @@ def model_stratification(
         template_model=tm,
         key=stratification_query.key,
         strata=strata,
-        strata_name_map=strata_name_map,
+        strata_curie_to_name=strata_name_map,
         structure=stratification_query.structure,
         directed=stratification_query.directed,
         conversion_cls=stratification_query.get_conversion_cls(),

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -191,7 +191,10 @@ class StratificationQuery(BaseModel):
     )
     strata_name_map: Union[Dict[str, str], None] = Field(
         None,
-        description="A mapping of the strata values to names.",
+        description="A mapping of the strata values to names to be used in "
+                    "renaming the concepts. If none given, will use the "
+                    "strata values as the names. This option only has an "
+                    "effect if ``modify_names`` is true.",
         example={
             "geonames:4930956": "Boston", "geonames:5128581": "New York City"
         },

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -281,7 +281,9 @@ def model_stratification(
         example={
             "template_model": template_model_example,
             "key": "city",
-            "strata": ["boston", "nyc"],
+            "strata": ["geonames:4930956", "geonames:5128581"],
+            "strata_name_map": {"geonames:4930956": "Boston",
+                                "geonames:5128581": "New York City"},
             "params_to_stratify": ["beta"],
         },
     )

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -187,7 +187,7 @@ def get_entities_web(curies: List[str]) -> List[Union[AskemEntity, Entity]]:
     curies_str = ",".join(curies)
     res_json = web_client(endpoint=f"/entities/{curies_str}", method="get")
     if res_json is not None:
-        return [Entity.from_data(**record) for record in res_json]
+        return [Entity(**record) for record in res_json]
 
 
 def get_lexical_web(api_url: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -18,7 +18,12 @@ __all__ = [
     "search_web",
     "get_transitive_closure_web",
     "is_ontological_child_web",
+    "MissingBaseUrlError",
 ]
+
+
+class MissingBaseUrlError(ValueError):
+    """Raised when the base url for the REST API is missing"""
 
 
 def web_client(
@@ -62,11 +67,11 @@ def web_client(
     base_url = api_url or os.environ.get("MIRA_REST_URL") or pystow.get_config("mira", "rest_url")
 
     if not base_url:
-        raise ValueError(
+        raise MissingBaseUrlError(
             "The base url for the REST API needs to either be set in the "
             "environment using the variable 'MIRA_REST_URL', be set in the "
             "pystow config 'mira'->'rest_url' or by passing it the 'api_url' "
-            "parameter to this function."
+            "parameter to the web client function used."
         )
 
     # Clean base url and endpoint

--- a/mira/dkg/web_client.py
+++ b/mira/dkg/web_client.py
@@ -5,12 +5,14 @@ import pystow
 import requests
 
 from mira.dkg import api, grounding
+from mira.dkg.client import Entity, AskemEntity
 from mira.dkg.utils import DKG_REFINER_RELS
 
 __all__ = [
     "web_client",
     "get_relations_web",
     "get_entity_web",
+    "get_entities_web",
     "get_lexical_web",
     "ground_web",
     "search_web",
@@ -156,6 +158,31 @@ def get_entity_web(curie: str, api_url: Optional[str] = None) -> Optional[api.En
     res_json = web_client(endpoint=f"/entity/{curie}", method="get", api_url=api_url)
     if res_json is not None:
         return api.Entity(**res_json)
+
+
+def get_entities_web(curies: List[str]) -> List[Union[AskemEntity, Entity]]:
+    """Get information about multiple entities (e.g., their names,
+    description synonyms, alternative identifiers, database
+    cross-references, etc.) based on their respective compact URIs (CURIEs).
+
+    A wrapper that calls the REST API's entities endpoint.
+
+    Parameters
+    ----------
+    curies :
+        A list of curies for entities to get information about.
+
+    Returns
+    -------
+    :
+        Returns a list of Entity models, if the entities exist in the graph.
+    """
+    # Endpoint expects '<prefix>:<local unique identifier>,...',
+    # e.g.: "ido:0000511,ido:0000512"
+    curies_str = ",".join(curies)
+    res_json = web_client(endpoint=f"/entities/{curies_str}", method="get")
+    if res_json is not None:
+        return [Entity.from_data(**record) for record in res_json]
 
 
 def get_lexical_web(api_url: Optional[str] = None) -> List[Dict[str, Any]]:

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -160,7 +160,7 @@ def stratify(
             if set(template.get_concept_names()) - exclude_concepts:
                 new_template = template.with_context(
                     do_rename=modify_names, exclude_concepts=exclude_concepts,
-                    name_map=strata_curie_to_name,
+                    curie_to_name_map=strata_curie_to_name,
                     **{key: stratum},
                 )
                 rewrite_rate_law(template_model=template_model,
@@ -247,7 +247,9 @@ def stratify(
             continue
         for stratum in strata:
             new_concept = initial.concept.with_context(
-                do_rename=modify_names, name_map=strata_curie_to_name, **{key: stratum},
+                do_rename=modify_names,
+                curie_to_name_map=strata_curie_to_name,
+                **{key: stratum},
             )
             initials[new_concept.name] = Initial(
                 concept=new_concept, expression=SympyExprStr(initial.expression.args[0] / len(strata))
@@ -261,7 +263,9 @@ def stratify(
             new_symbols = []
             for stratum in strata:
                 new_concept = concept_names_map[sym].with_context(
-                    do_rename=modify_names, name_map=strata_curie_to_name, **{key: stratum},
+                    do_rename=modify_names,
+                    curie_to_name_map=strata_curie_to_name,
+                    **{key: stratum},
                 )
                 new_symbols.append(sympy.Symbol(new_concept.name))
             expr = expr.subs(sympy.Symbol(sym), sympy.Add(*new_symbols))
@@ -281,10 +285,10 @@ def stratify(
         if param_name not in parameters:
             parameters[param_name] = Parameter(name=param_name, value=0.1)
         subject = concept.with_context(do_rename=modify_names,
-                                       name_map=strata_curie_to_name,
+                                       curie_to_name_map=strata_curie_to_name,
                                        **{key: source_stratum})
         outcome = concept.with_context(do_rename=modify_names,
-                                       name_map=strata_curie_to_name,
+                                       curie_to_name_map=strata_curie_to_name,
                                        **{key: target_stratum})
         # todo will need to generalize for different kwargs for different conversions
         template = conversion_cls(subject=subject, outcome=outcome)

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -277,11 +277,13 @@ def stratify(
         if concept.name in exclude_concepts:
             continue
         # Get stratum names from map if provided, otherwise use the stratum
-        src_strat_name = strata_curie_to_name.get(source_stratum, source_stratum) \
-            if strata_curie_to_name else source_stratum
-        tgt_strat_name = strata_curie_to_name.get(target_stratum, target_stratum) \
-            if strata_curie_to_name else target_stratum
-        param_name = f"p_{src_strat_name}_{tgt_strat_name}"
+        source_stratum_name = strata_curie_to_name.get(
+            source_stratum, source_stratum
+        ) if strata_curie_to_name else source_stratum
+        target_stratum_name = strata_curie_to_name.get(
+            target_stratum, target_stratum
+        ) if strata_curie_to_name else target_stratum
+        param_name = f"p_{source_stratum_name}_{target_stratum_name}"
         if param_name not in parameters:
             parameters[param_name] = Parameter(name=param_name, value=0.1)
         subject = concept.with_context(do_rename=modify_names,
@@ -295,7 +297,7 @@ def stratify(
         template.set_mass_action_rate_law(param_name)
         templates.append(template)
         if not directed:
-            param_name = f"p_{tgt_strat_name}_{src_strat_name}"
+            param_name = f"p_{target_stratum_name}_{source_stratum_name}"
             if param_name not in parameters:
                 parameters[param_name] = Parameter(name=param_name, value=0.1)
             reverse_template = conversion_cls(subject=outcome, outcome=subject)

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -1,5 +1,5 @@
 """Operations for template models."""
-
+import logging
 from copy import deepcopy
 from collections import defaultdict, Counter
 import itertools as itt
@@ -21,6 +21,9 @@ __all__ = [
     "counts_to_dimensionless",
     "deactivate_templates"
 ]
+
+
+logger = logging.getLogger(__name__)
 
 
 def stratify(
@@ -110,11 +113,17 @@ def stratify(
     strata = sorted(strata)
 
     if strata_name_lookup and strata_name_map is None:
-        from mira.dkg.web_client import get_entities_web
-        entity_map = {e.id: e.name for e in get_entities_web(strata)}
-        # Update the mapping with the strata values that are missing from
-        # the map
-        strata_name_map = {s: entity_map.get(s, s) for s in strata}
+        from mira.dkg.web_client import get_entities_web, MissingBaseUrlError
+        try:
+            entity_map = {e.id: e.name for e in get_entities_web(strata)}
+            # Update the mapping with the strata values that are missing from
+            # the map
+            strata_name_map = {s: entity_map.get(s, s) for s in strata}
+        except MissingBaseUrlError as err:
+            logger.warning(
+                "Web client not available, cannot look up strata names",
+                exc_info=True
+            )
 
     if structure is None:
         structure = list(itt.combinations(strata, 2))

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -623,17 +623,28 @@ class ControlledConversion(Template):
 
     concept_keys: ClassVar[List[str]] = ["controller", "subject", "outcome"]
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "ControlledConversion":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "ControlledConversion":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
             subject=self.subject if self.subject.name in exclude_concepts else
-                     self.subject.with_context(do_rename=do_rename, **context),
+                     self.subject.with_context(do_rename=do_rename,
+                                               name_map=name_map,
+                                               **context),
             outcome=self.outcome if self.outcome.name in exclude_concepts else
-                     self.outcome.with_context(do_rename=do_rename, **context),
+                     self.outcome.with_context(do_rename=do_rename,
+                                               name_map=name_map,
+                                               **context),
             controller=self.controller if self.controller.name in exclude_concepts else
-                        self.controller.with_context(do_rename=do_rename, **context),
+                        self.controller.with_context(do_rename=do_rename,
+                                                     name_map=name_map,
+                                                     **context),
             provenance=self.provenance,
             rate_law=self.rate_law,
         )
@@ -676,19 +687,30 @@ class GroupedControlledConversion(Template):
 
     concept_keys: ClassVar[List[str]] = ["controllers", "subject", "outcome"]
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "GroupedControlledConversion":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "GroupedControlledConversion":
         exclude_concepts = exclude_concepts or set()
 
         return self.__class__(
             type=self.type,
-            controllers=[c.with_context(do_rename, **context)
+            controllers=[c.with_context(do_rename=do_rename,
+                                        name_map=name_map,
+                                        **context)
                          if c.name not in exclude_concepts else c
                          for c in self.controllers],
             subject=self.subject if self.subject.name in exclude_concepts else
-                     self.subject.with_context(do_rename=do_rename, **context),
+                        self.subject.with_context(
+                            do_rename=do_rename, name_map=name_map, **context
+                        ),
             outcome=self.outcome if self.outcome.name in exclude_concepts else
-                        self.outcome.with_context(do_rename=do_rename, **context),
+                        self.outcome.with_context(
+                            do_rename=do_rename, name_map=name_map, **context
+                        ),
             provenance=self.provenance,
             rate_law=self.rate_law,
         )
@@ -773,15 +795,22 @@ class GroupedControlledProduction(Template):
             rate_law=self.rate_law,
         )
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "GroupedControlledProduction":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "GroupedControlledProduction":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            controllers=[c.with_context(do_rename, **context)
+            controllers=[c.with_context(do_rename, name_map=name_map, **context)
                          if c.name not in exclude_concepts else c
                          for c in self.controllers],
-            outcome=self.outcome.with_context(do_rename, **context)
+            outcome=self.outcome.with_context(
+                do_rename, name_map=name_map, **context
+            )
                 if self.outcome.name not in exclude_concepts else self.outcome,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -823,18 +852,26 @@ class ControlledProduction(Template):
             rate_law=self.rate_law,
         )
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "ControlledProduction":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "ControlledProduction":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            outcome=self.outcome.with_context(do_rename=do_rename, **context)
-                if self.outcome.name not in exclude_concepts else self.outcome,
-            controller=self.controller.with_context(do_rename=do_rename, **context)
-                if self.controller.name not in exclude_concepts else self.controller,
+            outcome=self.outcome.with_context(
+                do_rename=do_rename, name_map=name_map, **context
+            ) if self.outcome.name not in exclude_concepts else self.outcome,
+            controller=self.controller.with_context(
+                do_rename=do_rename, name_map=name_map, **context
+            ) if self.controller.name not in exclude_concepts else self.controller,
             provenance=self.provenance,
             rate_law=self.rate_law,
         )
+
 
 class NaturalConversion(Template):
     """Specifies a process of natural conversion from subject to outcome"""
@@ -846,15 +883,22 @@ class NaturalConversion(Template):
 
     concept_keys: ClassVar[List[str]] = ["subject", "outcome"]
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "NaturalConversion":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "NaturalConversion":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            subject=self.subject.with_context(do_rename=do_rename, **context)
-                if self.subject.name not in exclude_concepts else self.subject,
-            outcome=self.outcome.with_context(do_rename=do_rename, **context)
-                if self.outcome.name not in exclude_concepts else self.outcome,
+            subject=self.subject.with_context(
+                do_rename=do_rename, name_map=name_map, **context
+            ) if self.subject.name not in exclude_concepts else self.subject,
+            outcome=self.outcome.with_context(
+                do_rename=do_rename, name_map=name_map, **context
+            ) if self.outcome.name not in exclude_concepts else self.outcome,
             provenance=self.provenance,
             rate_law=self.rate_law,
         )
@@ -882,12 +926,19 @@ class NaturalProduction(Template):
             self.outcome.get_key(config=config),
         )
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "NaturalProduction":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "NaturalProduction":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            outcome=self.outcome.with_context(do_rename=do_rename, **context)
+            outcome=self.outcome.with_context(do_rename=do_rename,
+                                              name_map=name_map,
+                                              **context)
                 if self.outcome.name not in exclude_concepts else self.outcome,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -909,13 +960,19 @@ class NaturalDegradation(Template):
             self.subject.get_key(config=config),
         )
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "NaturalDegradation":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "NaturalDegradation":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            subject=self.subject.with_context(do_rename=do_rename, **context)
-                if self.subject.name not in exclude_concepts else self.subject,
+            subject=self.subject.with_context(
+                do_rename=do_rename, name_map=name_map, **context
+            ) if self.subject.name not in exclude_concepts else self.subject,
             provenance=self.provenance,
             rate_law=self.rate_law,
         )
@@ -956,15 +1013,22 @@ class ControlledDegradation(Template):
             rate_law=self.rate_law,
         )
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "ControlledDegradation":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "ControlledDegradation":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            subject=self.subject.with_context(do_rename=do_rename, **context)
-                if self.subject.name not in exclude_concepts else self.subject,
-            controller=self.controller.with_context(do_rename=do_rename, **context)
-                if self.controller.name not in exclude_concepts else self.controller,
+            subject=self.subject.with_context(
+                do_rename=do_rename, name_map=name_map, **context
+            ) if self.subject.name not in exclude_concepts else self.subject,
+            controller=self.controller.with_context(
+                do_rename=do_rename, name_map=name_map, **context
+            ) if self.controller.name not in exclude_concepts else self.controller,
             provenance=self.provenance,
             rate_law=self.rate_law,
         )
@@ -1012,15 +1076,20 @@ class GroupedControlledDegradation(Template):
             rate_law=self.rate_law,
         )
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "GroupedControlledDegradation":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ) -> "GroupedControlledDegradation":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            controllers=[c.with_context(do_rename, **context)
+            controllers=[c.with_context(do_rename, name_map=name_map, **context)
                          if c.name not in exclude_concepts else c
                          for c in self.controllers],
-            subject=self.subject.with_context(do_rename, **context)
+            subject=self.subject.with_context(do_rename, name_map=name_map, **context)
                 if self.subject.name not in exclude_concepts else self.subject,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -1045,14 +1114,19 @@ class StaticConcept(Template):
         """Return a list of the concepts in this template"""
         return [self.subject]
 
-    def with_context(self, do_rename=False, exclude_concepts=None, **context) -> "StaticConcept":
-        """Return a copy of this template with context added"""
+    def with_context(
+        self,
+        do_rename=False,
+        name_map=None,
+        exclude_concepts=None,
+        **context
+    ) -> "StaticConcept":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            subject=(self.subject.with_context(do_rename, **context)
-                     if self.subject.name not in exclude_concepts
-                     else self.subject),
+            subject=(self.subject.with_context(
+                do_rename, name_map=name_map, **context
+            ) if self.subject.name not in exclude_concepts else self.subject),
             provenance=self.provenance,
             rate_law=self.rate_law,
         )

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -427,6 +427,33 @@ class Template(BaseModel):
                     return False
         return True
 
+    def with_context(
+        self,
+        do_rename=False,
+        exclude_concepts=None,
+        name_map=None,
+        **context
+    ):
+        """Return a copy of this template with context added
+
+        Parameters
+        ----------
+        do_rename :
+            If True, rename the names of the concepts
+        exclude_concepts :
+            A set of concept names to keep unchanged.
+        name_map :
+            A mapping of context values to names. Useful if the context values
+            are e.g. curies. Will only be used if ``do_rename`` is True.
+
+
+        Returns
+        -------
+        :
+            A copy of this template with context added
+        """
+        raise NotImplementedError("This method can only be called on subclasses")
+
     def get_concepts(self):
         """Return the concepts in this template."""
         return [getattr(self, k) for k in self.concept_keys]

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -112,7 +112,7 @@ class Concept(BaseModel):
             SympyExprStr: lambda e: sympy.parse_expr(e)
         }
 
-    def with_context(self, do_rename=False, name_map=None, **context) -> "Concept":
+    def with_context(self, do_rename=False, curie_to_name_map=None, **context) -> "Concept":
         """Return this concept with extra context.
 
         Parameters
@@ -120,7 +120,7 @@ class Concept(BaseModel):
         do_rename :
             If true, will modify the name of the node based on the context
             introduced
-        name_map :
+        curie_to_name_map :
             A mapping of context values to names. Useful if the context values
             are e.g. curies.
 
@@ -134,7 +134,7 @@ class Concept(BaseModel):
                 self._base_name = self.name
             name_list = [self._base_name]
             for k, v in sorted(context.items()):
-                nv = name_map.get(v, v) if name_map else v
+                nv = curie_to_name_map.get(v, v) if curie_to_name_map else v
                 name_list.append(str(nv.replace(':', '_')))
             name = '_'.join(name_list)
         else:
@@ -431,7 +431,7 @@ class Template(BaseModel):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ):
         """Return a copy of this template with context added
@@ -442,7 +442,7 @@ class Template(BaseModel):
             If True, rename the names of the concepts
         exclude_concepts :
             A set of concept names to keep unchanged.
-        name_map :
+        curie_to_name_map :
             A mapping of context values to names. Useful if the context values
             are e.g. curies. Will only be used if ``do_rename`` is True.
 
@@ -627,7 +627,7 @@ class ControlledConversion(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "ControlledConversion":
         exclude_concepts = exclude_concepts or set()
@@ -635,15 +635,15 @@ class ControlledConversion(Template):
             type=self.type,
             subject=self.subject if self.subject.name in exclude_concepts else
                      self.subject.with_context(do_rename=do_rename,
-                                               name_map=name_map,
+                                               curie_to_name_map=curie_to_name_map,
                                                **context),
             outcome=self.outcome if self.outcome.name in exclude_concepts else
                      self.outcome.with_context(do_rename=do_rename,
-                                               name_map=name_map,
+                                               curie_to_name_map=curie_to_name_map,
                                                **context),
             controller=self.controller if self.controller.name in exclude_concepts else
                         self.controller.with_context(do_rename=do_rename,
-                                                     name_map=name_map,
+                                                     curie_to_name_map=curie_to_name_map,
                                                      **context),
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -691,7 +691,7 @@ class GroupedControlledConversion(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "GroupedControlledConversion":
         exclude_concepts = exclude_concepts or set()
@@ -699,17 +699,17 @@ class GroupedControlledConversion(Template):
         return self.__class__(
             type=self.type,
             controllers=[c.with_context(do_rename=do_rename,
-                                        name_map=name_map,
+                                        curie_to_name_map=curie_to_name_map,
                                         **context)
                          if c.name not in exclude_concepts else c
                          for c in self.controllers],
             subject=self.subject if self.subject.name in exclude_concepts else
                         self.subject.with_context(
-                            do_rename=do_rename, name_map=name_map, **context
+                            do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
                         ),
             outcome=self.outcome if self.outcome.name in exclude_concepts else
                         self.outcome.with_context(
-                            do_rename=do_rename, name_map=name_map, **context
+                            do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
                         ),
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -799,17 +799,17 @@ class GroupedControlledProduction(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "GroupedControlledProduction":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            controllers=[c.with_context(do_rename, name_map=name_map, **context)
+            controllers=[c.with_context(do_rename, curie_to_name_map=curie_to_name_map, **context)
                          if c.name not in exclude_concepts else c
                          for c in self.controllers],
             outcome=self.outcome.with_context(
-                do_rename, name_map=name_map, **context
+                do_rename, curie_to_name_map=curie_to_name_map, **context
             )
                 if self.outcome.name not in exclude_concepts else self.outcome,
             provenance=self.provenance,
@@ -856,17 +856,17 @@ class ControlledProduction(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "ControlledProduction":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
             outcome=self.outcome.with_context(
-                do_rename=do_rename, name_map=name_map, **context
+                do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.outcome.name not in exclude_concepts else self.outcome,
             controller=self.controller.with_context(
-                do_rename=do_rename, name_map=name_map, **context
+                do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.controller.name not in exclude_concepts else self.controller,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -887,17 +887,17 @@ class NaturalConversion(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "NaturalConversion":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
             subject=self.subject.with_context(
-                do_rename=do_rename, name_map=name_map, **context
+                do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.subject.name not in exclude_concepts else self.subject,
             outcome=self.outcome.with_context(
-                do_rename=do_rename, name_map=name_map, **context
+                do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.outcome.name not in exclude_concepts else self.outcome,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -930,14 +930,14 @@ class NaturalProduction(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "NaturalProduction":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
             outcome=self.outcome.with_context(do_rename=do_rename,
-                                              name_map=name_map,
+                                              curie_to_name_map=curie_to_name_map,
                                               **context)
                 if self.outcome.name not in exclude_concepts else self.outcome,
             provenance=self.provenance,
@@ -964,14 +964,14 @@ class NaturalDegradation(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "NaturalDegradation":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
             subject=self.subject.with_context(
-                do_rename=do_rename, name_map=name_map, **context
+                do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.subject.name not in exclude_concepts else self.subject,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -1017,17 +1017,17 @@ class ControlledDegradation(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "ControlledDegradation":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
             subject=self.subject.with_context(
-                do_rename=do_rename, name_map=name_map, **context
+                do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.subject.name not in exclude_concepts else self.subject,
             controller=self.controller.with_context(
-                do_rename=do_rename, name_map=name_map, **context
+                do_rename=do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.controller.name not in exclude_concepts else self.controller,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -1080,16 +1080,16 @@ class GroupedControlledDegradation(Template):
         self,
         do_rename=False,
         exclude_concepts=None,
-        name_map=None,
+        curie_to_name_map=None,
         **context
     ) -> "GroupedControlledDegradation":
         exclude_concepts = exclude_concepts or set()
         return self.__class__(
             type=self.type,
-            controllers=[c.with_context(do_rename, name_map=name_map, **context)
+            controllers=[c.with_context(do_rename, curie_to_name_map=curie_to_name_map, **context)
                          if c.name not in exclude_concepts else c
                          for c in self.controllers],
-            subject=self.subject.with_context(do_rename, name_map=name_map, **context)
+            subject=self.subject.with_context(do_rename, curie_to_name_map=curie_to_name_map, **context)
                 if self.subject.name not in exclude_concepts else self.subject,
             provenance=self.provenance,
             rate_law=self.rate_law,
@@ -1117,7 +1117,7 @@ class StaticConcept(Template):
     def with_context(
         self,
         do_rename=False,
-        name_map=None,
+        curie_to_name_map=None,
         exclude_concepts=None,
         **context
     ) -> "StaticConcept":
@@ -1125,7 +1125,7 @@ class StaticConcept(Template):
         return self.__class__(
             type=self.type,
             subject=(self.subject.with_context(
-                do_rename, name_map=name_map, **context
+                do_rename, curie_to_name_map=curie_to_name_map, **context
             ) if self.subject.name not in exclude_concepts else self.subject),
             provenance=self.provenance,
             rate_law=self.rate_law,

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -135,7 +135,7 @@ class Concept(BaseModel):
             name_list = [self._base_name]
             for k, v in sorted(context.items()):
                 nv = name_map.get(v, v) if name_map else v
-                name_list.append(str(nv.replace(':', '_').replace(" ", "_")))
+                name_list.append(str(nv.replace(':', '_')))
             name = '_'.join(name_list)
         else:
             name = self.name

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -121,8 +121,11 @@ class Concept(BaseModel):
             If true, will modify the name of the node based on the context
             introduced
         curie_to_name_map :
-            A mapping of context values to names. Useful if the context values
-            are e.g. curies.
+            Use to set a name different from the context values provided in
+            the **context kwarg when do_rename=True. Useful if
+            the context values are e.g. curies or longer names that should
+            be shortened, like {"New York City": "nyc"}. If not provided (
+            default behavior), the context values will be used as names.
 
         Returns
         -------

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -135,7 +135,7 @@ class Concept(BaseModel):
             name_list = [self._base_name]
             for k, v in sorted(context.items()):
                 nv = name_map.get(v, v)
-                name_list.append(str(nv.replace(':', '_')))
+                name_list.append(str(nv.replace(':', '_').replace(" ", "_")))
             name = '_'.join(name_list)
         else:
             name = self.name

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -134,7 +134,7 @@ class Concept(BaseModel):
                 self._base_name = self.name
             name_list = [self._base_name]
             for k, v in sorted(context.items()):
-                nv = name_map.get(v, v)
+                nv = name_map.get(v, v) if name_map else v
                 name_list.append(str(nv.replace(':', '_').replace(" ", "_")))
             name = '_'.join(name_list)
         else:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -133,9 +133,11 @@ class Concept(BaseModel):
             if self._base_name is None:
                 self._base_name = self.name
             name_list = [self._base_name]
-            for k, v in sorted(context.items()):
-                nv = curie_to_name_map.get(v, v) if curie_to_name_map else v
-                name_list.append(str(nv.replace(':', '_')))
+            for _, context_value in sorted(context.items()):
+                entity_name = curie_to_name_map.get(
+                    context_value, context_value
+                ) if curie_to_name_map else context_value
+                name_list.append(str(entity_name.replace(':', '_')))
             name = '_'.join(name_list)
         else:
             name = self.name

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -112,7 +112,7 @@ class Concept(BaseModel):
             SympyExprStr: lambda e: sympy.parse_expr(e)
         }
 
-    def with_context(self, do_rename=False, **context) -> "Concept":
+    def with_context(self, do_rename=False, name_map=None, **context) -> "Concept":
         """Return this concept with extra context.
 
         Parameters
@@ -120,6 +120,9 @@ class Concept(BaseModel):
         do_rename :
             If true, will modify the name of the node based on the context
             introduced
+        name_map :
+            A mapping of context values to names. Useful if the context values
+            are e.g. curies.
 
         Returns
         -------
@@ -129,8 +132,11 @@ class Concept(BaseModel):
         if do_rename:
             if self._base_name is None:
                 self._base_name = self.name
-            name = '_'.join([self._base_name] + \
-                [str(v.replace(':', '_')) for _, v in sorted(context.items())])
+            name_list = [self._base_name]
+            for k, v in sorted(context.items()):
+                nv = name_map.get(v, v)
+                name_list.append(str(nv.replace(':', '_')))
+            name = '_'.join(name_list)
         else:
             name = self.name
         concept = Concept(

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -236,7 +236,7 @@ class TestModelApi(unittest.TestCase):
             template_model=sir_templ_model,
             key=key,
             strata=set(strata),
-            strata_name_map=strata_name_map
+            strata_curie_to_name=strata_name_map
         )
         strat_str = sorted_json_str(strat_templ_model.dict())
 

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -218,17 +218,25 @@ class TestModelApi(unittest.TestCase):
         sir_templ_model = _get_sir_templatemodel()
         key = "city"
         strata = ["geonames:5128581", "geonames:4930956"]
+        strata_name_map = {
+            "geonames:5128581": "New York City",
+            "geonames:4930956": "Boston",
+        }
         query_json = {
             "template_model": sir_templ_model.dict(),
             "key": key,
             "strata": strata,
+            "strata_name_map": strata_name_map,
         }
         response = self.client.post("/api/stratify", json=query_json)
         self.assertEqual(200, response.status_code)
         resp_json_str = sorted_json_str(response.json())
 
         strat_templ_model = stratify(
-            template_model=sir_templ_model, key=key, strata=set(strata)
+            template_model=sir_templ_model,
+            key=key,
+            strata=set(strata),
+            strata_name_map=strata_name_map
         )
         strat_str = sorted_json_str(strat_templ_model.dict())
 
@@ -239,6 +247,7 @@ class TestModelApi(unittest.TestCase):
             "template_model": sir_templ_model.dict(),
             "key": key,
             "strata": strata,
+            "strata_name_map": strata_name_map,
             "directed": True,
         }
         response = self.client.post("/api/stratify", json=query_json)
@@ -249,6 +258,7 @@ class TestModelApi(unittest.TestCase):
             template_model=sir_templ_model,
             key=key,
             strata=set(strata),
+            strata_name_map=strata_name_map,
             directed=query_json["directed"],
         )
         strat_str = sorted_json_str(strat_templ_model.dict())

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -14,7 +14,8 @@ from mira.examples.sir import sir_parameterized, sir, \
     sir_parameterized_init, sir_init_val_norm
 from mira.dkg.model import model_blueprint, ModelComparisonResponse
 from mira.dkg.api import RelationQuery
-from mira.dkg.web_client import is_ontological_child_web, get_relations_web
+from mira.dkg.web_client import is_ontological_child_web, get_relations_web, \
+    get_entity_web
 from mira.metamodel import Concept, ControlledConversion, NaturalConversion, \
     TemplateModel, Distribution, Annotations, Time, Observable, SympyExprStr
 from mira.metamodel.ops import stratify
@@ -96,6 +97,14 @@ class MockNeo4jClient:
         )
         res = get_relations_web(relations_model=rq)
         return [r.dict(exclude_unset=True) for r in res]
+
+    @staticmethod
+    def get_entity(curie: str):
+        try:
+            res = get_entity_web(curie=curie)
+            return res.dict(exclude_unset=True)
+        except requests.exceptions.HTTPError:
+            return None
 
 
 class State:

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -242,12 +242,11 @@ class TestModelApi(unittest.TestCase):
 
         self.assertEqual(strat_str, resp_json_str)
 
-        # Test directed True
+        # Test directed True, also skip the name map
         query_json = {
             "template_model": sir_templ_model.dict(),
             "key": key,
             "strata": strata,
-            "strata_name_map": strata_name_map,
             "directed": True,
         }
         response = self.client.post("/api/stratify", json=query_json)
@@ -258,7 +257,6 @@ class TestModelApi(unittest.TestCase):
             template_model=sir_templ_model,
             key=key,
             strata=set(strata),
-            strata_name_map=strata_name_map,
             directed=query_json["directed"],
         )
         strat_str = sorted_json_str(strat_templ_model.dict())

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -219,7 +219,7 @@ class TestOperations(unittest.TestCase):
         self.assertIn(original_name, sir_parameterized.initials)
         for city in cities:
             city_name = city_name_map.get(city, city)
-            key = f"{original_name}_{city_name}".replace(':', '_').replace(' ', '_')
+            key = f"{original_name}_{city_name}".replace(':', '_')
             self.assertIn(key, actual.initials, msg=f"Key '{key}' not in initials")
             # Cannot use .args[0] here as .args[0] not a primitive data type
             self.assertEqual(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -202,7 +202,7 @@ class TestOperations(unittest.TestCase):
             sir_parameterized,
             key="city",
             strata=cities,
-            strata_name_map=city_name_map,
+            strata_curie_to_name=city_name_map,
             cartesian_control=False,
             directed=False
         )

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -229,6 +229,42 @@ class TestOperations(unittest.TestCase):
                     f"({original_name}) to stratified compartment ({key})"
             )
 
+    def test_stratify_w_client_mapping(self):
+        """Test stratifying a template model by labels."""
+        city_name_map = {
+            "geonames:5128581": "New York City", "geonames:4930956": "Boston"
+        }
+        actual = stratify(
+            sir_parameterized,
+            key="city",
+            strata=cities,
+            strata_name_lookup=True,
+            cartesian_control=False,
+            directed=False
+        )
+        for template in actual.templates:
+            for concept in template.get_concepts():
+                self.assertIn("city", concept.context)
+        self.assert_unique_controllers(actual)
+        self.assertEqual(
+            {template.get_key() for template in sir_2_city.templates},
+            {template.get_key() for template in actual.templates},
+        )
+
+        original_name = "susceptible_population"
+        self.assertIn(original_name, sir_parameterized.initials)
+        for city in cities:
+            city_name = city_name_map.get(city, city)
+            key = f"{original_name}_{city_name}".replace(':', '_')
+            self.assertIn(key, actual.initials, msg=f"Key '{key}' not in initials")
+            # Cannot use .args[0] here as .args[0] not a primitive data type
+            self.assertEqual(
+                SympyExprStr(float(str(sir_parameterized.initials[original_name].expression)) / len(cities)),
+                actual.initials[key].expression,
+                msg=f"initial value was not copied from original compartment "
+                    f"({original_name}) to stratified compartment ({key})"
+            )
+
     @unittest.skip(reason="Small bookkeeping still necessary")
     def test_stratify_control(self):
         """Test stratifying a template that properly multiples the controllers."""

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -217,8 +217,8 @@ class TestOperations(unittest.TestCase):
 
         original_name = "susceptible_population"
         self.assertIn(original_name, sir_parameterized.initials)
-        for city in cities:
-            city_name = city_name_map.get(city, city)
+        for city_curie in cities:
+            city_name = city_name_map.get(city_curie, city_curie)
             key = f"{original_name}_{city_name}".replace(':', '_')
             self.assertIn(key, actual.initials, msg=f"Key '{key}' not in initials")
             # Cannot use .args[0] here as .args[0] not a primitive data type


### PR DESCRIPTION
This PR allows the automatically generated stratification names to be more human friendly by passing through a mapping from calling the stratify function down to where the renaming happens: in the the `concept.with_context` method.

Tests are added for both the stratify module and for the model api.

When calling the stratify endpoint, a user can provide the name mapping or if no mapping is provided a lazy attempt to map from curies to entity names is done. If the curie mapping also fails, the behavior prior to this PR is expected.

## Example

```python
from mira.metamodel.ops import stratify
from mira.examples.sir import sir_parameterized
cities = [
    "geonames:5128581",  # NYC
    "geonames:4930956",  # boston
]
stratified_model = stratify(sir_parameterized, key="city", strata=cities, cartesian_control=False, directed=False)
print(stratified_model.templates[0].controller)
# > name='infected_population_geonames_4930956' display_name=None description=None identifiers={'ido': '0000511'} context={'city': 'geonames:4930956'} units=None
```
