### PR TITLE
Create TA1 Extraction Evaluation.ipynb

### DIFF
--- a/notebooks/TA1 Extraction Evaluation.ipynb
+++ b/notebooks/TA1 Extraction Evaluation.ipynb
@@ -1,0 +1,254 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "5169f54a-95d8-4f88-ba0a-02e0da27585b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<pandas.io.excel._base.ExcelFile at 0x10d53b6d0>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "url = \"https://docs.google.com/spreadsheets/d/e/2PACX-1vQ2G-ZFSotS2qo94mnTWCDvj9Y49ai-9O61DA7940sPYynEdBXq2cT2-Wl3nNldIb3gkpbPFaTFY2PJ/pub?output=xlsx\"\n",
+    "\n",
+    "xls = pd.ExcelFile(url)\n",
+    "xls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b1a81a6b-d9a3-4c8c-b62d-8db3b3951515",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'BIOMD0000000955',\n",
+       " 'BIOMD0000000956',\n",
+       " 'BIOMD0000000957',\n",
+       " 'BIOMD0000000958',\n",
+       " 'BIOMD0000000960'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sheets = {\n",
+    "    sheet_name: pd.read_excel(xls, sheet_name)\n",
+    "    for sheet_name in xls.sheet_names\n",
+    "}\n",
+    "for sheet in sheets.values():\n",
+    "    sheet['grounding'] = sheet['grounding'].map(eval)\n",
+    "set(sheets)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a6f22f14-4c75-4678-b935-3d8605c43273",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'BIOMD0000000958': {'apollosv:00000154',\n",
+       "  'ido:0000511',\n",
+       "  'ido:0000514',\n",
+       "  'ido:0000592',\n",
+       "  'ncit:C25179',\n",
+       "  'ncit:C25376',\n",
+       "  'ncit:C28554',\n",
+       "  'ncit:C3833',\n",
+       "  'ncit:C49508'},\n",
+       " 'BIOMD0000000960': {'apollosv:00000154',\n",
+       "  'biomodels.species:BIOMD0000000960:Cumulative_Cases',\n",
+       "  'ido:0000480',\n",
+       "  'ido:0000511',\n",
+       "  'ido:0000514',\n",
+       "  'ido:0000592',\n",
+       "  'ncit:C25179',\n",
+       "  'ncit:C25269',\n",
+       "  'ncit:C28554',\n",
+       "  'ncit:C3833',\n",
+       "  'ncit:C68851'},\n",
+       " 'BIOMD0000000957': {'ido:0000511',\n",
+       "  'ido:0000514',\n",
+       "  'ido:0000592',\n",
+       "  'ncit:C15220'},\n",
+       " 'BIOMD0000000956': {'ido:0000511', 'ido:0000514', 'ido:0000592'},\n",
+       " 'BIOMD0000000955': {'ido:0000511',\n",
+       "  'ido:0000514',\n",
+       "  'ido:0000592',\n",
+       "  'ncit:C113725',\n",
+       "  'ncit:C15220',\n",
+       "  'ncit:C25269',\n",
+       "  'ncit:C25467',\n",
+       "  'ncit:C28554'}}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from collections import defaultdict\n",
+    "ground_truth_df = pd.read_csv(\"/Users/cthoyt/Downloads/biomodels_groundings.tsv\", sep='\\t')\n",
+    "\n",
+    "dd = defaultdict(set)\n",
+    "for model_id, curie in ground_truth_df.values:\n",
+    "    dd[model_id].add(curie)\n",
+    "dd = dict(dd)\n",
+    "dd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "bf087fbd-ad04-4cfe-b1c6-c997e9be208e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>model</th>\n",
+       "      <th>structured</th>\n",
+       "      <th>TA-1</th>\n",
+       "      <th>precision</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>BIOMD0000000955</td>\n",
+       "      <td>8</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.12</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>BIOMD0000000956</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BIOMD0000000957</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.25</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>BIOMD0000000958</td>\n",
+       "      <td>9</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.11</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>BIOMD0000000960</td>\n",
+       "      <td>11</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.09</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "             model  structured  TA-1  precision\n",
+       "0  BIOMD0000000955           8     1       0.12\n",
+       "1  BIOMD0000000956           3     0       0.00\n",
+       "2  BIOMD0000000957           4     1       0.25\n",
+       "3  BIOMD0000000958           9     1       0.11\n",
+       "4  BIOMD0000000960          11     1       0.09"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rows = []\n",
+    "for model_id, sheet in sheets.items():\n",
+    "    sheet_curies = {\n",
+    "        grounding[\"id\"]\n",
+    "        for groundings in sheet[\"grounding\"]\n",
+    "        for grounding in groundings\n",
+    "    }\n",
+    "    ground_truth_curies = dd[model_id]\n",
+    "\n",
+    "    intersection_curies = sheet_curies & ground_truth_curies\n",
+    "    n_intersection = len(intersection_curies)\n",
+    "    n_ground_truth = len(ground_truth_curies)\n",
+    "    n_sheet = len(sheet_curies)\n",
+    "    rows.append((\n",
+    "        model_id,\n",
+    "        n_ground_truth,\n",
+    "        n_intersection,\n",
+    "        round(n_intersection / n_ground_truth, 2)\n",
+    "    ))\n",
+    "\n",
+    "print(\"The way to interpret the precision is the percent\")\n",
+    "pd.DataFrame(rows, columns=[\"model\", \"structured\", \"TA-1\", \"precision\"])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This notebook compares the initial [TA 1 extractions](https://docs.google.com/spreadsheets/d/13ejF72xXHxhDdcypBFSKyu9KoJcBxabKTklyBgwLDU8/edit?usp=sharing) for papers corresponding to 5 models in the BioModels database to the ground truth from MIRA's structured ingestion of the same models.

The [Jupyter notebook in this PR](https://github.com/gyorilab/mira/blob/ta1-evaluation/notebooks/TA1%20Extraction%20Evaluation.ipynb) creates the following table. The way to interpret the precision is the percentage of the ground truth CURIEs from the model that appear in any extraction.

| model           |   structured |   TA-1 |   precision |
|:----------------|-------------:|-------:|------------:|
| BIOMD0000000955 |            8 |      1 |        0.12 |
| BIOMD0000000956 |            3 |      0 |        0    |
| BIOMD0000000957 |            4 |      1 |        0.25 |
| BIOMD0000000958 |            9 |      1 |        0.11 |
| BIOMD0000000960 |           11 |      1 |        0.09 |