### PR TITLE
Get physical constants from Wikidata

### DIFF
--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -50,6 +50,7 @@ from mira.dkg.resources import SLIMS, get_ncbitaxon
 from mira.dkg.resources.extract_ncit import get_ncit_subset
 from mira.dkg.resources.probonto import get_probonto_terms
 from mira.dkg.units import get_unit_terms
+from mira.dkg.physical_constants import get_physical_constant_terms
 from mira.dkg.constants import EDGE_HEADER, NODE_HEADER
 from mira.dkg.utils import PREFIXES
 
@@ -516,6 +517,31 @@ def construct(
             property_predicates="",
             property_values="",
             xref_types=";".join("oboinowl:hasDbXref" for _ in xrefs),
+            synonym_types="",
+        )
+
+    click.secho("Physical Constants", fg="green", bold=True)
+    for wikidata_id, label, description, synonyms, xrefs, _value, _formula, _symbols in tqdm(
+        get_physical_constant_terms(), desc="Physical Constants"
+    ):
+        # TODO how to model value, formula?
+        # TODO process mathml and make readable
+        curie = f"wikidata:{wikidata_id}"
+        node_sources[curie].add("wikidata")
+        nodes[curie] = NodeInfo(
+            curie=curie,
+            prefix="wikidata;constant",
+            label=label,
+            synonyms=";".join(synonyms),
+            deprecated="false",
+            type="class",
+            definition=description,
+            xrefs=";".join(xrefs),
+            xref_types=";".join("oboinowl:hasDbXref" for _ in xrefs),
+            alts="",
+            version="",
+            property_predicates="",
+            property_values="",
             synonym_types="",
         )
 

--- a/mira/dkg/physical_constants.py
+++ b/mira/dkg/physical_constants.py
@@ -3,6 +3,7 @@
 import json
 from typing import List, Mapping, Any
 import logging
+from xml.etree import ElementTree
 
 import requests
 from mira.dkg.resources import get_resource_path
@@ -89,7 +90,7 @@ def get_physical_constant_terms():
         )
         symbols = sorted(
             {
-                mathml.strip()
+                _process_xml(mathml.strip())
                 for mathml in record["latexes"]["value"].split("|")
                 if mathml.strip()
             }
@@ -120,6 +121,15 @@ def get_physical_constant_terms():
             )
         )
     return rv
+
+
+def _process_xml(xml_str):
+    tree = ElementTree.fromstring(xml_str)
+    text = tree[0][1].text
+    k = "{\displaystyle "
+    if text.startswith(k):
+        text = text[len(k) : -1]  # remove trailing }
+    return text
 
 
 def update_physical_constants_resource():

--- a/mira/dkg/physical_constants.py
+++ b/mira/dkg/physical_constants.py
@@ -102,7 +102,8 @@ def get_physical_constant_terms():
         ]:
             if xref_values := record.get(key):
                 for xref_value in xref_values["value"].split("|"):
-                    xrefs.append(f"{prefix}:{xref_value}")
+                    if xref_value.strip():
+                        xrefs.append(f"{prefix}:{xref_value}")
 
         rv.append(
             (
@@ -134,7 +135,10 @@ def update_physical_constants_resource():
         "formula",
         "symbols",
     ]
-    terms = [dict(zip(rows, term)) for term in get_physical_constant_terms()]
+    terms = [
+        {k: v for k, v in zip(rows, term) if v}
+        for term in get_physical_constant_terms()
+    ]
     with open(path, "w") as file:
         json.dump(terms, file, indent=2)
 

--- a/mira/dkg/physical_constants.py
+++ b/mira/dkg/physical_constants.py
@@ -126,7 +126,7 @@ def update_physical_constants_resource():
     """Update a resource file with all physical constant names."""
     path = get_resource_path("physical_constants.json")
     rows = [
-        "curie",
+        "wikidata_id",
         "label",
         "description",
         "synonyms",

--- a/mira/dkg/physical_constants.py
+++ b/mira/dkg/physical_constants.py
@@ -1,0 +1,121 @@
+"""Get physical constants from wikidata."""
+
+from typing import List, Mapping, Any
+import logging
+import requests
+from .resources import get_resource_path
+
+__all__ = [
+    "get_physical_constant_terms",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Wikidata SPARQL endpoint. See https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service#Interfacing
+WIKIDATA_ENDPOINT = "https://query.wikidata.org/bigdata/namespace/wdq/sparql"
+
+SPARQL = """\
+SELECT 
+  ?item ?itemLabel ?itemDescription ?itemAltLabel ?value ?defining_formula 
+  (group_concat(?nist;separator="|") as ?nists)
+  (group_concat(?goldbook; separator="|") as ?goldbooks)
+  (group_concat(?latex; separator="||") as ?latexes)
+WHERE 
+{
+  ?item wdt:P31 wd:Q173227 .
+  OPTIONAL { ?item wdt:P1181 ?value . }
+  OPTIONAL { ?item wdt:P2534 ?defining_formula . }
+  OPTIONAL { ?item wdt:P7973 ?latex . }
+  OPTIONAL { ?item wdt:P1645 ?nist . }
+  OPTIONAL { ?item wdt:P4732 ?goldbook . }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+} 
+GROUP BY ?item ?itemLabel ?itemDescription ?itemAltLabel ?value ?defining_formula
+"""
+
+
+def query_wikidata(sparql: str) -> List[Mapping[str, Any]]:
+    """Query Wikidata's sparql service.
+
+    Parameters
+    ----------
+    sparql :
+        A SPARQL query string
+
+    Returns
+    -------
+    :
+        A list of bindings
+    """
+    logger.debug("running query: %s", sparql)
+    res = requests.get(
+        WIKIDATA_ENDPOINT, params={"query": sparql, "format": "json"}
+    )
+    res.raise_for_status()
+    res_json = res.json()
+    return res_json["results"]["bindings"]
+
+
+def get_physical_constant_terms():
+    """Get tuples for each constant."""
+    records = query_wikidata(SPARQL)
+    rv = []
+    for record in records:
+        label = record["itemLabel"]["value"].strip()
+        if not label:
+            continue
+
+        try:
+            description = record["itemDescription"]["value"]
+        except KeyError:
+            description = ""
+
+        synonyms = [
+            synonym.strip()
+            for synonym in (
+                record.get("itemAltLabel", {}).get("value") or ""
+            ).split(",")
+            if synonym.strip()
+        ]
+
+        # the actual number for the constant
+        value = record["value"]["value"]
+        formula = record["defining_formula"]["value"]
+        symbols = [mathml for mathml in record["latexes"]["values"].split("|")]
+
+        xrefs = []
+        for key, prefix in [
+            ("nists", "nist.codata"),
+            ("goldbooks", "goldbook"),
+        ]:
+            if xref_values := record.get(key):
+                for xref_value in xref_values["value"].split("|"):
+                    xrefs.append(f"{prefix}:{xref_value}")
+
+        rv.append(
+            (
+                record["item"]["value"][
+                    len("http://www.wikidata.org/entity/") :
+                ],
+                label,
+                description,
+                synonyms,
+                xrefs,
+                value,
+                formula,
+                symbols,,
+            )
+        )
+    return rv
+
+
+def update_physical_constants_resource():
+    """Update a resource file with all physical constant names."""
+    path = get_resource_path("physical_constants.tsv")
+    names = sorted([row[1] for row in get_physical_constant_terms()])
+    with open(path, "w") as file:
+        file.write("\n".join(names))
+
+
+if __name__ == "__main__":
+    update_physical_constants_resource()

--- a/mira/dkg/physical_constants.py
+++ b/mira/dkg/physical_constants.py
@@ -103,7 +103,7 @@ def get_physical_constant_terms():
                 xrefs,
                 value,
                 formula,
-                symbols,,
+                symbols,
             )
         )
     return rv

--- a/mira/dkg/resources/physical_constants.json
+++ b/mira/dkg/resources/physical_constants.json
@@ -10,8 +10,8 @@
     ],
     "value": "-2.00231930436256",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {e} ^{-}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <msup>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">e</mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>&#x2212;<!-- \u2212 --></mo>\n              </mrow>\n            </msup>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {e} ^{-}}}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+      "g_{\\mathrm {e} ^{-}}",
+      "g_{\\mathrm {e} }"
     ]
   },
   {
@@ -25,7 +25,7 @@
     ],
     "value": "5.5856946893",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+      "g_{\\mathrm {p} }"
     ]
   },
   {
@@ -40,8 +40,8 @@
     ],
     "value": "-2.0023318418",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {\\mu } ^{-}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <msup>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>&#x2212;<!-- \u2212 --></mo>\n              </mrow>\n            </msup>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {\\mu } ^{-}}}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {\\mu } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {\\mu } }}</annotation>\n  </semantics>\n</math>"
+      "g_{\\mathrm {\\mu } ^{-}}",
+      "g_{\\mathrm {\\mu } }"
     ]
   },
   {
@@ -55,7 +55,7 @@
     ],
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1L}=2hc^{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n            <mi>L</mi>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mn>2</mn>\n        <mi>h</mi>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1L}=2hc^{2}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1L}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n            <mi>L</mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1L}}</annotation>\n  </semantics>\n</math>"
+      "c_{1L}"
     ]
   },
   {
@@ -64,7 +64,7 @@
     "description": "reciprocal of the impedance of vacuum",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Y</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <msub>\n              <mi>Z</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Y_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Y</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Y_{0}}</annotation>\n  </semantics>\n</math>"
+      "Y_{0}"
     ]
   },
   {
@@ -76,7 +76,7 @@
     ],
     "value": "0.000000000000100209952",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {xu} (\\mathrm {Mo} \\,\\mathrm {K\\alpha } _{1})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">x</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">M</mi>\n          <mi mathvariant=\"normal\">o</mi>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {xu} (\\mathrm {Mo} \\,\\mathrm {K\\alpha } _{1})}</annotation>\n  </semantics>\n</math>"
+      "\\mathrm {xu} (\\mathrm {Mo} \\,\\mathrm {K\\alpha } _{1})"
     ]
   },
   {
@@ -97,7 +97,7 @@
     "value": "0.0000000000000003741771852",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1}=2\\pi hc^{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mn>2</mn>\n        <mi>&#x03C0;<!-- \u03c0 --></mi>\n        <mi>h</mi>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1}=2\\pi hc^{2}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1}}</annotation>\n  </semantics>\n</math>"
+      "c_{1}"
     ]
   },
   {
@@ -110,7 +110,7 @@
     "value": "0.01438776877",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{2}={\\frac {hc}{k_{\\mathrm {B} }}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>h</mi>\n              <mi>c</mi>\n            </mrow>\n            <msub>\n              <mi>k</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">B</mi>\n                </mrow>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{2}={\\frac {hc}{k_{\\mathrm {B} }}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{2}}</annotation>\n  </semantics>\n</math>"
+      "c_{2}"
     ]
   },
   {
@@ -141,7 +141,7 @@
     ],
     "value": "0.0000000000000000001602176634",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle e}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>e</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle e}</annotation>\n  </semantics>\n</math>"
+      "e"
     ]
   },
   {
@@ -167,8 +167,8 @@
     "value": "299792458",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{0}=299792458\\,\\mathrm {m} /\\mathrm {s} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mn>299792458</mn>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">m</mi>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">s</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{0}=299792458\\,\\mathrm {m} /\\mathrm {s} }</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{0}}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>c</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c}</annotation>\n  </semantics>\n</math>"
+      "c",
+      "c_{0}"
     ]
   },
   {
@@ -181,8 +181,8 @@
     ],
     "value": "0.00000000000000000000001380649",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k_{\\mathrm {B} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>k</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">B</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k_{\\mathrm {B} }}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
+      "k",
+      "k_{\\mathrm {B} }"
     ]
   },
   {
@@ -201,7 +201,7 @@
     "value": "0.0072973525693",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\alpha ={\\frac {1}{4\\pi \\varepsilon _{0}}}{\\frac {e^{2}}{\\hbar c}}={\\frac {\\mu _{0}}{4\\pi }}{\\frac {e^{2}c}{\\hbar }}={\\frac {k_{\\text{e}}e^{2}}{\\hbar c}}={\\frac {c\\mu _{0}}{2R_{\\text{K}}}}={\\frac {e^{2}}{4\\pi }}{\\frac {Z_{0}}{\\hbar }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03B1;<!-- \u03b1 --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <mi>c</mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n              <mi>c</mi>\n            </mrow>\n            <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msub>\n                <mi>k</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mtext>e</mtext>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <mi>c</mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>c</mi>\n              <msub>\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>R</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mtext>K</mtext>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>Z</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n            <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\alpha ={\\frac {1}{4\\pi \\varepsilon _{0}}}{\\frac {e^{2}}{\\hbar c}}={\\frac {\\mu _{0}}{4\\pi }}{\\frac {e^{2}c}{\\hbar }}={\\frac {k_{\\text{e}}e^{2}}{\\hbar c}}={\\frac {c\\mu _{0}}{2R_{\\text{K}}}}={\\frac {e^{2}}{4\\pi }}{\\frac {Z_{0}}{\\hbar }}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\alpha }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03B1;<!-- \u03b1 --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\alpha }</annotation>\n  </semantics>\n</math>"
+      "\\alpha "
     ]
   },
   {
@@ -221,7 +221,7 @@
     "value": "0.0000000000088541878128",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\varepsilon _{0}={\\frac {1}{\\mu _{0}c_{0}^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B5;<!-- \u03b5 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <mrow>\n              <msub>\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msubsup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msubsup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\varepsilon _{0}={\\frac {1}{\\mu _{0}c_{0}^{2}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\varepsilon _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B5;<!-- \u03b5 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\varepsilon _{0}}</annotation>\n  </semantics>\n</math>"
+      "\\varepsilon _{0}"
     ]
   },
   {
@@ -241,7 +241,7 @@
     ],
     "value": "602214076000000000000000",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N_{\\mathrm {A} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">A</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N_{\\mathrm {A} }}</annotation>\n  </semantics>\n</math>"
+      "N_{\\mathrm {A} }"
     ]
   },
   {
@@ -259,7 +259,7 @@
     ],
     "value": "0.000000000066743",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle G}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>G</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle G}</annotation>\n  </semantics>\n</math>"
+      "G"
     ]
   },
   {
@@ -276,7 +276,7 @@
     "value": "0.0000000567037441918442945397099673188923087584012297029130368240546173705394816062652332608257185777044688703926026976455142",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma ={\\frac {2\\pi ^{5}k_{\\mathrm {B} }^{4}}{15h^{3}c^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>2</mn>\n              <msup>\n                <mi>&#x03C0;<!-- \u03c0 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n              <msubsup>\n                <mi>k</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">B</mi>\n                  </mrow>\n                </mrow>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>4</mn>\n                </mrow>\n              </msubsup>\n            </mrow>\n            <mrow>\n              <mn>15</mn>\n              <msup>\n                <mi>h</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>3</mn>\n                </mrow>\n              </msup>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma ={\\frac {2\\pi ^{5}k_{\\mathrm {B} }^{4}}{15h^{3}c^{2}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma }</annotation>\n  </semantics>\n</math>"
+      "\\sigma "
     ]
   },
   {
@@ -293,7 +293,7 @@
     "value": "0.0000000567037441918442945397099673188923087584012297029130368240546173705394816062652332608257185777044688703926026976455142",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma ={\\frac {5\\,454\\,781\\,984\\,210\\,512\\,994\\,952\\,000\\,000\\pi ^{5}}{29\\,438\\,455\\,734\\,650\\,141\\,042\\,413\\,712\\,126\\,365\\,436\\,049}}\\mathrm {W} /(\\mathrm {m} ^{2}\\cdot \\mathrm {K} ^{4})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>5</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>454</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>781</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>984</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>210</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>512</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>994</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>952</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>000</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>000</mn>\n              <msup>\n                <mi>&#x03C0;<!-- \u03c0 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>29</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>438</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>455</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>734</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>650</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>141</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>042</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>413</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>712</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>126</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>365</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>436</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>049</mn>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">W</mi>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">m</mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>4</mn>\n          </mrow>\n        </msup>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma ={\\frac {5\\,454\\,781\\,984\\,210\\,512\\,994\\,952\\,000\\,000\\pi ^{5}}{29\\,438\\,455\\,734\\,650\\,141\\,042\\,413\\,712\\,126\\,365\\,436\\,049}}\\mathrm {W} /(\\mathrm {m} ^{2}\\cdot \\mathrm {K} ^{4})}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma }</annotation>\n  </semantics>\n</math>"
+      "\\sigma "
     ]
   },
   {
@@ -306,7 +306,7 @@
     ],
     "value": "0.00000000000000000000000000000000000000000000000000011056",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Lambda }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi mathvariant=\"normal\">&#x039B;<!-- \u039b --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Lambda }</annotation>\n  </semantics>\n</math>"
+      "\\Lambda "
     ]
   },
   {
@@ -324,7 +324,7 @@
     "value": "0.0000000000000000001602176634",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle 1\\;{\\text{eV}}/c^{2}={\\frac {(1.60217646\\times 10^{-19}\\;{\\text{C}})\\cdot 1\\;{\\text{V}}}{(2.99792458\\times 10^{8}\\;{\\text{m}}/{\\text{s}})^{2}}}=1.783\\times 10^{-36}\\;{\\text{kg}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mn>1</mn>\n        <mspace width=\"thickmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mtext>eV</mtext>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mo stretchy=\"false\">(</mo>\n              <mn>1.60217646</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mo>&#x2212;<!-- \u2212 --></mo>\n                  <mn>19</mn>\n                </mrow>\n              </msup>\n              <mspace width=\"thickmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>C</mtext>\n              </mrow>\n              <mo stretchy=\"false\">)</mo>\n              <mo>&#x22C5;<!-- \u22c5 --></mo>\n              <mn>1</mn>\n              <mspace width=\"thickmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>V</mtext>\n              </mrow>\n            </mrow>\n            <mrow>\n              <mo stretchy=\"false\">(</mo>\n              <mn>2.99792458</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>8</mn>\n                </mrow>\n              </msup>\n              <mspace width=\"thickmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>m</mtext>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>/</mo>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>s</mtext>\n              </mrow>\n              <msup>\n                <mo stretchy=\"false\">)</mo>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mn>1.783</mn>\n        <mo>&#x00D7;<!-- \u00d7 --></mo>\n        <msup>\n          <mn>10</mn>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mo>&#x2212;<!-- \u2212 --></mo>\n            <mn>36</mn>\n          </mrow>\n        </msup>\n        <mspace width=\"thickmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mtext>kg</mtext>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle 1\\;{\\text{eV}}/c^{2}={\\frac {(1.60217646\\times 10^{-19}\\;{\\text{C}})\\cdot 1\\;{\\text{V}}}{(2.99792458\\times 10^{8}\\;{\\text{m}}/{\\text{s}})^{2}}}=1.783\\times 10^{-36}\\;{\\text{kg}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle eV}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>e</mi>\n        <mi>V</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle eV}</annotation>\n  </semantics>\n</math>"
+      "eV"
     ]
   },
   {
@@ -343,7 +343,7 @@
     "value": "0.000000000000000000000000000000000662607015",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle h={\\frac {3\\times 7\\times 6\\,310\\,543}{2^{42}\\times 5^{41}}}\\,\\mathrm {J} \\cdot \\mathrm {s} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>h</mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>3</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>7</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>6</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>310</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>543</mn>\n            </mrow>\n            <mrow>\n              <msup>\n                <mn>2</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>42</mn>\n                </mrow>\n              </msup>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>5</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>41</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">J</mi>\n        </mrow>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">s</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle h={\\frac {3\\times 7\\times 6\\,310\\,543}{2^{42}\\times 5^{41}}}\\,\\mathrm {J} \\cdot \\mathrm {s} }</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle h}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>h</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle h}</annotation>\n  </semantics>\n</math>"
+      "h"
     ]
   },
   {
@@ -361,8 +361,8 @@
     ],
     "value": "101325",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle atm}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>a</mi>\n        <mi>t</mi>\n        <mi>m</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle atm}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\text{&#x430;&#x442;&#x43C;.}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mtext>&#x430;&#x442;&#x43C;.</mtext>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\text{\u0430\u0442\u043c.}}}</annotation>\n  </semantics>\n</math>"
+      "atm",
+      "{\\text{\u0430\u0442\u043c.}}"
     ]
   },
   {
@@ -383,7 +383,7 @@
     "value": "8.31446261815324",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R=kN_{\\mathrm {A} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>R</mi>\n        <mo>=</mo>\n        <mi>k</mi>\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">A</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R=kN_{\\mathrm {A} }}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>R</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R}</annotation>\n  </semantics>\n</math>"
+      "R"
     ]
   },
   {
@@ -400,7 +400,7 @@
     "value": "96485.3321233100184",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle F=eN_{\\mathrm {A} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>F</mi>\n        <mo>=</mo>\n        <mi>e</mi>\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">A</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle F=eN_{\\mathrm {A} }}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle F}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>F</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle F}</annotation>\n  </semantics>\n</math>"
+      "F"
     ]
   },
   {
@@ -413,7 +413,7 @@
     "value": "0.00000000000000000000000000000000000000000005391247",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle t_{\\mathrm {P} }={\\sqrt {\\frac {\\hbar G}{c^{5}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>t</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <mi>G</mi>\n              </mrow>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle t_{\\mathrm {P} }={\\sqrt {\\frac {\\hbar G}{c^{5}}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle t_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>t</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle t_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+      "t_{\\mathrm {P} }"
     ]
   },
   {
@@ -426,7 +426,7 @@
     "value": "0.00000000000000000000000000000000001616255",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle l_{\\mathrm {P} }={\\sqrt {\\frac {G\\hbar }{c^{3}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>l</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi>G</mi>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              </mrow>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>3</mn>\n                </mrow>\n              </msup>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle l_{\\mathrm {P} }={\\sqrt {\\frac {G\\hbar }{c^{3}}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle l_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>l</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle l_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+      "l_{\\mathrm {P} }"
     ]
   },
   {
@@ -446,7 +446,7 @@
     "value": "376.730313461",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}={\\sqrt {\\frac {\\mu _{0}}{\\varepsilon _{0}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <msub>\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}={\\sqrt {\\frac {\\mu _{0}}{\\varepsilon _{0}}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+      "Z_{0}"
     ]
   },
   {
@@ -466,7 +466,7 @@
     "value": "376.730313461",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}=c_{0}\\mu _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}=c_{0}\\mu _{0}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+      "Z_{0}"
     ]
   },
   {
@@ -486,7 +486,7 @@
     "value": "376.730313461",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}={\\frac {|{\\boldsymbol {E}}|}{|{\\boldsymbol {H}}|}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"bold-italic\">E</mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n            </mrow>\n            <mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"bold-italic\">H</mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}={\\frac {|{\\boldsymbol {E}}|}{|{\\boldsymbol {H}}|}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+      "Z_{0}"
     ]
   },
   {
@@ -506,7 +506,7 @@
     "value": "376.730313461",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\"><merror><strong class=\"error texerror\">Failed to parse (SVG (MathML can be enabled via browser plugin): Invalid response (&quot;Math extension cannot connect to Restbase.&quot;) from server &quot;http://localhost:6011/www.wikidata.org/v1/&quot;:): {\\displaystyle Z_0 = \\mu_0 c_0}</strong>\n</merror></math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+      "Z_{0}"
     ]
   },
   {
@@ -523,7 +523,7 @@
     "value": "25812.80745",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }={\\frac {5\\,521\\,725\\,125}{213\\,914\\,163\\,877\\,964\\,163}}\\mathrm {T\\Omega } }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>5</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>521</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>725</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>125</mn>\n            </mrow>\n            <mrow>\n              <mn>213</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>914</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>163</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>877</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>964</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>163</mn>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">T</mi>\n          <mi mathvariant=\"normal\">&#x03A9;<!-- \u03a9 --></mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }={\\frac {5\\,521\\,725\\,125}{213\\,914\\,163\\,877\\,964\\,163}}\\mathrm {T\\Omega } }</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }}</annotation>\n  </semantics>\n</math>"
+      "R_{\\mathrm {K} }"
     ]
   },
   {
@@ -540,7 +540,7 @@
     "value": "25812.80745",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }={\\frac {h}{e^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mi>h</mi>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }={\\frac {h}{e^{2}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }}</annotation>\n  </semantics>\n</math>"
+      "R_{\\mathrm {K} }"
     ]
   },
   {
@@ -555,7 +555,7 @@
     "description": "intensity of sunlight",
     "value": "1361",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {eo} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n              <mi mathvariant=\"normal\">o</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {eo} }}</annotation>\n  </semantics>\n</math>"
+      "E_{\\mathrm {eo} }"
     ]
   },
   {
@@ -573,8 +573,8 @@
     "value": "0.0000000000000000043597447222071",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {H} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}a_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">H</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>a</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {H} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}a_{0}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {H} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">H</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {H} }}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {h} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">h</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {h} }}</annotation>\n  </semantics>\n</math>"
+      "E_{\\mathrm {H} }",
+      "E_{\\mathrm {h} }"
     ]
   },
   {
@@ -587,7 +587,7 @@
     "value": "0.00000002176434",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {P} }={\\sqrt {\\frac {c\\hbar }{G}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi>c</mi>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              </mrow>\n              <mi>G</mi>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {P} }={\\sqrt {\\frac {c\\hbar }{G}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {P} }"
     ]
   },
   {
@@ -601,7 +601,7 @@
     "value": "0.0000000000529177210903",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{0}={\\frac {4\\pi \\varepsilon _{0}\\hbar ^{2}}{m_{\\mathrm {e} }e^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msup>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{0}={\\frac {4\\pi \\varepsilon _{0}\\hbar ^{2}}{m_{\\mathrm {e} }e^{2}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{0}}</annotation>\n  </semantics>\n</math>"
+      "a_{0}"
     ]
   },
   {
@@ -615,7 +615,7 @@
     "value": "10973731.56816",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\infty }={\\frac {e^{2}}{8\\pi \\varepsilon _{0}a_{0}hc_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">&#x221E;<!-- \u221e --></mi>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>a</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mi>h</mi>\n              <msub>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\infty }={\\frac {e^{2}}{8\\pi \\varepsilon _{0}a_{0}hc_{0}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\infty }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">&#x221E;<!-- \u221e --></mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\infty }}</annotation>\n  </semantics>\n</math>"
+      "R_{\\infty }"
     ]
   },
   {
@@ -631,7 +631,7 @@
     "value": "141678400000000000000000000000000",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle T_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{Gk_{\\text{B}}^{2}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>T</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>P</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <msup>\n                  <mi>c</mi>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mn>5</mn>\n                  </mrow>\n                </msup>\n              </mrow>\n              <mrow>\n                <mi>G</mi>\n                <msubsup>\n                  <mi>k</mi>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mtext>B</mtext>\n                  </mrow>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mn>2</mn>\n                  </mrow>\n                </msubsup>\n              </mrow>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle T_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{Gk_{\\text{B}}^{2}}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle T_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>T</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle T_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+      "T_{\\mathrm {P} }"
     ]
   },
   {
@@ -648,7 +648,7 @@
     "value": "0.0000000000000000000000092740100783",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {B} }={\\frac {e\\hbar }{2m_{\\mathrm {e} }}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">B</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>e</mi>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {B} }={\\frac {e\\hbar }{2m_{\\mathrm {e} }}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {B} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">B</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {B} }}</annotation>\n  </semantics>\n</math>"
+      "\\mu _{\\mathrm {B} }"
     ]
   },
   {
@@ -664,7 +664,7 @@
     "value": "26867801117984438224481531.574",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle n_{0}={\\frac {101\\,325\\,\\mathrm {Pa} }{k_{\\mathrm {B} }\\cdot 273.15\\,\\mathrm {K} }}={\\frac {6\\,755\\times 10^{31}}{2\\,514\\,161\\,829}}\\,\\mathrm {m} ^{-3}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>n</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>101</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>325</mn>\n              <mspace width=\"thinmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">P</mi>\n                <mi mathvariant=\"normal\">a</mi>\n              </mrow>\n            </mrow>\n            <mrow>\n              <msub>\n                <mi>k</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">B</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <mo>&#x22C5;<!-- \u22c5 --></mo>\n              <mn>273.15</mn>\n              <mspace width=\"thinmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">K</mi>\n              </mrow>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>6</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>755</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>31</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>514</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>161</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>829</mn>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">m</mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mo>&#x2212;<!-- \u2212 --></mo>\n            <mn>3</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle n_{0}={\\frac {101\\,325\\,\\mathrm {Pa} }{k_{\\mathrm {B} }\\cdot 273.15\\,\\mathrm {K} }}={\\frac {6\\,755\\times 10^{31}}{2\\,514\\,161\\,829}}\\,\\mathrm {m} ^{-3}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle n_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>n</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle n_{0}}</annotation>\n  </semantics>\n</math>"
+      "n_{0}"
     ]
   },
   {
@@ -682,7 +682,7 @@
     "value": "12208900000000000000",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{G}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>P</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <msup>\n                  <mi>c</mi>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mn>5</mn>\n                  </mrow>\n                </msup>\n              </mrow>\n              <mi>G</mi>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{G}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {P} }c^{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {P} }c^{2}}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {P} }c^{2}"
     ]
   },
   {
@@ -705,7 +705,7 @@
     "value": "0.0000000000000000000000000050507837461",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {N} }={\\frac {e\\hbar }{2m_{\\mathrm {p} }}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">N</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>e</mi>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">p</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {N} }={\\frac {e\\hbar }{2m_{\\mathrm {p} }}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {N} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">N</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {N} }}</annotation>\n  </semantics>\n</math>"
+      "\\mu _{\\mathrm {N} }"
     ]
   },
   {
@@ -730,7 +730,7 @@
     "label": "Gaussian gravitational constant",
     "description": "constant used in orbital mechanics of the solar system",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
+      "k"
     ]
   },
   {
@@ -748,7 +748,7 @@
     ],
     "value": "0.00000125663706212",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{0}}</annotation>\n  </semantics>\n</math>"
+      "\\mu _{0}"
     ]
   },
   {
@@ -775,7 +775,7 @@
     "value": "0.0000000000000000000000000000000001054500197921765038361332005608763113259910823179829917019987020293609409175803660557740077",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\hbar ={\\frac {h}{2\\pi }}={\\frac {3\\times 19\\times 2\\,324\\,779}{4\\times 10^{41}\\pi }}\\,\\mathrm {J} \\cdot \\mathrm {s} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mi>h</mi>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>3</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>19</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>2</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>324</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>779</mn>\n            </mrow>\n            <mrow>\n              <mn>4</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>41</mn>\n                </mrow>\n              </msup>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">J</mi>\n        </mrow>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">s</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\hbar ={\\frac {h}{2\\pi }}={\\frac {3\\times 19\\times 2\\,324\\,779}{4\\times 10^{41}\\pi }}\\,\\mathrm {J} \\cdot \\mathrm {s} }</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\hbar }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\hbar }</annotation>\n  </semantics>\n</math>"
+      "\\hbar "
     ]
   },
   {
@@ -793,7 +793,7 @@
     "value": "2.8179403262",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle r_{\\mathrm {e} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}m_{\\mathrm {e} }c_{0}^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>r</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msubsup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msubsup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle r_{\\mathrm {e} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}m_{\\mathrm {e} }c_{0}^{2}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle r_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>r</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle r_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+      "r_{\\mathrm {e} }"
     ]
   },
   {
@@ -809,7 +809,7 @@
     "value": "0.000000000000002067833848",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Phi _{0}={\\frac {h}{2e}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mi>h</mi>\n            <mrow>\n              <mn>2</mn>\n              <mi>e</mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Phi _{0}={\\frac {h}{2e}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Phi _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Phi _{0}}</annotation>\n  </semantics>\n</math>"
+      "\\Phi _{0}"
     ]
   },
   {
@@ -820,7 +820,7 @@
     ],
     "value": "1836.15267389",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {p} }/m_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {p} }/m_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {p} }/m_{\\mathrm {e} }"
     ]
   },
   {
@@ -835,7 +835,7 @@
     ],
     "value": "-0.0000000000000000000000000096623651",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+      "\\mu _{\\mathrm {n} }"
     ]
   },
   {
@@ -851,7 +851,7 @@
     ],
     "value": "0.00000000000000000000000000000091093837015",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {e} }"
     ]
   },
   {
@@ -863,7 +863,7 @@
     ],
     "value": "0.4",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
+      "\\kappa "
     ]
   },
   {
@@ -879,7 +879,7 @@
     ],
     "value": "0.0000000000000000000000000016605390666",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {u} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">u</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {u} }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {u} }"
     ]
   },
   {
@@ -891,7 +891,7 @@
     "value": "0.00099999999965",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle M_{\\text{u}}=N_{\\text{A}}m_{\\text{u}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>M</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>u</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>A</mtext>\n          </mrow>\n        </msub>\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>u</mtext>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle M_{\\text{u}}=N_{\\text{A}}m_{\\text{u}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle M_{\\mathrm {u} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>M</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">u</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle M_{\\mathrm {u} }}</annotation>\n  </semantics>\n</math>"
+      "M_{\\mathrm {u} }"
     ]
   },
   {
@@ -912,7 +912,7 @@
     ],
     "value": "267522187.44",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+      "\\gamma _{\\mathrm {p} }"
     ]
   },
   {
@@ -926,10 +926,10 @@
     "value": "8987551787.3681764",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k={\\frac {1}{4\\pi \\varepsilon _{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k={\\frac {1}{4\\pi \\varepsilon _{0}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>K</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k_{\\mathrm {C} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>k</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k_{\\mathrm {C} }}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>k</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
+      "K",
+      "k",
+      "k_{\\mathrm {C} }",
+      "k_{\\mathrm {e} }"
     ]
   },
   {
@@ -947,7 +947,7 @@
     "value": "0.00289771955",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle b={\\frac {hc}{k(5+W_{0}(-5e^{-5}))}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>b</mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>h</mi>\n              <mi>c</mi>\n            </mrow>\n            <mrow>\n              <mi>k</mi>\n              <mo stretchy=\"false\">(</mo>\n              <mn>5</mn>\n              <mo>+</mo>\n              <msub>\n                <mi>W</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mo stretchy=\"false\">(</mo>\n              <mo>&#x2212;<!-- \u2212 --></mo>\n              <mn>5</mn>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mo>&#x2212;<!-- \u2212 --></mo>\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n              <mo stretchy=\"false\">)</mo>\n              <mo stretchy=\"false\">)</mo>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle b={\\frac {hc}{k(5+W_{0}(-5e^{-5}))}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle b}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>b</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle b}</annotation>\n  </semantics>\n</math>"
+      "b"
     ]
   },
   {
@@ -957,7 +957,7 @@
     "value": "0.000000000000000000000000018664",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <mi>G</mi>\n            </mrow>\n            <msup>\n              <mi>c</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{2}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
+      "\\kappa "
     ]
   },
   {
@@ -969,7 +969,7 @@
     ],
     "value": "0.000000000100001495",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {\\AA} ^{*}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mo>&#xC5;</mo>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mo>&#x2217;<!-- \u2217 --></mo>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {\\AA} ^{*}}</annotation>\n  </semantics>\n</math>"
+      "\\mathrm {\\AA} ^{*}"
     ]
   },
   {
@@ -994,8 +994,8 @@
     ],
     "value": "9.80665",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>g</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g}</annotation>\n  </semantics>\n</math>"
+      "g",
+      "g_{\\mathrm {n} }"
     ]
   },
   {
@@ -1011,7 +1011,7 @@
     "value": "-0.0000000000000000000000092847647043",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\boldsymbol {\\mu }}={\\frac {-e}{2m_{\\text{e}}}}\\,\\mathbf {L} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold-italic\">&#x03BC;<!-- \u03bc --></mi>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mo>&#x2212;<!-- \u2212 --></mo>\n              <mi>e</mi>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mtext>e</mtext>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold\">L</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\boldsymbol {\\mu }}={\\frac {-e}{2m_{\\text{e}}}}\\,\\mathbf {L} }</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+      "\\mu _{\\mathrm {e} }"
     ]
   },
   {
@@ -1040,7 +1040,7 @@
     "value": "0.00007748091729",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle G_{0}={\\frac {2e^{2}}{h}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>G</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>2</mn>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mi>h</mi>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle G_{0}={\\frac {2e^{2}}{h}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle G_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>G</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle G_{0}}</annotation>\n  </semantics>\n</math>"
+      "G_{0}"
     ]
   },
   {
@@ -1055,7 +1055,7 @@
     ],
     "value": "0.0000000000000000000000000141060679736",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+      "\\mu _{\\mathrm {p} }"
     ]
   },
   {
@@ -1065,7 +1065,7 @@
     "value": "5560800000000000000000000000000000000000000000000000",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{\\text{P}}={\\sqrt {\\frac {c^{7}}{\\hbar G}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>P</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>7</mn>\n                </mrow>\n              </msup>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <mi>G</mi>\n              </mrow>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{\\text{P}}={\\sqrt {\\frac {c^{7}}{\\hbar G}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+      "a_{\\mathrm {P} }"
     ]
   },
   {
@@ -1092,8 +1092,8 @@
     ],
     "value": "602214076000000000000000",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N_{0}}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>N</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N}</annotation>\n  </semantics>\n</math>"
+      "N",
+      "N_{0}"
     ]
   },
   {
@@ -1106,7 +1106,7 @@
     "value": "483597.848416984",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }={\\frac {1}{\\Phi _{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <msub>\n              <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }={\\frac {1}{\\Phi _{0}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }}</annotation>\n  </semantics>\n</math>"
+      "K_{\\mathrm {J} }"
     ]
   },
   {
@@ -1119,7 +1119,7 @@
     "value": "483597.848416984",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }={\\frac {2e}{h}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>2</mn>\n              <mi>e</mi>\n            </mrow>\n            <mi>h</mi>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }={\\frac {2e}{h}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }}</annotation>\n  </semantics>\n</math>"
+      "K_{\\mathrm {J} }"
     ]
   },
   {
@@ -1131,7 +1131,7 @@
     ],
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{4}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <mi>G</mi>\n            </mrow>\n            <msup>\n              <mi>c</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>4</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{4}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
+      "\\kappa "
     ]
   },
   {
@@ -1146,7 +1146,7 @@
     ],
     "value": "9192631770",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Delta \\nu _{\\mathrm {Cs} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi mathvariant=\"normal\">&#x0394;<!-- \u0394 --></mi>\n        <msub>\n          <mi>&#x03BD;<!-- \u03bd --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n              <mi mathvariant=\"normal\">s</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Delta \\nu _{\\mathrm {Cs} }}</annotation>\n  </semantics>\n</math>"
+      "\\Delta \\nu _{\\mathrm {Cs} }"
     ]
   },
   {
@@ -1161,7 +1161,7 @@
     ],
     "value": "683",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {cd} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">c</mi>\n              <mi mathvariant=\"normal\">d</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {cd} }}</annotation>\n  </semantics>\n</math>"
+      "K_{\\mathrm {cd} }"
     ]
   },
   {
@@ -1173,7 +1173,7 @@
     ],
     "value": "0.0000000000000000000000000066446573357",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\alpha }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\alpha }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\alpha }"
     ]
   },
   {
@@ -1188,7 +1188,7 @@
     ],
     "value": "0.2229",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sin ^{2}{\\theta _{\\mathrm {W} }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msup>\n          <mi>sin</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n        <mo>&#x2061;<!-- \u2061 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msub>\n            <mi>&#x03B8;<!-- \u03b8 --></mi>\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">W</mi>\n              </mrow>\n            </mrow>\n          </msub>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sin ^{2}{\\theta _{\\mathrm {W} }}}</annotation>\n  </semantics>\n</math>"
+      "\\sin ^{2}{\\theta _{\\mathrm {W} }}"
     ]
   },
   {
@@ -1204,7 +1204,7 @@
     ],
     "value": "0.00000000000000000000000000167262192369",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {p} }"
     ]
   },
   {
@@ -1222,7 +1222,7 @@
     "value": "176085963023",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\boldsymbol {\\mu }}=\\gamma _{\\mathrm {e} }{\\boldsymbol {J}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold-italic\">&#x03BC;<!-- \u03bc --></mi>\n        </mrow>\n        <mo>=</mo>\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold-italic\">J</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\boldsymbol {\\mu }}=\\gamma _{\\mathrm {e} }{\\boldsymbol {J}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+      "\\gamma _{\\mathrm {e} }"
     ]
   },
   {
@@ -1233,7 +1233,7 @@
     ],
     "value": "0.00000000000242631023867",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\lambda _{\\mathrm {C} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BB;<!-- \u03bb --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\lambda _{\\mathrm {C} }}</annotation>\n  </semantics>\n</math>"
+      "\\lambda _{\\mathrm {C} }"
     ]
   },
   {
@@ -1248,7 +1248,7 @@
     ],
     "value": "0.00000000000000000000000000167492749804",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {n} }"
     ]
   },
   {
@@ -1256,7 +1256,7 @@
     "label": "Planck magnetic flux density",
     "value": "215000000000000000000000000000000000000000000000000000",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle B_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>B</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle B_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+      "B_{\\mathrm {P} }"
     ]
   },
   {
@@ -1264,7 +1264,7 @@
     "label": "Planck magnetic flux",
     "value": "0.000000000000000056227",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Phi _{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Phi _{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+      "\\Phi _{\\mathrm {P} }"
     ]
   },
   {
@@ -1286,8 +1286,8 @@
     ],
     "value": "28024.9514242",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {e} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">e</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {e} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+      "{\\frac {\\gamma _{\\mathrm {e} }}{2\\pi }}",
+      "{\\tilde {\\gamma }}_{\\mathrm {e} }"
     ]
   },
   {
@@ -1304,8 +1304,8 @@
     ],
     "value": "42.577478518",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {p} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">p</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {p} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+      "{\\frac {\\gamma _{\\mathrm {p} }}{2\\pi }}",
+      "{\\tilde {\\gamma }}_{\\mathrm {p} }"
     ]
   },
   {
@@ -1321,7 +1321,7 @@
     ],
     "value": "183247171",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+      "\\gamma _{\\mathrm {n} }"
     ]
   },
   {
@@ -1338,8 +1338,8 @@
     ],
     "value": "29.1646931",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {n} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">n</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {n} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+      "{\\frac {\\gamma _{\\mathrm {n} }}{2\\pi }}",
+      "{\\tilde {\\gamma }}_{\\mathrm {n} }"
     ]
   },
   {
@@ -1351,7 +1351,7 @@
     ],
     "value": "0.0000000000000000000000000001883531627",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {\\mu } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {\\mu } }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {\\mu } }"
     ]
   },
   {
@@ -1363,7 +1363,7 @@
     ],
     "value": "0.00000000000000000000000000316754",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {\\tau } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03C4;<!-- \u03c4 --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {\\tau } }}</annotation>\n  </semantics>\n</math>"
+      "m_{\\mathrm {\\tau } }"
     ]
   },
   {
@@ -1375,7 +1375,7 @@
     ],
     "value": "0.000000000000100207697",
     "symbols": [
-      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {xu} (\\mathrm {Cu} \\,\\mathrm {K\\alpha } _{1})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">x</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">C</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {xu} (\\mathrm {Cu} \\,\\mathrm {K\\alpha } _{1})}</annotation>\n  </semantics>\n</math>"
+      "\\mathrm {xu} (\\mathrm {Cu} \\,\\mathrm {K\\alpha } _{1})"
     ]
   }
 ]

--- a/mira/dkg/resources/physical_constants.json
+++ b/mira/dkg/resources/physical_constants.json
@@ -1,6 +1,6 @@
 [
   {
-    "curie": "Q112703485",
+    "wikidata_id": "Q112703485",
     "label": "electron g factor",
     "synonyms": [
       "electron spin g factor"
@@ -15,7 +15,7 @@
     ]
   },
   {
-    "curie": "Q112703647",
+    "wikidata_id": "Q112703647",
     "label": "proton g factor",
     "synonyms": [
       "proton spin g factor"
@@ -29,7 +29,7 @@
     ]
   },
   {
-    "curie": "Q112703993",
+    "wikidata_id": "Q112703993",
     "label": "muon g factor",
     "synonyms": [
       "muon g-factor",
@@ -45,7 +45,7 @@
     ]
   },
   {
-    "curie": "Q117771430",
+    "wikidata_id": "Q117771430",
     "label": "first radiation constant for spectral radiance",
     "synonyms": [
       "first radiation constant"
@@ -59,7 +59,7 @@
     ]
   },
   {
-    "curie": "Q119348262",
+    "wikidata_id": "Q119348262",
     "label": "admittance of vacuum",
     "description": "reciprocal of the impedance of vacuum",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Y</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <msub>\n              <mi>Z</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}</annotation>\n  </semantics>\n</math>",
@@ -68,7 +68,7 @@
     ]
   },
   {
-    "curie": "Q108899315",
+    "wikidata_id": "Q108899315",
     "label": "molybdenum x unit",
     "description": "unit of length",
     "xrefs": [
@@ -80,7 +80,7 @@
     ]
   },
   {
-    "curie": "Q109366037",
+    "wikidata_id": "Q109366037",
     "label": "molar Planck constant",
     "xrefs": [
       "nist.codata:nah"
@@ -88,7 +88,7 @@
     "value": "0.0000000003990312712"
   },
   {
-    "curie": "Q112299891",
+    "wikidata_id": "Q112299891",
     "label": "first radiation constant",
     "description": "constant in Wien's radiation law",
     "xrefs": [
@@ -101,7 +101,7 @@
     ]
   },
   {
-    "curie": "Q112300321",
+    "wikidata_id": "Q112300321",
     "label": "second radiation constant",
     "description": "constant in Wien's radiation law",
     "xrefs": [
@@ -114,7 +114,7 @@
     ]
   },
   {
-    "curie": "Q531",
+    "wikidata_id": "Q531",
     "label": "light-year",
     "description": "unit of length used to express astronomical distances, defined as the distance that light travels in a vacuum in one year",
     "synonyms": [
@@ -128,7 +128,7 @@
     ]
   },
   {
-    "curie": "Q2101",
+    "wikidata_id": "Q2101",
     "label": "elementary charge",
     "description": "the electric charge carried by a single proton or a single positron",
     "synonyms": [
@@ -145,7 +145,7 @@
     ]
   },
   {
-    "curie": "Q2111",
+    "wikidata_id": "Q2111",
     "label": "speed of light in vacuum",
     "description": "speed of electromagnetic waves in vacuum",
     "synonyms": [
@@ -172,7 +172,7 @@
     ]
   },
   {
-    "curie": "Q5962",
+    "wikidata_id": "Q5962",
     "label": "Boltzmann constant",
     "description": "physical constant relating energy at the individual particle level with temperature",
     "xrefs": [
@@ -186,7 +186,7 @@
     ]
   },
   {
-    "curie": "Q5997",
+    "wikidata_id": "Q5997",
     "label": "fine-structure constant",
     "description": "physical constant quantifying the strength of the electromagnetic interaction between elementary charged particles",
     "synonyms": [
@@ -205,7 +205,7 @@
     ]
   },
   {
-    "curie": "Q6158",
+    "wikidata_id": "Q6158",
     "label": "permittivity of vacuum",
     "description": "physical constant defining the capability of an electric field to permeate a vacuum",
     "synonyms": [
@@ -225,7 +225,7 @@
     ]
   },
   {
-    "curie": "Q6203",
+    "wikidata_id": "Q6203",
     "label": "Avogadro constant",
     "description": "fundamental physical constant (symbols: L, N\u1d00) representing the molar number of entities",
     "synonyms": [
@@ -245,7 +245,7 @@
     ]
   },
   {
-    "curie": "Q18373",
+    "wikidata_id": "Q18373",
     "label": "gravitational constant",
     "description": "physical constant relating the gravitational force between objects to their mass and distance",
     "synonyms": [
@@ -263,7 +263,7 @@
     ]
   },
   {
-    "curie": "Q51374",
+    "wikidata_id": "Q51374",
     "label": "Stefan-Boltzmann constant",
     "description": "ratio between the radiative power of a black body to the fourth power of its temperature",
     "synonyms": [
@@ -280,7 +280,7 @@
     ]
   },
   {
-    "curie": "Q51374",
+    "wikidata_id": "Q51374",
     "label": "Stefan-Boltzmann constant",
     "description": "ratio between the radiative power of a black body to the fourth power of its temperature",
     "synonyms": [
@@ -297,7 +297,7 @@
     ]
   },
   {
-    "curie": "Q59151",
+    "wikidata_id": "Q59151",
     "label": "cosmological constant",
     "description": "constant representing stress-energy density of the vacuum in Einstein's equation and accounts for the rate of expansion of the universe",
     "synonyms": [
@@ -310,7 +310,7 @@
     ]
   },
   {
-    "curie": "Q83327",
+    "wikidata_id": "Q83327",
     "label": "electronvolt",
     "description": "unit of energy",
     "synonyms": [
@@ -328,7 +328,7 @@
     ]
   },
   {
-    "curie": "Q122894",
+    "wikidata_id": "Q122894",
     "label": "Planck constant",
     "description": "physical constant representing the quantum of action",
     "synonyms": [
@@ -347,7 +347,7 @@
     ]
   },
   {
-    "curie": "Q177974",
+    "wikidata_id": "Q177974",
     "label": "standard atmosphere",
     "description": "unit of pressure defined as 101325 Pa",
     "synonyms": [
@@ -366,7 +366,7 @@
     ]
   },
   {
-    "curie": "Q182333",
+    "wikidata_id": "Q182333",
     "label": "molar gas constant",
     "description": "physical constant; the molar equivalent to the Boltzmann constant",
     "synonyms": [
@@ -387,7 +387,7 @@
     ]
   },
   {
-    "curie": "Q192819",
+    "wikidata_id": "Q192819",
     "label": "Faraday constant",
     "description": "physical constant: electric charge of one mole of electrons",
     "synonyms": [
@@ -404,7 +404,7 @@
     ]
   },
   {
-    "curie": "Q202642",
+    "wikidata_id": "Q202642",
     "label": "Planck time",
     "description": "very small unit of time",
     "xrefs": [
@@ -417,7 +417,7 @@
     ]
   },
   {
-    "curie": "Q207387",
+    "wikidata_id": "Q207387",
     "label": "Planck length",
     "description": "very small-scale unit of length",
     "xrefs": [
@@ -430,7 +430,7 @@
     ]
   },
   {
-    "curie": "Q269492",
+    "wikidata_id": "Q269492",
     "label": "impedance of vacuum",
     "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
     "synonyms": [
@@ -450,7 +450,7 @@
     ]
   },
   {
-    "curie": "Q269492",
+    "wikidata_id": "Q269492",
     "label": "impedance of vacuum",
     "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
     "synonyms": [
@@ -470,7 +470,7 @@
     ]
   },
   {
-    "curie": "Q269492",
+    "wikidata_id": "Q269492",
     "label": "impedance of vacuum",
     "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
     "synonyms": [
@@ -490,7 +490,7 @@
     ]
   },
   {
-    "curie": "Q269492",
+    "wikidata_id": "Q269492",
     "label": "impedance of vacuum",
     "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
     "synonyms": [
@@ -510,7 +510,7 @@
     ]
   },
   {
-    "curie": "Q304770",
+    "wikidata_id": "Q304770",
     "label": "von Klitzing constant",
     "description": "inverse of the quantum of conductance in the integer quantum Hall effect",
     "synonyms": [
@@ -527,7 +527,7 @@
     ]
   },
   {
-    "curie": "Q304770",
+    "wikidata_id": "Q304770",
     "label": "von Klitzing constant",
     "description": "inverse of the quantum of conductance in the integer quantum Hall effect",
     "synonyms": [
@@ -544,13 +544,13 @@
     ]
   },
   {
-    "curie": "Q319686",
+    "wikidata_id": "Q319686",
     "label": "speed of gravity",
     "description": "physical constant equal to the speed of light",
     "value": "299792458"
   },
   {
-    "curie": "Q335272",
+    "wikidata_id": "Q335272",
     "label": "solar constant",
     "description": "intensity of sunlight",
     "value": "1361",
@@ -559,7 +559,7 @@
     ]
   },
   {
-    "curie": "Q476572",
+    "wikidata_id": "Q476572",
     "label": "Hartree energy",
     "description": "atomic unit of energy",
     "synonyms": [
@@ -578,7 +578,7 @@
     ]
   },
   {
-    "curie": "Q592634",
+    "wikidata_id": "Q592634",
     "label": "Planck mass",
     "description": "unit of mass in the system of Planck units",
     "xrefs": [
@@ -591,7 +591,7 @@
     ]
   },
   {
-    "curie": "Q652571",
+    "wikidata_id": "Q652571",
     "label": "Bohr radius",
     "description": "physical constant; the most probable distance between an electron and the nucleus in a nonrelativistic model of the hydrogen atom with infinitely heavy nucleus",
     "xrefs": [
@@ -605,7 +605,7 @@
     ]
   },
   {
-    "curie": "Q658065",
+    "wikidata_id": "Q658065",
     "label": "Rydberg constant",
     "description": "physical constant",
     "xrefs": [
@@ -619,7 +619,7 @@
     ]
   },
   {
-    "curie": "Q720055",
+    "wikidata_id": "Q720055",
     "label": "Planck temperature",
     "description": "very large unit of temperature",
     "synonyms": [
@@ -635,7 +635,7 @@
     ]
   },
   {
-    "curie": "Q737120",
+    "wikidata_id": "Q737120",
     "label": "Bohr magneton",
     "description": "unit of magnetic moment (approx. 9.2 J/T); the magnetic dipole moment of an electron orbiting an atom with angular momentum \u210f in the Bohr model",
     "synonyms": [
@@ -652,7 +652,7 @@
     ]
   },
   {
-    "curie": "Q903271",
+    "wikidata_id": "Q903271",
     "label": "Loschmidt constant",
     "description": "physical constant - number density of molecules in an ideal gas at standard temperature and pressure",
     "synonyms": [
@@ -668,12 +668,12 @@
     ]
   },
   {
-    "curie": "Q905618",
+    "wikidata_id": "Q905618",
     "label": "cryoscopic constant",
     "description": "material property relating molality to freezing point depression"
   },
   {
-    "curie": "Q913365",
+    "wikidata_id": "Q913365",
     "label": "Planck energy",
     "description": "unit of energy in the system of Planck units",
     "xrefs": [
@@ -686,7 +686,7 @@
     ]
   },
   {
-    "curie": "Q1139232",
+    "wikidata_id": "Q1139232",
     "label": "Tolman\u2013Oppenheimer\u2013Volkoff limit",
     "description": "upper bound to the mass of cold, nonrotating neutron stars",
     "synonyms": [
@@ -695,7 +695,7 @@
     ]
   },
   {
-    "curie": "Q1166093",
+    "wikidata_id": "Q1166093",
     "label": "nuclear magneton",
     "description": "physical constant of magnetic moment",
     "xrefs": [
@@ -709,7 +709,7 @@
     ]
   },
   {
-    "curie": "Q1194225",
+    "wikidata_id": "Q1194225",
     "label": "pound-force",
     "description": "unit of force: the force exerted by one standard gravity on a one-pound mass",
     "synonyms": [
@@ -726,7 +726,7 @@
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n          <mi mathvariant=\"normal\">f</mi>\n        </mrow>\n        <mo>=</mo>\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }</annotation>\n  </semantics>\n</math>"
   },
   {
-    "curie": "Q1496380",
+    "wikidata_id": "Q1496380",
     "label": "Gaussian gravitational constant",
     "description": "constant used in orbital mechanics of the solar system",
     "symbols": [
@@ -734,7 +734,7 @@
     ]
   },
   {
-    "curie": "Q1515261",
+    "wikidata_id": "Q1515261",
     "label": "magnetic constant",
     "description": "physical constant; ratio between the magnetic H-field and the magnetic B-field in classical vacuum",
     "synonyms": [
@@ -752,11 +752,11 @@
     ]
   },
   {
-    "curie": "Q1606390",
+    "wikidata_id": "Q1606390",
     "label": "Henry's Law constant"
   },
   {
-    "curie": "Q2115969",
+    "wikidata_id": "Q2115969",
     "label": "reduced Planck constant",
     "description": "the Planck constant divided by 2 \u03c0",
     "synonyms": [
@@ -779,7 +779,7 @@
     ]
   },
   {
-    "curie": "Q2152581",
+    "wikidata_id": "Q2152581",
     "label": "classical electron radius",
     "description": "physical constant providing length scale to interatomic interactions",
     "synonyms": [
@@ -797,7 +797,7 @@
     ]
   },
   {
-    "curie": "Q2265632",
+    "wikidata_id": "Q2265632",
     "label": "magnetic flux quantum",
     "description": "quantized unit of magnetic flux threading a loop in a bulk superconductor",
     "synonyms": [
@@ -813,7 +813,7 @@
     ]
   },
   {
-    "curie": "Q2912520",
+    "wikidata_id": "Q2912520",
     "label": "proton-to-electron mass ratio",
     "xrefs": [
       "nist.codata:mpsme"
@@ -824,7 +824,7 @@
     ]
   },
   {
-    "curie": "Q3109934",
+    "wikidata_id": "Q3109934",
     "label": "neutron magnetic dipole moment",
     "description": "intrinsic magnetic dipole moment of neutrons",
     "synonyms": [
@@ -839,7 +839,7 @@
     ]
   },
   {
-    "curie": "Q3814108",
+    "wikidata_id": "Q3814108",
     "label": "electron mass",
     "description": "mass of a stationary electron",
     "synonyms": [
@@ -855,7 +855,7 @@
     ]
   },
   {
-    "curie": "Q4516306",
+    "wikidata_id": "Q4516306",
     "label": "von K\u00e1rm\u00e1n constant",
     "description": "physical constant in hydraulics",
     "synonyms": [
@@ -867,7 +867,7 @@
     ]
   },
   {
-    "curie": "Q4817337",
+    "wikidata_id": "Q4817337",
     "label": "unified atomic mass constant",
     "description": "a twelfth of the mass of a carbon-12 atom in its ground state",
     "synonyms": [
@@ -883,7 +883,7 @@
     ]
   },
   {
-    "curie": "Q6895682",
+    "wikidata_id": "Q6895682",
     "label": "molar mass constant",
     "xrefs": [
       "nist.codata:mu"
@@ -895,12 +895,12 @@
     ]
   },
   {
-    "curie": "Q7196620",
+    "wikidata_id": "Q7196620",
     "label": "pion decay constant",
     "description": "physical constant"
   },
   {
-    "curie": "Q7252077",
+    "wikidata_id": "Q7252077",
     "label": "proton gyromagnetic ratio",
     "synonyms": [
       "gyromagnetic coefficient of the proton",
@@ -916,7 +916,7 @@
     ]
   },
   {
-    "curie": "Q9855158",
+    "wikidata_id": "Q9855158",
     "label": "Coulomb's constant",
     "description": "proportionality constant in electrodynamics equations",
     "synonyms": [
@@ -933,7 +933,7 @@
     ]
   },
   {
-    "curie": "Q10843113",
+    "wikidata_id": "Q10843113",
     "label": "Wien wavelength displacement law constant",
     "description": "constant in Wien's displacement law",
     "synonyms": [
@@ -951,7 +951,7 @@
     ]
   },
   {
-    "curie": "Q11282513",
+    "wikidata_id": "Q11282513",
     "label": "Einstein's constant",
     "description": "physical constant occurring in Einstein's equations (c^2 convention)",
     "value": "0.000000000000000000000000018664",
@@ -961,7 +961,7 @@
     ]
   },
   {
-    "curie": "Q12472160",
+    "wikidata_id": "Q12472160",
     "label": "Angstrom star",
     "description": "unit of length; equals 1.000\u2009014\u200998(90) angstrom",
     "xrefs": [
@@ -973,7 +973,7 @@
     ]
   },
   {
-    "curie": "Q13400897",
+    "wikidata_id": "Q13400897",
     "label": "standard acceleration of free fall",
     "description": "standard gravitational acceleration on Earth's surface",
     "synonyms": [
@@ -999,7 +999,7 @@
     ]
   },
   {
-    "curie": "Q13534105",
+    "wikidata_id": "Q13534105",
     "label": "electron magnetic dipole moment",
     "description": "spin of an electron",
     "synonyms": [
@@ -1015,7 +1015,7 @@
     ]
   },
   {
-    "curie": "Q13542672",
+    "wikidata_id": "Q13542672",
     "label": "Rydberg energy",
     "description": "physical constant equal to the ionization energy of the hydrogen atom in a simplified Bohr model",
     "synonyms": [
@@ -1028,7 +1028,7 @@
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mn>1</mn>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">R</mi>\n          <mi mathvariant=\"normal\">y</mi>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>4</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <mo stretchy=\"false\">(</mo>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03F5;<!-- \u03f5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <msup>\n                <mo stretchy=\"false\">)</mo>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}</annotation>\n  </semantics>\n</math>"
   },
   {
-    "curie": "Q13570090",
+    "wikidata_id": "Q13570090",
     "label": "conductance quantum",
     "description": "quantized unit of electrical conductance",
     "synonyms": [
@@ -1044,7 +1044,7 @@
     ]
   },
   {
-    "curie": "Q17076647",
+    "wikidata_id": "Q17076647",
     "label": "proton magnetic dipole moment",
     "synonyms": [
       "proton magnetic moment"
@@ -1059,7 +1059,7 @@
     ]
   },
   {
-    "curie": "Q28003216",
+    "wikidata_id": "Q28003216",
     "label": "Planck acceleration",
     "description": "acceleration from zero to the speed of light in one Planck time",
     "value": "5560800000000000000000000000000000000000000000000000",
@@ -1069,7 +1069,7 @@
     ]
   },
   {
-    "curie": "Q69189081",
+    "wikidata_id": "Q69189081",
     "label": "Avogadro number",
     "description": "dimensionless number corresponding to Avogadro's constant (which has units of inverse mole)",
     "synonyms": [
@@ -1097,7 +1097,7 @@
     ]
   },
   {
-    "curie": "Q92605166",
+    "wikidata_id": "Q92605166",
     "label": "Josephson constant",
     "description": "the inverse of the flux quantum",
     "xrefs": [
@@ -1110,7 +1110,7 @@
     ]
   },
   {
-    "curie": "Q92605166",
+    "wikidata_id": "Q92605166",
     "label": "Josephson constant",
     "description": "the inverse of the flux quantum",
     "xrefs": [
@@ -1123,7 +1123,7 @@
     ]
   },
   {
-    "curie": "Q92894650",
+    "wikidata_id": "Q92894650",
     "label": "Einstein's constant",
     "description": "physical constant occurring in Einstein's equations (c^4 convention)",
     "synonyms": [
@@ -1135,7 +1135,7 @@
     ]
   },
   {
-    "curie": "Q94196529",
+    "wikidata_id": "Q94196529",
     "label": "unperturbed ground state hyperfine transition frequency of the caesium 133 atom",
     "description": "physical constant used to define the second, equal to 9.19263177 GHz by definition",
     "synonyms": [
@@ -1150,7 +1150,7 @@
     ]
   },
   {
-    "curie": "Q94199486",
+    "wikidata_id": "Q94199486",
     "label": "luminous efficacy of monochromatic radiation of frequency 540 \u00d7 10\u00b9\u00b2 Hz",
     "description": "physical constant",
     "synonyms": [
@@ -1165,7 +1165,7 @@
     ]
   },
   {
-    "curie": "Q96440139",
+    "wikidata_id": "Q96440139",
     "label": "alpha particle mass",
     "description": "physical constant",
     "xrefs": [
@@ -1177,7 +1177,7 @@
     ]
   },
   {
-    "curie": "Q97060889",
+    "wikidata_id": "Q97060889",
     "label": "weak mixing angle constant",
     "description": "physical constant",
     "synonyms": [
@@ -1192,7 +1192,7 @@
     ]
   },
   {
-    "curie": "Q97275155",
+    "wikidata_id": "Q97275155",
     "label": "proton mass",
     "description": "physical constant",
     "synonyms": [
@@ -1208,7 +1208,7 @@
     ]
   },
   {
-    "curie": "Q97543076",
+    "wikidata_id": "Q97543076",
     "label": "electron gyromagnetic ratio",
     "description": "physical constant",
     "synonyms": [
@@ -1226,7 +1226,7 @@
     ]
   },
   {
-    "curie": "Q97967308",
+    "wikidata_id": "Q97967308",
     "label": "electron Compton wavelength",
     "xrefs": [
       "nist.codata:ecomwl"
@@ -1237,7 +1237,7 @@
     ]
   },
   {
-    "curie": "Q98000454",
+    "wikidata_id": "Q98000454",
     "label": "neutron mass",
     "synonyms": [
       "neutron rest mass"
@@ -1252,7 +1252,7 @@
     ]
   },
   {
-    "curie": "Q98380812",
+    "wikidata_id": "Q98380812",
     "label": "Planck magnetic flux density",
     "value": "215000000000000000000000000000000000000000000000000000",
     "symbols": [
@@ -1260,7 +1260,7 @@
     ]
   },
   {
-    "curie": "Q98380823",
+    "wikidata_id": "Q98380823",
     "label": "Planck magnetic flux",
     "value": "0.000000000000000056227",
     "symbols": [
@@ -1268,12 +1268,12 @@
     ]
   },
   {
-    "curie": "Q99476928",
+    "wikidata_id": "Q99476928",
     "label": "gram-force",
     "description": "unit of force"
   },
   {
-    "curie": "Q106589812",
+    "wikidata_id": "Q106589812",
     "label": "reduced electron gyromagnetic ratio",
     "synonyms": [
       "electron reduced gyromagnetic ratio",
@@ -1291,7 +1291,7 @@
     ]
   },
   {
-    "curie": "Q106589932",
+    "wikidata_id": "Q106589932",
     "label": "reduced proton gyromagnetic ratio",
     "synonyms": [
       "proton reduced gyromagnetic ratio",
@@ -1309,7 +1309,7 @@
     ]
   },
   {
-    "curie": "Q106589964",
+    "wikidata_id": "Q106589964",
     "label": "neutron gyromagnetic ratio",
     "synonyms": [
       "gyromagnetic coefficient of the neutron",
@@ -1325,7 +1325,7 @@
     ]
   },
   {
-    "curie": "Q106589981",
+    "wikidata_id": "Q106589981",
     "label": "neutron reduced gyromagnetic ratio",
     "synonyms": [
       "reduced gyromagnetic coefficient of the neutron",
@@ -1343,7 +1343,7 @@
     ]
   },
   {
-    "curie": "Q106764378",
+    "wikidata_id": "Q106764378",
     "label": "muon mass",
     "description": "physical constant",
     "xrefs": [
@@ -1355,7 +1355,7 @@
     ]
   },
   {
-    "curie": "Q106764397",
+    "wikidata_id": "Q106764397",
     "label": "tau mass",
     "description": "physical constant",
     "xrefs": [
@@ -1367,7 +1367,7 @@
     ]
   },
   {
-    "curie": "Q108899308",
+    "wikidata_id": "Q108899308",
     "label": "copper x unit",
     "description": "unit of length",
     "xrefs": [

--- a/mira/dkg/resources/physical_constants.json
+++ b/mira/dkg/resources/physical_constants.json
@@ -2,16 +2,13 @@
   {
     "curie": "Q112703485",
     "label": "electron g factor",
-    "description": "",
     "synonyms": [
       "electron spin g factor"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gem"
     ],
     "value": "-2.00231930436256",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {e} ^{-}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <msup>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">e</mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>&#x2212;<!-- \u2212 --></mo>\n              </mrow>\n            </msup>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {e} ^{-}}}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
@@ -20,16 +17,13 @@
   {
     "curie": "Q112703647",
     "label": "proton g factor",
-    "description": "",
     "synonyms": [
       "proton spin g factor"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gp"
     ],
     "value": "5.5856946893",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -37,17 +31,14 @@
   {
     "curie": "Q112703993",
     "label": "muon g factor",
-    "description": "",
     "synonyms": [
       "muon g-factor",
       "muon spin g factor"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gmum"
     ],
     "value": "-2.0023318418",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {\\mu } ^{-}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <msup>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>&#x2212;<!-- \u2212 --></mo>\n              </mrow>\n            </msup>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {\\mu } ^{-}}}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {\\mu } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {\\mu } }}</annotation>\n  </semantics>\n</math>"
@@ -56,15 +47,12 @@
   {
     "curie": "Q117771430",
     "label": "first radiation constant for spectral radiance",
-    "description": "",
     "synonyms": [
       "first radiation constant"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:c1l"
     ],
-    "value": null,
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1L}=2hc^{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n            <mi>L</mi>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mn>2</mn>\n        <mi>h</mi>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1L}=2hc^{2}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1L}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n            <mi>L</mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1L}}</annotation>\n  </semantics>\n</math>"
@@ -74,12 +62,6 @@
     "curie": "Q119348262",
     "label": "admittance of vacuum",
     "description": "reciprocal of the impedance of vacuum",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Y</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <msub>\n              <mi>Z</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Y_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Y</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Y_{0}}</annotation>\n  </semantics>\n</math>"
@@ -89,13 +71,10 @@
     "curie": "Q108899315",
     "label": "molybdenum x unit",
     "description": "unit of length",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:xumokalph1"
     ],
     "value": "0.000000000000100209952",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {xu} (\\mathrm {Mo} \\,\\mathrm {K\\alpha } _{1})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">x</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">M</mi>\n          <mi mathvariant=\"normal\">o</mi>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {xu} (\\mathrm {Mo} \\,\\mathrm {K\\alpha } _{1})}</annotation>\n  </semantics>\n</math>"
     ]
@@ -103,23 +82,16 @@
   {
     "curie": "Q109366037",
     "label": "molar Planck constant",
-    "description": "",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:nah"
     ],
-    "value": "0.0000000003990312712",
-    "formula": null,
-    "symbols": []
+    "value": "0.0000000003990312712"
   },
   {
     "curie": "Q112299891",
     "label": "first radiation constant",
     "description": "constant in Wien's radiation law",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:c11strc"
     ],
     "value": "0.0000000000000003741771852",
@@ -132,9 +104,7 @@
     "curie": "Q112300321",
     "label": "second radiation constant",
     "description": "constant in Wien's radiation law",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:c22ndrc"
     ],
     "value": "0.01438776877",
@@ -155,14 +125,7 @@
       "lightyear",
       "lightyears",
       "ly"
-    ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": null,
-    "symbols": []
+    ]
   },
   {
     "curie": "Q2101",
@@ -177,7 +140,6 @@
       "nist.codata:e"
     ],
     "value": "0.0000000000000000001602176634",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle e}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>e</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle e}</annotation>\n  </semantics>\n</math>"
     ]
@@ -213,13 +175,11 @@
     "curie": "Q5962",
     "label": "Boltzmann constant",
     "description": "physical constant relating energy at the individual particle level with temperature",
-    "synonyms": [],
     "xrefs": [
       "goldbook:B00695",
       "nist.codata:k"
     ],
     "value": "0.00000000000000000000001380649",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k_{\\mathrm {B} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>k</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">B</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k_{\\mathrm {B} }}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
@@ -280,7 +240,6 @@
       "nist.codata:na"
     ],
     "value": "602214076000000000000000",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N_{\\mathrm {A} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">A</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N_{\\mathrm {A} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -299,7 +258,6 @@
       "nist.codata:bg"
     ],
     "value": "0.000000000066743",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle G}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>G</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle G}</annotation>\n  </semantics>\n</math>"
     ]
@@ -346,12 +304,7 @@
       "\u039b",
       "Einstein's cosmological constant"
     ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "0.00000000000000000000000000000000000000000000000000011056",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Lambda }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi mathvariant=\"normal\">&#x039B;<!-- \u039b --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Lambda }</annotation>\n  </semantics>\n</math>"
     ]
@@ -407,7 +360,6 @@
       "nist.codata:stdatm"
     ],
     "value": "101325",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle atm}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>a</mi>\n        <mi>t</mi>\n        <mi>m</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle atm}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\text{&#x430;&#x442;&#x43C;.}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mtext>&#x430;&#x442;&#x43C;.</mtext>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\text{\u0430\u0442\u043c.}}}</annotation>\n  </semantics>\n</math>"
@@ -455,9 +407,7 @@
     "curie": "Q202642",
     "label": "Planck time",
     "description": "very small unit of time",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:plkt"
     ],
     "value": "0.00000000000000000000000000000000000000000005391247",
@@ -470,9 +420,7 @@
     "curie": "Q207387",
     "label": "Planck length",
     "description": "very small-scale unit of length",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:plkl"
     ],
     "value": "0.00000000000000000000000000000000001616255",
@@ -493,7 +441,6 @@
       "wave impedance in vacuum"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:z0"
     ],
     "value": "376.730313461",
@@ -514,7 +461,6 @@
       "wave impedance in vacuum"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:z0"
     ],
     "value": "376.730313461",
@@ -535,7 +481,6 @@
       "wave impedance in vacuum"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:z0"
     ],
     "value": "376.730313461",
@@ -556,7 +501,6 @@
       "wave impedance in vacuum"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:z0"
     ],
     "value": "376.730313461",
@@ -574,7 +518,6 @@
       "R_K"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:rk"
     ],
     "value": "25812.80745",
@@ -592,7 +535,6 @@
       "R_K"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:rk"
     ],
     "value": "25812.80745",
@@ -605,26 +547,13 @@
     "curie": "Q319686",
     "label": "speed of gravity",
     "description": "physical constant equal to the speed of light",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": "299792458",
-    "formula": null,
-    "symbols": []
+    "value": "299792458"
   },
   {
     "curie": "Q335272",
     "label": "solar constant",
     "description": "intensity of sunlight",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "1361",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {eo} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n              <mi mathvariant=\"normal\">o</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {eo} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -652,9 +581,7 @@
     "curie": "Q592634",
     "label": "Planck mass",
     "description": "unit of mass in the system of Planck units",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:plkm"
     ],
     "value": "0.00000002176434",
@@ -667,7 +594,6 @@
     "curie": "Q652571",
     "label": "Bohr radius",
     "description": "physical constant; the most probable distance between an electron and the nucleus in a nonrelativistic model of the hydrogen atom with infinitely heavy nucleus",
-    "synonyms": [],
     "xrefs": [
       "goldbook:B00693",
       "nist.codata:bohrrada0"
@@ -682,7 +608,6 @@
     "curie": "Q658065",
     "label": "Rydberg constant",
     "description": "physical constant",
-    "synonyms": [],
     "xrefs": [
       "goldbook:R05430",
       "nist.codata:ryd"
@@ -701,7 +626,6 @@
       "Planck temperature scale"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:plktmp"
     ],
     "value": "141678400000000000000000000000000",
@@ -735,7 +659,6 @@
       "Loschmidt's number"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:n0std"
     ],
     "value": "26867801117984438224481531.574",
@@ -747,23 +670,13 @@
   {
     "curie": "Q905618",
     "label": "cryoscopic constant",
-    "description": "material property relating molality to freezing point depression",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": null,
-    "symbols": []
+    "description": "material property relating molality to freezing point depression"
   },
   {
     "curie": "Q913365",
     "label": "Planck energy",
     "description": "unit of energy in the system of Planck units",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:plkmc2gev"
     ],
     "value": "12208900000000000000",
@@ -779,20 +692,12 @@
     "synonyms": [
       "Tolman-Oppenheimer-Volkoff limit",
       "TOV limit"
-    ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": null,
-    "symbols": []
+    ]
   },
   {
     "curie": "Q1166093",
     "label": "nuclear magneton",
     "description": "physical constant of magnetic moment",
-    "synonyms": [],
     "xrefs": [
       "goldbook:N04236",
       "nist.codata:mun"
@@ -818,25 +723,12 @@
       "pound-weight",
       "poundforce"
     ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n          <mi mathvariant=\"normal\">f</mi>\n        </mrow>\n        <mo>=</mo>\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }</annotation>\n  </semantics>\n</math>",
-    "symbols": []
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n          <mi mathvariant=\"normal\">f</mi>\n        </mrow>\n        <mo>=</mo>\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }</annotation>\n  </semantics>\n</math>"
   },
   {
     "curie": "Q1496380",
     "label": "Gaussian gravitational constant",
     "description": "constant used in orbital mechanics of the solar system",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
     ]
@@ -855,23 +747,13 @@
       "nist.codata:mu0"
     ],
     "value": "0.00000125663706212",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{0}}</annotation>\n  </semantics>\n</math>"
     ]
   },
   {
     "curie": "Q1606390",
-    "label": "Henry's Law constant",
-    "description": "",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": null,
-    "symbols": []
+    "label": "Henry's Law constant"
   },
   {
     "curie": "Q2115969",
@@ -888,7 +770,6 @@
       "reduced Planck's constant"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:hbar"
     ],
     "value": "0.0000000000000000000000000000000001054500197921765038361332005608763113259910823179829917019987020293609409175803660557740077",
@@ -907,7 +788,6 @@
       "Thomson scattering length"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:re"
     ],
     "value": "2.8179403262",
@@ -924,7 +804,6 @@
       "flux quantum"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:flxquhs2e"
     ],
     "value": "0.000000000000002067833848",
@@ -936,14 +815,10 @@
   {
     "curie": "Q2912520",
     "label": "proton-to-electron mass ratio",
-    "description": "",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:mpsme"
     ],
     "value": "1836.15267389",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {p} }/m_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {p} }/m_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -956,11 +831,9 @@
       "neutron magnetic moment"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:munn"
     ],
     "value": "-0.0000000000000000000000000096623651",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -977,7 +850,6 @@
       "nist.codata:me"
     ],
     "value": "0.00000000000000000000000000000091093837015",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -989,12 +861,7 @@
     "synonyms": [
       "K\u00e1rm\u00e1n's constant"
     ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "0.4",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
     ]
@@ -1011,7 +878,6 @@
       "nist.codata:u"
     ],
     "value": "0.0000000000000000000000000016605390666",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {u} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">u</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {u} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1019,10 +885,7 @@
   {
     "curie": "Q6895682",
     "label": "molar mass constant",
-    "description": "",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:mu"
     ],
     "value": "0.00099999999965",
@@ -1034,31 +897,20 @@
   {
     "curie": "Q7196620",
     "label": "pion decay constant",
-    "description": "physical constant",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": null,
-    "symbols": []
+    "description": "physical constant"
   },
   {
     "curie": "Q7252077",
     "label": "proton gyromagnetic ratio",
-    "description": "",
     "synonyms": [
       "gyromagnetic coefficient of the proton",
       "gyromagnetic ratio of the proton",
       "magnetogyric ratio of the proton"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gammap"
     ],
     "value": "267522187.44",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1070,10 +922,6 @@
     "synonyms": [
       "electric force constant",
       "electrostatic constant"
-    ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
     ],
     "value": "8987551787.3681764",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k={\\frac {1}{4\\pi \\varepsilon _{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k={\\frac {1}{4\\pi \\varepsilon _{0}}}}</annotation>\n  </semantics>\n</math>",
@@ -1094,7 +942,6 @@
       "Wien's displacement constant"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:bwien"
     ],
     "value": "0.00289771955",
@@ -1107,11 +954,6 @@
     "curie": "Q11282513",
     "label": "Einstein's constant",
     "description": "physical constant occurring in Einstein's equations (c^2 convention)",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "0.000000000000000000000000018664",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <mi>G</mi>\n            </mrow>\n            <msup>\n              <mi>c</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{2}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
@@ -1122,13 +964,10 @@
     "curie": "Q12472160",
     "label": "Angstrom star",
     "description": "unit of length; equals 1.000\u2009014\u200998(90) angstrom",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:angstar"
     ],
     "value": "0.000000000100001495",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {\\AA} ^{*}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mo>&#xC5;</mo>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mo>&#x2217;<!-- \u2217 --></mo>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {\\AA} ^{*}}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1154,7 +993,6 @@
       "nist.codata:gn"
     ],
     "value": "9.80665",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>g</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g}</annotation>\n  </semantics>\n</math>"
@@ -1168,7 +1006,6 @@
       "electron magnetic moment"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:muem"
     ],
     "value": "-0.0000000000000000000000092847647043",
@@ -1185,12 +1022,10 @@
       "rydberg"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:rydhcj"
     ],
     "value": "0.0000000000000000021798723611035",
-    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mn>1</mn>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">R</mi>\n          <mi mathvariant=\"normal\">y</mi>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>4</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <mo stretchy=\"false\">(</mo>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03F5;<!-- \u03f5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <msup>\n                <mo stretchy=\"false\">)</mo>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}</annotation>\n  </semantics>\n</math>",
-    "symbols": []
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mn>1</mn>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">R</mi>\n          <mi mathvariant=\"normal\">y</mi>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>4</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <mo stretchy=\"false\">(</mo>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03F5;<!-- \u03f5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <msup>\n                <mo stretchy=\"false\">)</mo>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}</annotation>\n  </semantics>\n</math>"
   },
   {
     "curie": "Q13570090",
@@ -1200,7 +1035,6 @@
       "G0"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:conqu2e2sh"
     ],
     "value": "0.00007748091729",
@@ -1212,7 +1046,6 @@
   {
     "curie": "Q17076647",
     "label": "proton magnetic dipole moment",
-    "description": "",
     "synonyms": [
       "proton magnetic moment"
     ],
@@ -1221,7 +1054,6 @@
       "nist.codata:mup"
     ],
     "value": "0.0000000000000000000000000141060679736",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1230,11 +1062,6 @@
     "curie": "Q28003216",
     "label": "Planck acceleration",
     "description": "acceleration from zero to the speed of light in one Planck time",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "5560800000000000000000000000000000000000000000000000",
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{\\text{P}}={\\sqrt {\\frac {c^{7}}{\\hbar G}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>P</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>7</mn>\n                </mrow>\n              </msup>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <mi>G</mi>\n              </mrow>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{\\text{P}}={\\sqrt {\\frac {c^{7}}{\\hbar G}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
@@ -1263,12 +1090,7 @@
       "6.02214e23",
       "6.02e23"
     ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "602214076000000000000000",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N_{0}}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>N</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N}</annotation>\n  </semantics>\n</math>"
@@ -1278,9 +1100,7 @@
     "curie": "Q92605166",
     "label": "Josephson constant",
     "description": "the inverse of the flux quantum",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:kjos"
     ],
     "value": "483597.848416984",
@@ -1293,9 +1113,7 @@
     "curie": "Q92605166",
     "label": "Josephson constant",
     "description": "the inverse of the flux quantum",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:kjos"
     ],
     "value": "483597.848416984",
@@ -1311,11 +1129,6 @@
     "synonyms": [
       "\ud835\udf52"
     ],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
     "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{4}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <mi>G</mi>\n            </mrow>\n            <msup>\n              <mi>c</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>4</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{4}}}}</annotation>\n  </semantics>\n</math>",
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
@@ -1329,11 +1142,9 @@
       "hyperfine transition frequency of Cs-133"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:nucs"
     ],
     "value": "9192631770",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Delta \\nu _{\\mathrm {Cs} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi mathvariant=\"normal\">&#x0394;<!-- \u0394 --></mi>\n        <msub>\n          <mi>&#x03BD;<!-- \u03bd --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n              <mi mathvariant=\"normal\">s</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Delta \\nu _{\\mathrm {Cs} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1346,11 +1157,9 @@
       "luminous efficacy for monochromatic radiation of frequency 540 \u00d7 10\u00b9\u00b2 Hz"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:kcd"
     ],
     "value": "683",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {cd} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">c</mi>\n              <mi mathvariant=\"normal\">d</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {cd} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1359,13 +1168,10 @@
     "curie": "Q96440139",
     "label": "alpha particle mass",
     "description": "physical constant",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:mal"
     ],
     "value": "0.0000000000000000000000000066446573357",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\alpha }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\alpha }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1378,11 +1184,9 @@
       "weak mixing angle"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:sin2th"
     ],
     "value": "0.2229",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sin ^{2}{\\theta _{\\mathrm {W} }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msup>\n          <mi>sin</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n        <mo>&#x2061;<!-- \u2061 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msub>\n            <mi>&#x03B8;<!-- \u03b8 --></mi>\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">W</mi>\n              </mrow>\n            </mrow>\n          </msub>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sin ^{2}{\\theta _{\\mathrm {W} }}}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1399,7 +1203,6 @@
       "nist.codata:mp"
     ],
     "value": "0.00000000000000000000000000167262192369",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1414,7 +1217,6 @@
       "magnetogyric ratio of the electron"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gammae"
     ],
     "value": "176085963023",
@@ -1426,14 +1228,10 @@
   {
     "curie": "Q97967308",
     "label": "electron Compton wavelength",
-    "description": "",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:ecomwl"
     ],
     "value": "0.00000000000242631023867",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\lambda _{\\mathrm {C} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BB;<!-- \u03bb --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\lambda _{\\mathrm {C} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1441,7 +1239,6 @@
   {
     "curie": "Q98000454",
     "label": "neutron mass",
-    "description": "",
     "synonyms": [
       "neutron rest mass"
     ],
@@ -1450,7 +1247,6 @@
       "nist.codata:mn"
     ],
     "value": "0.00000000000000000000000000167492749804",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1458,14 +1254,7 @@
   {
     "curie": "Q98380812",
     "label": "Planck magnetic flux density",
-    "description": "",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "215000000000000000000000000000000000000000000000000000",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle B_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>B</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle B_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1473,14 +1262,7 @@
   {
     "curie": "Q98380823",
     "label": "Planck magnetic flux",
-    "description": "",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
     "value": "0.000000000000000056227",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Phi _{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Phi _{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1488,20 +1270,11 @@
   {
     "curie": "Q99476928",
     "label": "gram-force",
-    "description": "unit of force",
-    "synonyms": [],
-    "xrefs": [
-      "goldbook:",
-      "nist.codata:"
-    ],
-    "value": null,
-    "formula": null,
-    "symbols": []
+    "description": "unit of force"
   },
   {
     "curie": "Q106589812",
     "label": "reduced electron gyromagnetic ratio",
-    "description": "",
     "synonyms": [
       "electron reduced gyromagnetic ratio",
       "reduced gyromagnetic coefficient of the electron",
@@ -1509,11 +1282,9 @@
       "reduced magnetogyric ratio of the electron"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gammaebar"
     ],
     "value": "28024.9514242",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {e} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">e</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {e} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
@@ -1522,7 +1293,6 @@
   {
     "curie": "Q106589932",
     "label": "reduced proton gyromagnetic ratio",
-    "description": "",
     "synonyms": [
       "proton reduced gyromagnetic ratio",
       "reduced gyromagnetic coefficient of the proton",
@@ -1530,11 +1300,9 @@
       "reduced magnetogyric ratio of the proton"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gammapbar"
     ],
     "value": "42.577478518",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {p} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">p</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {p} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
@@ -1543,18 +1311,15 @@
   {
     "curie": "Q106589964",
     "label": "neutron gyromagnetic ratio",
-    "description": "",
     "synonyms": [
       "gyromagnetic coefficient of the neutron",
       "gyromagnetic ratio of the of the neutron",
       "magnetogyric ratio of the neutron"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gamman"
     ],
     "value": "183247171",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1562,7 +1327,6 @@
   {
     "curie": "Q106589981",
     "label": "neutron reduced gyromagnetic ratio",
-    "description": "",
     "synonyms": [
       "reduced gyromagnetic coefficient of the neutron",
       "reduced gyromagnetic ratio of the neutron",
@@ -1570,11 +1334,9 @@
       "reduced neutron gyromagnetic ratio"
     ],
     "xrefs": [
-      "goldbook:",
       "nist.codata:gammanbar"
     ],
     "value": "29.1646931",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {n} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">n</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {n} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
@@ -1584,13 +1346,10 @@
     "curie": "Q106764378",
     "label": "muon mass",
     "description": "physical constant",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:mmu"
     ],
     "value": "0.0000000000000000000000000001883531627",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {\\mu } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {\\mu } }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1599,13 +1358,10 @@
     "curie": "Q106764397",
     "label": "tau mass",
     "description": "physical constant",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:mtau"
     ],
     "value": "0.00000000000000000000000000316754",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {\\tau } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03C4;<!-- \u03c4 --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {\\tau } }}</annotation>\n  </semantics>\n</math>"
     ]
@@ -1614,13 +1370,10 @@
     "curie": "Q108899308",
     "label": "copper x unit",
     "description": "unit of length",
-    "synonyms": [],
     "xrefs": [
-      "goldbook:",
       "nist.codata:xucukalph1"
     ],
     "value": "0.000000000000100207697",
-    "formula": null,
     "symbols": [
       "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {xu} (\\mathrm {Cu} \\,\\mathrm {K\\alpha } _{1})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">x</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">C</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {xu} (\\mathrm {Cu} \\,\\mathrm {K\\alpha } _{1})}</annotation>\n  </semantics>\n</math>"
     ]

--- a/mira/dkg/resources/physical_constants.json
+++ b/mira/dkg/resources/physical_constants.json
@@ -1,0 +1,1628 @@
+[
+  {
+    "curie": "Q112703485",
+    "label": "electron g factor",
+    "description": "",
+    "synonyms": [
+      "electron spin g factor"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gem"
+    ],
+    "value": "-2.00231930436256",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {e} ^{-}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <msup>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">e</mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>&#x2212;<!-- \u2212 --></mo>\n              </mrow>\n            </msup>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {e} ^{-}}}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q112703647",
+    "label": "proton g factor",
+    "description": "",
+    "synonyms": [
+      "proton spin g factor"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gp"
+    ],
+    "value": "5.5856946893",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q112703993",
+    "label": "muon g factor",
+    "description": "",
+    "synonyms": [
+      "muon g-factor",
+      "muon spin g factor"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gmum"
+    ],
+    "value": "-2.0023318418",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {\\mu } ^{-}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <msup>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>&#x2212;<!-- \u2212 --></mo>\n              </mrow>\n            </msup>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {\\mu } ^{-}}}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {\\mu } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {\\mu } }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q117771430",
+    "label": "first radiation constant for spectral radiance",
+    "description": "",
+    "synonyms": [
+      "first radiation constant"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:c1l"
+    ],
+    "value": null,
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1L}=2hc^{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n            <mi>L</mi>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mn>2</mn>\n        <mi>h</mi>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1L}=2hc^{2}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1L}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n            <mi>L</mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1L}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q119348262",
+    "label": "admittance of vacuum",
+    "description": "reciprocal of the impedance of vacuum",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Y</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <msub>\n              <mi>Z</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Y_{0}={\\frac {1}{Z_{0}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Y_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Y</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Y_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q108899315",
+    "label": "molybdenum x unit",
+    "description": "unit of length",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:xumokalph1"
+    ],
+    "value": "0.000000000000100209952",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {xu} (\\mathrm {Mo} \\,\\mathrm {K\\alpha } _{1})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">x</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">M</mi>\n          <mi mathvariant=\"normal\">o</mi>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {xu} (\\mathrm {Mo} \\,\\mathrm {K\\alpha } _{1})}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q109366037",
+    "label": "molar Planck constant",
+    "description": "",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:nah"
+    ],
+    "value": "0.0000000003990312712",
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q112299891",
+    "label": "first radiation constant",
+    "description": "constant in Wien's radiation law",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:c11strc"
+    ],
+    "value": "0.0000000000000003741771852",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1}=2\\pi hc^{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mn>2</mn>\n        <mi>&#x03C0;<!-- \u03c0 --></mi>\n        <mi>h</mi>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1}=2\\pi hc^{2}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{1}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{1}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q112300321",
+    "label": "second radiation constant",
+    "description": "constant in Wien's radiation law",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:c22ndrc"
+    ],
+    "value": "0.01438776877",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{2}={\\frac {hc}{k_{\\mathrm {B} }}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>h</mi>\n              <mi>c</mi>\n            </mrow>\n            <msub>\n              <mi>k</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">B</mi>\n                </mrow>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{2}={\\frac {hc}{k_{\\mathrm {B} }}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{2}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q531",
+    "label": "light-year",
+    "description": "unit of length used to express astronomical distances, defined as the distance that light travels in a vacuum in one year",
+    "synonyms": [
+      "l.y.",
+      "light year",
+      "light years",
+      "light-years",
+      "lightyear",
+      "lightyears",
+      "ly"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q2101",
+    "label": "elementary charge",
+    "description": "the electric charge carried by a single proton or a single positron",
+    "synonyms": [
+      "elementary electric charge",
+      "elementary positive charge"
+    ],
+    "xrefs": [
+      "goldbook:E02032",
+      "nist.codata:e"
+    ],
+    "value": "0.0000000000000000001602176634",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle e}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>e</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle e}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q2111",
+    "label": "speed of light in vacuum",
+    "description": "speed of electromagnetic waves in vacuum",
+    "synonyms": [
+      "speed of light",
+      "light speed",
+      "lightspeed",
+      "Planck speed",
+      "speed of electromagnetic waves in vacuum",
+      "speed of light in a vacuum",
+      "vacuum speed of light",
+      "velocity of light",
+      "luminal speed",
+      "light speed in vacuum"
+    ],
+    "xrefs": [
+      "goldbook:S05854",
+      "nist.codata:c"
+    ],
+    "value": "299792458",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{0}=299792458\\,\\mathrm {m} /\\mathrm {s} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mn>299792458</mn>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">m</mi>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">s</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{0}=299792458\\,\\mathrm {m} /\\mathrm {s} }</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c_{0}}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle c}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>c</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle c}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q5962",
+    "label": "Boltzmann constant",
+    "description": "physical constant relating energy at the individual particle level with temperature",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:B00695",
+      "nist.codata:k"
+    ],
+    "value": "0.00000000000000000000001380649",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k_{\\mathrm {B} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>k</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">B</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k_{\\mathrm {B} }}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q5997",
+    "label": "fine-structure constant",
+    "description": "physical constant quantifying the strength of the electromagnetic interaction between elementary charged particles",
+    "synonyms": [
+      "fine structure constant",
+      "Sommerfeld's constant",
+      "Sommerfeld fine structure constant"
+    ],
+    "xrefs": [
+      "goldbook:F02389",
+      "nist.codata:alph"
+    ],
+    "value": "0.0072973525693",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\alpha ={\\frac {1}{4\\pi \\varepsilon _{0}}}{\\frac {e^{2}}{\\hbar c}}={\\frac {\\mu _{0}}{4\\pi }}{\\frac {e^{2}c}{\\hbar }}={\\frac {k_{\\text{e}}e^{2}}{\\hbar c}}={\\frac {c\\mu _{0}}{2R_{\\text{K}}}}={\\frac {e^{2}}{4\\pi }}{\\frac {Z_{0}}{\\hbar }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03B1;<!-- \u03b1 --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <mi>c</mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n              <mi>c</mi>\n            </mrow>\n            <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msub>\n                <mi>k</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mtext>e</mtext>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <mi>c</mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>c</mi>\n              <msub>\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>R</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mtext>K</mtext>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>Z</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n            <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\alpha ={\\frac {1}{4\\pi \\varepsilon _{0}}}{\\frac {e^{2}}{\\hbar c}}={\\frac {\\mu _{0}}{4\\pi }}{\\frac {e^{2}c}{\\hbar }}={\\frac {k_{\\text{e}}e^{2}}{\\hbar c}}={\\frac {c\\mu _{0}}{2R_{\\text{K}}}}={\\frac {e^{2}}{4\\pi }}{\\frac {Z_{0}}{\\hbar }}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\alpha }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03B1;<!-- \u03b1 --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\alpha }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q6158",
+    "label": "permittivity of vacuum",
+    "description": "physical constant defining the capability of an electric field to permeate a vacuum",
+    "synonyms": [
+      "electric constant",
+      "permittivity of free space",
+      "vacuum electric permittivity",
+      "vacuum permittivity"
+    ],
+    "xrefs": [
+      "goldbook:P04508",
+      "nist.codata:ep0"
+    ],
+    "value": "0.0000000000088541878128",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\varepsilon _{0}={\\frac {1}{\\mu _{0}c_{0}^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B5;<!-- \u03b5 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <mrow>\n              <msub>\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msubsup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msubsup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\varepsilon _{0}={\\frac {1}{\\mu _{0}c_{0}^{2}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\varepsilon _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B5;<!-- \u03b5 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\varepsilon _{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q6203",
+    "label": "Avogadro constant",
+    "description": "fundamental physical constant (symbols: L, N\u1d00) representing the molar number of entities",
+    "synonyms": [
+      "L",
+      "6 \u00d710^23",
+      "Avogadro's constant",
+      "N_A",
+      "N\u1d00"
+    ],
+    "xrefs": [
+      "goldbook:A00543",
+      "nist.codata:na"
+    ],
+    "value": "602214076000000000000000",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N_{\\mathrm {A} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">A</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N_{\\mathrm {A} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q18373",
+    "label": "gravitational constant",
+    "description": "physical constant relating the gravitational force between objects to their mass and distance",
+    "synonyms": [
+      "G",
+      "Newton's gravitational constant",
+      "Newtonian constant of gravitation"
+    ],
+    "xrefs": [
+      "goldbook:G02695",
+      "nist.codata:bg"
+    ],
+    "value": "0.000000000066743",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle G}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>G</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle G}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q51374",
+    "label": "Stefan-Boltzmann constant",
+    "description": "ratio between the radiative power of a black body to the fourth power of its temperature",
+    "synonyms": [
+      "Stefan Boltzmann constant"
+    ],
+    "xrefs": [
+      "goldbook:S05964",
+      "nist.codata:sigma"
+    ],
+    "value": "0.0000000567037441918442945397099673188923087584012297029130368240546173705394816062652332608257185777044688703926026976455142",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma ={\\frac {2\\pi ^{5}k_{\\mathrm {B} }^{4}}{15h^{3}c^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>2</mn>\n              <msup>\n                <mi>&#x03C0;<!-- \u03c0 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n              <msubsup>\n                <mi>k</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">B</mi>\n                  </mrow>\n                </mrow>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>4</mn>\n                </mrow>\n              </msubsup>\n            </mrow>\n            <mrow>\n              <mn>15</mn>\n              <msup>\n                <mi>h</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>3</mn>\n                </mrow>\n              </msup>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma ={\\frac {2\\pi ^{5}k_{\\mathrm {B} }^{4}}{15h^{3}c^{2}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q51374",
+    "label": "Stefan-Boltzmann constant",
+    "description": "ratio between the radiative power of a black body to the fourth power of its temperature",
+    "synonyms": [
+      "Stefan Boltzmann constant"
+    ],
+    "xrefs": [
+      "goldbook:S05964",
+      "nist.codata:sigma"
+    ],
+    "value": "0.0000000567037441918442945397099673188923087584012297029130368240546173705394816062652332608257185777044688703926026976455142",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma ={\\frac {5\\,454\\,781\\,984\\,210\\,512\\,994\\,952\\,000\\,000\\pi ^{5}}{29\\,438\\,455\\,734\\,650\\,141\\,042\\,413\\,712\\,126\\,365\\,436\\,049}}\\mathrm {W} /(\\mathrm {m} ^{2}\\cdot \\mathrm {K} ^{4})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>5</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>454</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>781</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>984</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>210</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>512</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>994</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>952</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>000</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>000</mn>\n              <msup>\n                <mi>&#x03C0;<!-- \u03c0 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>29</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>438</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>455</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>734</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>650</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>141</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>042</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>413</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>712</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>126</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>365</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>436</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>049</mn>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">W</mi>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">m</mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>4</mn>\n          </mrow>\n        </msup>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma ={\\frac {5\\,454\\,781\\,984\\,210\\,512\\,994\\,952\\,000\\,000\\pi ^{5}}{29\\,438\\,455\\,734\\,650\\,141\\,042\\,413\\,712\\,126\\,365\\,436\\,049}}\\mathrm {W} /(\\mathrm {m} ^{2}\\cdot \\mathrm {K} ^{4})}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sigma }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03C3;<!-- \u03c3 --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sigma }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q59151",
+    "label": "cosmological constant",
+    "description": "constant representing stress-energy density of the vacuum in Einstein's equation and accounts for the rate of expansion of the universe",
+    "synonyms": [
+      "\u039b",
+      "Einstein's cosmological constant"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "0.00000000000000000000000000000000000000000000000000011056",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Lambda }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi mathvariant=\"normal\">&#x039B;<!-- \u039b --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Lambda }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q83327",
+    "label": "electronvolt",
+    "description": "unit of energy",
+    "synonyms": [
+      "electron volt",
+      "eV"
+    ],
+    "xrefs": [
+      "goldbook:E02014",
+      "nist.codata:evj"
+    ],
+    "value": "0.0000000000000000001602176634",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle 1\\;{\\text{eV}}/c^{2}={\\frac {(1.60217646\\times 10^{-19}\\;{\\text{C}})\\cdot 1\\;{\\text{V}}}{(2.99792458\\times 10^{8}\\;{\\text{m}}/{\\text{s}})^{2}}}=1.783\\times 10^{-36}\\;{\\text{kg}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mn>1</mn>\n        <mspace width=\"thickmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mtext>eV</mtext>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mo stretchy=\"false\">(</mo>\n              <mn>1.60217646</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mo>&#x2212;<!-- \u2212 --></mo>\n                  <mn>19</mn>\n                </mrow>\n              </msup>\n              <mspace width=\"thickmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>C</mtext>\n              </mrow>\n              <mo stretchy=\"false\">)</mo>\n              <mo>&#x22C5;<!-- \u22c5 --></mo>\n              <mn>1</mn>\n              <mspace width=\"thickmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>V</mtext>\n              </mrow>\n            </mrow>\n            <mrow>\n              <mo stretchy=\"false\">(</mo>\n              <mn>2.99792458</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>8</mn>\n                </mrow>\n              </msup>\n              <mspace width=\"thickmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>m</mtext>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo>/</mo>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mtext>s</mtext>\n              </mrow>\n              <msup>\n                <mo stretchy=\"false\">)</mo>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mn>1.783</mn>\n        <mo>&#x00D7;<!-- \u00d7 --></mo>\n        <msup>\n          <mn>10</mn>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mo>&#x2212;<!-- \u2212 --></mo>\n            <mn>36</mn>\n          </mrow>\n        </msup>\n        <mspace width=\"thickmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mtext>kg</mtext>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle 1\\;{\\text{eV}}/c^{2}={\\frac {(1.60217646\\times 10^{-19}\\;{\\text{C}})\\cdot 1\\;{\\text{V}}}{(2.99792458\\times 10^{8}\\;{\\text{m}}/{\\text{s}})^{2}}}=1.783\\times 10^{-36}\\;{\\text{kg}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle eV}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>e</mi>\n        <mi>V</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle eV}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q122894",
+    "label": "Planck constant",
+    "description": "physical constant representing the quantum of action",
+    "synonyms": [
+      "h",
+      "\ud835\udc89",
+      "Planck's constant"
+    ],
+    "xrefs": [
+      "goldbook:P04685",
+      "nist.codata:h"
+    ],
+    "value": "0.000000000000000000000000000000000662607015",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle h={\\frac {3\\times 7\\times 6\\,310\\,543}{2^{42}\\times 5^{41}}}\\,\\mathrm {J} \\cdot \\mathrm {s} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>h</mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>3</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>7</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>6</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>310</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>543</mn>\n            </mrow>\n            <mrow>\n              <msup>\n                <mn>2</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>42</mn>\n                </mrow>\n              </msup>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>5</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>41</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">J</mi>\n        </mrow>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">s</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle h={\\frac {3\\times 7\\times 6\\,310\\,543}{2^{42}\\times 5^{41}}}\\,\\mathrm {J} \\cdot \\mathrm {s} }</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle h}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>h</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle h}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q177974",
+    "label": "standard atmosphere",
+    "description": "unit of pressure defined as 101325 Pa",
+    "synonyms": [
+      "atmosphere",
+      "atm"
+    ],
+    "xrefs": [
+      "goldbook:A00490",
+      "goldbook:S05906",
+      "nist.codata:stdatm"
+    ],
+    "value": "101325",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle atm}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>a</mi>\n        <mi>t</mi>\n        <mi>m</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle atm}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\text{&#x430;&#x442;&#x43C;.}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mtext>&#x430;&#x442;&#x43C;.</mtext>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\text{\u0430\u0442\u043c.}}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q182333",
+    "label": "molar gas constant",
+    "description": "physical constant; the molar equivalent to the Boltzmann constant",
+    "synonyms": [
+      "R",
+      "gas constant",
+      "ideal gas constant",
+      "universal gas constant",
+      "Regnault constant"
+    ],
+    "xrefs": [
+      "goldbook:G02579",
+      "nist.codata:r"
+    ],
+    "value": "8.31446261815324",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R=kN_{\\mathrm {A} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>R</mi>\n        <mo>=</mo>\n        <mi>k</mi>\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">A</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R=kN_{\\mathrm {A} }}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>R</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q192819",
+    "label": "Faraday constant",
+    "description": "physical constant: electric charge of one mole of electrons",
+    "synonyms": [
+      "F"
+    ],
+    "xrefs": [
+      "goldbook:F02325",
+      "nist.codata:f"
+    ],
+    "value": "96485.3321233100184",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle F=eN_{\\mathrm {A} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>F</mi>\n        <mo>=</mo>\n        <mi>e</mi>\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">A</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle F=eN_{\\mathrm {A} }}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle F}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>F</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle F}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q202642",
+    "label": "Planck time",
+    "description": "very small unit of time",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:plkt"
+    ],
+    "value": "0.00000000000000000000000000000000000000000005391247",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle t_{\\mathrm {P} }={\\sqrt {\\frac {\\hbar G}{c^{5}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>t</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <mi>G</mi>\n              </mrow>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle t_{\\mathrm {P} }={\\sqrt {\\frac {\\hbar G}{c^{5}}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle t_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>t</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle t_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q207387",
+    "label": "Planck length",
+    "description": "very small-scale unit of length",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:plkl"
+    ],
+    "value": "0.00000000000000000000000000000000001616255",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle l_{\\mathrm {P} }={\\sqrt {\\frac {G\\hbar }{c^{3}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>l</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi>G</mi>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              </mrow>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>3</mn>\n                </mrow>\n              </msup>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle l_{\\mathrm {P} }={\\sqrt {\\frac {G\\hbar }{c^{3}}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle l_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>l</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle l_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q269492",
+    "label": "impedance of vacuum",
+    "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
+    "synonyms": [
+      "Planck impedance",
+      "characteristic impedance of vacuum",
+      "impedance of free space",
+      "vacuum impedance",
+      "wave impedance in vacuum"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:z0"
+    ],
+    "value": "376.730313461",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}={\\sqrt {\\frac {\\mu _{0}}{\\varepsilon _{0}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <msub>\n                <mi>&#x03BC;<!-- \u03bc --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}={\\sqrt {\\frac {\\mu _{0}}{\\varepsilon _{0}}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q269492",
+    "label": "impedance of vacuum",
+    "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
+    "synonyms": [
+      "Planck impedance",
+      "characteristic impedance of vacuum",
+      "impedance of free space",
+      "vacuum impedance",
+      "wave impedance in vacuum"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:z0"
+    ],
+    "value": "376.730313461",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}=c_{0}\\mu _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <msub>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}=c_{0}\\mu _{0}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q269492",
+    "label": "impedance of vacuum",
+    "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
+    "synonyms": [
+      "Planck impedance",
+      "characteristic impedance of vacuum",
+      "impedance of free space",
+      "vacuum impedance",
+      "wave impedance in vacuum"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:z0"
+    ],
+    "value": "376.730313461",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}={\\frac {|{\\boldsymbol {E}}|}{|{\\boldsymbol {H}}|}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"bold-italic\">E</mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n            </mrow>\n            <mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"bold-italic\">H</mi>\n              </mrow>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mo stretchy=\"false\">|</mo>\n              </mrow>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}={\\frac {|{\\boldsymbol {E}}|}{|{\\boldsymbol {H}}|}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q269492",
+    "label": "impedance of vacuum",
+    "description": "physical constant relating the magnitudes of the electric and magnetic fields of electromagnetic radiation travelling through free space",
+    "synonyms": [
+      "Planck impedance",
+      "characteristic impedance of vacuum",
+      "impedance of free space",
+      "vacuum impedance",
+      "wave impedance in vacuum"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:z0"
+    ],
+    "value": "376.730313461",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\"><merror><strong class=\"error texerror\">Failed to parse (SVG (MathML can be enabled via browser plugin): Invalid response (&quot;Math extension cannot connect to Restbase.&quot;) from server &quot;http://localhost:6011/www.wikidata.org/v1/&quot;:): {\\displaystyle Z_0 = \\mu_0 c_0}</strong>\n</merror></math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle Z_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>Z</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle Z_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q304770",
+    "label": "von Klitzing constant",
+    "description": "inverse of the quantum of conductance in the integer quantum Hall effect",
+    "synonyms": [
+      "RK",
+      "R_K"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:rk"
+    ],
+    "value": "25812.80745",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }={\\frac {5\\,521\\,725\\,125}{213\\,914\\,163\\,877\\,964\\,163}}\\mathrm {T\\Omega } }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>5</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>521</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>725</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>125</mn>\n            </mrow>\n            <mrow>\n              <mn>213</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>914</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>163</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>877</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>964</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>163</mn>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">T</mi>\n          <mi mathvariant=\"normal\">&#x03A9;<!-- \u03a9 --></mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }={\\frac {5\\,521\\,725\\,125}{213\\,914\\,163\\,877\\,964\\,163}}\\mathrm {T\\Omega } }</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q304770",
+    "label": "von Klitzing constant",
+    "description": "inverse of the quantum of conductance in the integer quantum Hall effect",
+    "synonyms": [
+      "RK",
+      "R_K"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:rk"
+    ],
+    "value": "25812.80745",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }={\\frac {h}{e^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mi>h</mi>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }={\\frac {h}{e^{2}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\mathrm {K} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">K</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\mathrm {K} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q319686",
+    "label": "speed of gravity",
+    "description": "physical constant equal to the speed of light",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "299792458",
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q335272",
+    "label": "solar constant",
+    "description": "intensity of sunlight",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "1361",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {eo} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n              <mi mathvariant=\"normal\">o</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {eo} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q476572",
+    "label": "Hartree energy",
+    "description": "atomic unit of energy",
+    "synonyms": [
+      "hartree"
+    ],
+    "xrefs": [
+      "goldbook:H02747",
+      "goldbook:H02748",
+      "nist.codata:hr"
+    ],
+    "value": "0.0000000000000000043597447222071",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {H} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}a_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">H</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>a</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {H} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}a_{0}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {H} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">H</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {H} }}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\mathrm {h} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">h</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\mathrm {h} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q592634",
+    "label": "Planck mass",
+    "description": "unit of mass in the system of Planck units",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:plkm"
+    ],
+    "value": "0.00000002176434",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {P} }={\\sqrt {\\frac {c\\hbar }{G}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi>c</mi>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              </mrow>\n              <mi>G</mi>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {P} }={\\sqrt {\\frac {c\\hbar }{G}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q652571",
+    "label": "Bohr radius",
+    "description": "physical constant; the most probable distance between an electron and the nucleus in a nonrelativistic model of the hydrogen atom with infinitely heavy nucleus",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:B00693",
+      "nist.codata:bohrrada0"
+    ],
+    "value": "0.0000000000529177210903",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{0}={\\frac {4\\pi \\varepsilon _{0}\\hbar ^{2}}{m_{\\mathrm {e} }e^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msup>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{0}={\\frac {4\\pi \\varepsilon _{0}\\hbar ^{2}}{m_{\\mathrm {e} }e^{2}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q658065",
+    "label": "Rydberg constant",
+    "description": "physical constant",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:R05430",
+      "nist.codata:ryd"
+    ],
+    "value": "10973731.56816",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\infty }={\\frac {e^{2}}{8\\pi \\varepsilon _{0}a_{0}hc_{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">&#x221E;<!-- \u221e --></mi>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>a</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mi>h</mi>\n              <msub>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\infty }={\\frac {e^{2}}{8\\pi \\varepsilon _{0}a_{0}hc_{0}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle R_{\\infty }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>R</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">&#x221E;<!-- \u221e --></mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle R_{\\infty }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q720055",
+    "label": "Planck temperature",
+    "description": "very large unit of temperature",
+    "synonyms": [
+      "Planck temperature scale"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:plktmp"
+    ],
+    "value": "141678400000000000000000000000000",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle T_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{Gk_{\\text{B}}^{2}}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>T</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>P</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <msup>\n                  <mi>c</mi>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mn>5</mn>\n                  </mrow>\n                </msup>\n              </mrow>\n              <mrow>\n                <mi>G</mi>\n                <msubsup>\n                  <mi>k</mi>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mtext>B</mtext>\n                  </mrow>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mn>2</mn>\n                  </mrow>\n                </msubsup>\n              </mrow>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle T_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{Gk_{\\text{B}}^{2}}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle T_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>T</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle T_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q737120",
+    "label": "Bohr magneton",
+    "description": "unit of magnetic moment (approx. 9.2 J/T); the magnetic dipole moment of an electron orbiting an atom with angular momentum \u210f in the Bohr model",
+    "synonyms": [
+      "Bohr\u2013Procopiu magneton"
+    ],
+    "xrefs": [
+      "goldbook:B00692",
+      "nist.codata:mub"
+    ],
+    "value": "0.0000000000000000000000092740100783",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {B} }={\\frac {e\\hbar }{2m_{\\mathrm {e} }}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">B</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>e</mi>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {B} }={\\frac {e\\hbar }{2m_{\\mathrm {e} }}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {B} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">B</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {B} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q903271",
+    "label": "Loschmidt constant",
+    "description": "physical constant - number density of molecules in an ideal gas at standard temperature and pressure",
+    "synonyms": [
+      "Loschmidt's number"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:n0std"
+    ],
+    "value": "26867801117984438224481531.574",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle n_{0}={\\frac {101\\,325\\,\\mathrm {Pa} }{k_{\\mathrm {B} }\\cdot 273.15\\,\\mathrm {K} }}={\\frac {6\\,755\\times 10^{31}}{2\\,514\\,161\\,829}}\\,\\mathrm {m} ^{-3}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>n</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>101</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>325</mn>\n              <mspace width=\"thinmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">P</mi>\n                <mi mathvariant=\"normal\">a</mi>\n              </mrow>\n            </mrow>\n            <mrow>\n              <msub>\n                <mi>k</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">B</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <mo>&#x22C5;<!-- \u22c5 --></mo>\n              <mn>273.15</mn>\n              <mspace width=\"thinmathspace\" />\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">K</mi>\n              </mrow>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>6</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>755</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>31</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>514</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>161</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>829</mn>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">m</mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mo>&#x2212;<!-- \u2212 --></mo>\n            <mn>3</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle n_{0}={\\frac {101\\,325\\,\\mathrm {Pa} }{k_{\\mathrm {B} }\\cdot 273.15\\,\\mathrm {K} }}={\\frac {6\\,755\\times 10^{31}}{2\\,514\\,161\\,829}}\\,\\mathrm {m} ^{-3}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle n_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>n</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle n_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q905618",
+    "label": "cryoscopic constant",
+    "description": "material property relating molality to freezing point depression",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q913365",
+    "label": "Planck energy",
+    "description": "unit of energy in the system of Planck units",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:plkmc2gev"
+    ],
+    "value": "12208900000000000000",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle E_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{G}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>E</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>P</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <msup>\n                  <mi>c</mi>\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mn>5</mn>\n                  </mrow>\n                </msup>\n              </mrow>\n              <mi>G</mi>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle E_{\\text{P}}={\\sqrt {\\frac {\\hbar c^{5}}{G}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {P} }c^{2}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <msup>\n          <mi>c</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {P} }c^{2}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q1139232",
+    "label": "Tolman\u2013Oppenheimer\u2013Volkoff limit",
+    "description": "upper bound to the mass of cold, nonrotating neutron stars",
+    "synonyms": [
+      "Tolman-Oppenheimer-Volkoff limit",
+      "TOV limit"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q1166093",
+    "label": "nuclear magneton",
+    "description": "physical constant of magnetic moment",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:N04236",
+      "nist.codata:mun"
+    ],
+    "value": "0.0000000000000000000000000050507837461",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {N} }={\\frac {e\\hbar }{2m_{\\mathrm {p} }}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">N</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>e</mi>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">p</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {N} }={\\frac {e\\hbar }{2m_{\\mathrm {p} }}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {N} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">N</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {N} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q1194225",
+    "label": "pound-force",
+    "description": "unit of force: the force exerted by one standard gravity on a one-pound mass",
+    "synonyms": [
+      "lb",
+      "pound",
+      "lbf",
+      "pound (weight)",
+      "pound force",
+      "pound of force",
+      "pound weight",
+      "pound-weight",
+      "poundforce"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n          <mi mathvariant=\"normal\">f</mi>\n        </mrow>\n        <mo>=</mo>\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">l</mi>\n          <mi mathvariant=\"normal\">b</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {lbf} =g_{0}\\cdot \\mathrm {lb} }</annotation>\n  </semantics>\n</math>",
+    "symbols": []
+  },
+  {
+    "curie": "Q1496380",
+    "label": "Gaussian gravitational constant",
+    "description": "constant used in orbital mechanics of the solar system",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q1515261",
+    "label": "magnetic constant",
+    "description": "physical constant; ratio between the magnetic H-field and the magnetic B-field in classical vacuum",
+    "synonyms": [
+      "permeability of free space",
+      "permeability of vacuum",
+      "vacuum permeability"
+    ],
+    "xrefs": [
+      "goldbook:P04504",
+      "nist.codata:mu0"
+    ],
+    "value": "0.00000125663706212",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q1606390",
+    "label": "Henry's Law constant",
+    "description": "",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q2115969",
+    "label": "reduced Planck constant",
+    "description": "the Planck constant divided by 2 \u03c0",
+    "synonyms": [
+      "Dirac constant",
+      "Dirac's constant",
+      "\u210f",
+      "h-bar",
+      "\u210e-bar",
+      "Planck action",
+      "Planck angular momentum",
+      "reduced Planck's constant"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:hbar"
+    ],
+    "value": "0.0000000000000000000000000000000001054500197921765038361332005608763113259910823179829917019987020293609409175803660557740077",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\hbar ={\\frac {h}{2\\pi }}={\\frac {3\\times 19\\times 2\\,324\\,779}{4\\times 10^{41}\\pi }}\\,\\mathrm {J} \\cdot \\mathrm {s} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mi>h</mi>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>3</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>19</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <mn>2</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>324</mn>\n              <mspace width=\"thinmathspace\" />\n              <mn>779</mn>\n            </mrow>\n            <mrow>\n              <mn>4</mn>\n              <mo>&#x00D7;<!-- \u00d7 --></mo>\n              <msup>\n                <mn>10</mn>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>41</mn>\n                </mrow>\n              </msup>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">J</mi>\n        </mrow>\n        <mo>&#x22C5;<!-- \u22c5 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">s</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\hbar ={\\frac {h}{2\\pi }}={\\frac {3\\times 19\\times 2\\,324\\,779}{4\\times 10^{41}\\pi }}\\,\\mathrm {J} \\cdot \\mathrm {s} }</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\hbar }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\hbar }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q2152581",
+    "label": "classical electron radius",
+    "description": "physical constant providing length scale to interatomic interactions",
+    "synonyms": [
+      "electron radius",
+      "Lorentz radius",
+      "Thomson scattering length"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:re"
+    ],
+    "value": "2.8179403262",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle r_{\\mathrm {e} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}m_{\\mathrm {e} }c_{0}^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>r</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msup>\n              <mi>e</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msubsup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msubsup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle r_{\\mathrm {e} }={\\frac {e^{2}}{4\\pi \\varepsilon _{0}m_{\\mathrm {e} }c_{0}^{2}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle r_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>r</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle r_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q2265632",
+    "label": "magnetic flux quantum",
+    "description": "quantized unit of magnetic flux threading a loop in a bulk superconductor",
+    "synonyms": [
+      "flux quantum"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:flxquhs2e"
+    ],
+    "value": "0.000000000000002067833848",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Phi _{0}={\\frac {h}{2e}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mi>h</mi>\n            <mrow>\n              <mn>2</mn>\n              <mi>e</mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Phi _{0}={\\frac {h}{2e}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Phi _{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Phi _{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q2912520",
+    "label": "proton-to-electron mass ratio",
+    "description": "",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:mpsme"
+    ],
+    "value": "1836.15267389",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {p} }/m_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mo>/</mo>\n        </mrow>\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {p} }/m_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q3109934",
+    "label": "neutron magnetic dipole moment",
+    "description": "intrinsic magnetic dipole moment of neutrons",
+    "synonyms": [
+      "neutron magnetic moment"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:munn"
+    ],
+    "value": "-0.0000000000000000000000000096623651",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q3814108",
+    "label": "electron mass",
+    "description": "mass of a stationary electron",
+    "synonyms": [
+      "electron rest mass"
+    ],
+    "xrefs": [
+      "goldbook:E02008",
+      "nist.codata:me"
+    ],
+    "value": "0.00000000000000000000000000000091093837015",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q4516306",
+    "label": "von K\u00e1rm\u00e1n constant",
+    "description": "physical constant in hydraulics",
+    "synonyms": [
+      "K\u00e1rm\u00e1n's constant"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "0.4",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q4817337",
+    "label": "unified atomic mass constant",
+    "description": "a twelfth of the mass of a carbon-12 atom in its ground state",
+    "synonyms": [
+      "atomic mass constant"
+    ],
+    "xrefs": [
+      "goldbook:A00497",
+      "nist.codata:u"
+    ],
+    "value": "0.0000000000000000000000000016605390666",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {u} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">u</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {u} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q6895682",
+    "label": "molar mass constant",
+    "description": "",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:mu"
+    ],
+    "value": "0.00099999999965",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle M_{\\text{u}}=N_{\\text{A}}m_{\\text{u}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>M</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>u</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>A</mtext>\n          </mrow>\n        </msub>\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>u</mtext>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle M_{\\text{u}}=N_{\\text{A}}m_{\\text{u}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle M_{\\mathrm {u} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>M</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">u</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle M_{\\mathrm {u} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q7196620",
+    "label": "pion decay constant",
+    "description": "physical constant",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q7252077",
+    "label": "proton gyromagnetic ratio",
+    "description": "",
+    "synonyms": [
+      "gyromagnetic coefficient of the proton",
+      "gyromagnetic ratio of the proton",
+      "magnetogyric ratio of the proton"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gammap"
+    ],
+    "value": "267522187.44",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q9855158",
+    "label": "Coulomb's constant",
+    "description": "proportionality constant in electrodynamics equations",
+    "synonyms": [
+      "electric force constant",
+      "electrostatic constant"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "8987551787.3681764",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k={\\frac {1}{4\\pi \\varepsilon _{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <mrow>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03B5;<!-- \u03b5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k={\\frac {1}{4\\pi \\varepsilon _{0}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>K</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k_{\\mathrm {C} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>k</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k_{\\mathrm {C} }}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>k</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle k}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>k</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle k}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q10843113",
+    "label": "Wien wavelength displacement law constant",
+    "description": "constant in Wien's displacement law",
+    "synonyms": [
+      "third radiation constant",
+      "Wien constant",
+      "Wien's displacement constant"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:bwien"
+    ],
+    "value": "0.00289771955",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle b={\\frac {hc}{k(5+W_{0}(-5e^{-5}))}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>b</mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mi>h</mi>\n              <mi>c</mi>\n            </mrow>\n            <mrow>\n              <mi>k</mi>\n              <mo stretchy=\"false\">(</mo>\n              <mn>5</mn>\n              <mo>+</mo>\n              <msub>\n                <mi>W</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mo stretchy=\"false\">(</mo>\n              <mo>&#x2212;<!-- \u2212 --></mo>\n              <mn>5</mn>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mo>&#x2212;<!-- \u2212 --></mo>\n                  <mn>5</mn>\n                </mrow>\n              </msup>\n              <mo stretchy=\"false\">)</mo>\n              <mo stretchy=\"false\">)</mo>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle b={\\frac {hc}{k(5+W_{0}(-5e^{-5}))}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle b}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>b</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle b}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q11282513",
+    "label": "Einstein's constant",
+    "description": "physical constant occurring in Einstein's equations (c^2 convention)",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "0.000000000000000000000000018664",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <mi>G</mi>\n            </mrow>\n            <msup>\n              <mi>c</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>2</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{2}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q12472160",
+    "label": "Angstrom star",
+    "description": "unit of length; equals 1.000\u2009014\u200998(90) angstrom",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:angstar"
+    ],
+    "value": "0.000000000100001495",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {\\AA} ^{*}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msup>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mo>&#xC5;</mo>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mo>&#x2217;<!-- \u2217 --></mo>\n          </mrow>\n        </msup>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {\\AA} ^{*}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q13400897",
+    "label": "standard acceleration of free fall",
+    "description": "standard gravitational acceleration on Earth's surface",
+    "synonyms": [
+      "g",
+      "g-force",
+      "acceleration due to gravity on Earth",
+      "g_0",
+      "g_n",
+      "g's",
+      "gee",
+      "gravities",
+      "standard acceleration of gravity",
+      "standard gravity"
+    ],
+    "xrefs": [
+      "goldbook:S05905",
+      "nist.codata:gn"
+    ],
+    "value": "9.80665",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>g</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle g}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>g</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle g}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q13534105",
+    "label": "electron magnetic dipole moment",
+    "description": "spin of an electron",
+    "synonyms": [
+      "electron magnetic moment"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:muem"
+    ],
+    "value": "-0.0000000000000000000000092847647043",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\boldsymbol {\\mu }}={\\frac {-e}{2m_{\\text{e}}}}\\,\\mathbf {L} }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold-italic\">&#x03BC;<!-- \u03bc --></mi>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mo>&#x2212;<!-- \u2212 --></mo>\n              <mi>e</mi>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mtext>e</mtext>\n                </mrow>\n              </msub>\n            </mrow>\n          </mfrac>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold\">L</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\boldsymbol {\\mu }}={\\frac {-e}{2m_{\\text{e}}}}\\,\\mathbf {L} }</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q13542672",
+    "label": "Rydberg energy",
+    "description": "physical constant equal to the ionization energy of the hydrogen atom in a simplified Bohr model",
+    "synonyms": [
+      "rydberg"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:rydhcj"
+    ],
+    "value": "0.0000000000000000021798723611035",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mn>1</mn>\n        <mspace width=\"thinmathspace\" />\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">R</mi>\n          <mi mathvariant=\"normal\">y</mi>\n        </mrow>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <msub>\n                <mi>m</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mrow class=\"MJX-TeXAtom-ORD\">\n                    <mi mathvariant=\"normal\">e</mi>\n                  </mrow>\n                </mrow>\n              </msub>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>4</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mrow>\n              <mn>2</mn>\n              <mo stretchy=\"false\">(</mo>\n              <mn>4</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <msub>\n                <mi>&#x03F5;<!-- \u03f5 --></mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>0</mn>\n                </mrow>\n              </msub>\n              <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n              <msup>\n                <mo stretchy=\"false\">)</mo>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle 1\\,\\mathrm {Ry} ={\\frac {m_{\\mathrm {e} }e^{4}}{2(4\\pi \\epsilon _{0}\\hbar )^{2}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": []
+  },
+  {
+    "curie": "Q13570090",
+    "label": "conductance quantum",
+    "description": "quantized unit of electrical conductance",
+    "synonyms": [
+      "G0"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:conqu2e2sh"
+    ],
+    "value": "0.00007748091729",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle G_{0}={\\frac {2e^{2}}{h}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>G</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>2</mn>\n              <msup>\n                <mi>e</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>2</mn>\n                </mrow>\n              </msup>\n            </mrow>\n            <mi>h</mi>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle G_{0}={\\frac {2e^{2}}{h}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle G_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>G</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle G_{0}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q17076647",
+    "label": "proton magnetic dipole moment",
+    "description": "",
+    "synonyms": [
+      "proton magnetic moment"
+    ],
+    "xrefs": [
+      "goldbook:P04911",
+      "nist.codata:mup"
+    ],
+    "value": "0.0000000000000000000000000141060679736",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mu _{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BC;<!-- \u03bc --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mu _{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q28003216",
+    "label": "Planck acceleration",
+    "description": "acceleration from zero to the speed of light in one Planck time",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "5560800000000000000000000000000000000000000000000000",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{\\text{P}}={\\sqrt {\\frac {c^{7}}{\\hbar G}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mtext>P</mtext>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msqrt>\n            <mfrac>\n              <msup>\n                <mi>c</mi>\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mn>7</mn>\n                </mrow>\n              </msup>\n              <mrow>\n                <mi class=\"MJX-variant\">&#x210F;<!-- \u210f --></mi>\n                <mi>G</mi>\n              </mrow>\n            </mfrac>\n          </msqrt>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{\\text{P}}={\\sqrt {\\frac {c^{7}}{\\hbar G}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle a_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>a</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle a_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q69189081",
+    "label": "Avogadro number",
+    "description": "dimensionless number corresponding to Avogadro's constant (which has units of inverse mole)",
+    "synonyms": [
+      "602",
+      "214",
+      "076",
+      "000",
+      "000",
+      "000",
+      "000",
+      "000",
+      "602214076000000000000000",
+      "Avogadro's number",
+      "602 Sextillion",
+      "602.214 Sextillion",
+      "602.214e21",
+      "602e21",
+      "6.02214e23",
+      "6.02e23"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "602214076000000000000000",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N_{0}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>N</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>0</mn>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N_{0}}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle N}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>N</mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle N}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q92605166",
+    "label": "Josephson constant",
+    "description": "the inverse of the flux quantum",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:kjos"
+    ],
+    "value": "483597.848416984",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }={\\frac {1}{\\Phi _{0}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mn>1</mn>\n            <msub>\n              <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>0</mn>\n              </mrow>\n            </msub>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }={\\frac {1}{\\Phi _{0}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q92605166",
+    "label": "Josephson constant",
+    "description": "the inverse of the flux quantum",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:kjos"
+    ],
+    "value": "483597.848416984",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }={\\frac {2e}{h}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>2</mn>\n              <mi>e</mi>\n            </mrow>\n            <mi>h</mi>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }={\\frac {2e}{h}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {J} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">J</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {J} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q92894650",
+    "label": "Einstein's constant",
+    "description": "physical constant occurring in Einstein's equations (c^4 convention)",
+    "synonyms": [
+      "\ud835\udf52"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{4}}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n        <mo>=</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <mrow>\n              <mn>8</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n              <mi>G</mi>\n            </mrow>\n            <msup>\n              <mi>c</mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mn>4</mn>\n              </mrow>\n            </msup>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa ={\\frac {8\\pi G}{c^{4}}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\kappa }\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi>&#x03BA;<!-- \u03ba --></mi>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\kappa }</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q94196529",
+    "label": "unperturbed ground state hyperfine transition frequency of the caesium 133 atom",
+    "description": "physical constant used to define the second, equal to 9.19263177 GHz by definition",
+    "synonyms": [
+      "hyperfine transition frequency of Cs-133"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:nucs"
+    ],
+    "value": "9192631770",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Delta \\nu _{\\mathrm {Cs} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mi mathvariant=\"normal\">&#x0394;<!-- \u0394 --></mi>\n        <msub>\n          <mi>&#x03BD;<!-- \u03bd --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n              <mi mathvariant=\"normal\">s</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Delta \\nu _{\\mathrm {Cs} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q94199486",
+    "label": "luminous efficacy of monochromatic radiation of frequency 540 \u00d7 10\u00b9\u00b2 Hz",
+    "description": "physical constant",
+    "synonyms": [
+      "luminous efficacy for monochromatic radiation of frequency 540 \u00d7 10\u00b9\u00b2 Hz"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:kcd"
+    ],
+    "value": "683",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle K_{\\mathrm {cd} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>K</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">c</mi>\n              <mi mathvariant=\"normal\">d</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle K_{\\mathrm {cd} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q96440139",
+    "label": "alpha particle mass",
+    "description": "physical constant",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:mal"
+    ],
+    "value": "0.0000000000000000000000000066446573357",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\alpha }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\alpha }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q97060889",
+    "label": "weak mixing angle constant",
+    "description": "physical constant",
+    "synonyms": [
+      "weak mixing angle"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:sin2th"
+    ],
+    "value": "0.2229",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\sin ^{2}{\\theta _{\\mathrm {W} }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msup>\n          <mi>sin</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>2</mn>\n          </mrow>\n        </msup>\n        <mo>&#x2061;<!-- \u2061 --></mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <msub>\n            <mi>&#x03B8;<!-- \u03b8 --></mi>\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mi mathvariant=\"normal\">W</mi>\n              </mrow>\n            </mrow>\n          </msub>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\sin ^{2}{\\theta _{\\mathrm {W} }}}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q97275155",
+    "label": "proton mass",
+    "description": "physical constant",
+    "synonyms": [
+      "proton rest mass"
+    ],
+    "xrefs": [
+      "goldbook:P04914",
+      "nist.codata:mp"
+    ],
+    "value": "0.00000000000000000000000000167262192369",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q97543076",
+    "label": "electron gyromagnetic ratio",
+    "description": "physical constant",
+    "synonyms": [
+      "gyromagnetic coefficient of the electron",
+      "gyromagnetic ratio of the electron",
+      "magnetogyric ratio of the electron"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gammae"
+    ],
+    "value": "176085963023",
+    "formula": "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\boldsymbol {\\mu }}=\\gamma _{\\mathrm {e} }{\\boldsymbol {J}}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold-italic\">&#x03BC;<!-- \u03bc --></mi>\n        </mrow>\n        <mo>=</mo>\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"bold-italic\">J</mi>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\boldsymbol {\\mu }}=\\gamma _{\\mathrm {e} }{\\boldsymbol {J}}}</annotation>\n  </semantics>\n</math>",
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q97967308",
+    "label": "electron Compton wavelength",
+    "description": "",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:ecomwl"
+    ],
+    "value": "0.00000000000242631023867",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\lambda _{\\mathrm {C} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03BB;<!-- \u03bb --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">C</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\lambda _{\\mathrm {C} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q98000454",
+    "label": "neutron mass",
+    "description": "",
+    "synonyms": [
+      "neutron rest mass"
+    ],
+    "xrefs": [
+      "goldbook:N04120",
+      "nist.codata:mn"
+    ],
+    "value": "0.00000000000000000000000000167492749804",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q98380812",
+    "label": "Planck magnetic flux density",
+    "description": "",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "215000000000000000000000000000000000000000000000000000",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle B_{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>B</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle B_{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q98380823",
+    "label": "Planck magnetic flux",
+    "description": "",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": "0.000000000000000056227",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\Phi _{\\mathrm {P} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi mathvariant=\"normal\">&#x03A6;<!-- \u03a6 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">P</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\Phi _{\\mathrm {P} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q99476928",
+    "label": "gram-force",
+    "description": "unit of force",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:"
+    ],
+    "value": null,
+    "formula": null,
+    "symbols": []
+  },
+  {
+    "curie": "Q106589812",
+    "label": "reduced electron gyromagnetic ratio",
+    "description": "",
+    "synonyms": [
+      "electron reduced gyromagnetic ratio",
+      "reduced gyromagnetic coefficient of the electron",
+      "reduced gyromagnetic ratio of the electron",
+      "reduced magnetogyric ratio of the electron"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gammaebar"
+    ],
+    "value": "28024.9514242",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {e} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">e</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {e} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {e} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">e</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {e} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q106589932",
+    "label": "reduced proton gyromagnetic ratio",
+    "description": "",
+    "synonyms": [
+      "proton reduced gyromagnetic ratio",
+      "reduced gyromagnetic coefficient of the proton",
+      "reduced gyromagnetic ratio of the proton",
+      "reduced magnetogyric ratio of the proton"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gammapbar"
+    ],
+    "value": "42.577478518",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {p} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">p</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {p} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {p} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">p</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {p} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q106589964",
+    "label": "neutron gyromagnetic ratio",
+    "description": "",
+    "synonyms": [
+      "gyromagnetic coefficient of the neutron",
+      "gyromagnetic ratio of the of the neutron",
+      "magnetogyric ratio of the neutron"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gamman"
+    ],
+    "value": "183247171",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\gamma _{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>&#x03B3;<!-- \u03b3 --></mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\gamma _{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q106589981",
+    "label": "neutron reduced gyromagnetic ratio",
+    "description": "",
+    "synonyms": [
+      "reduced gyromagnetic coefficient of the neutron",
+      "reduced gyromagnetic ratio of the neutron",
+      "reduced magnetogyric ratio of the neutron",
+      "reduced neutron gyromagnetic ratio"
+    ],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:gammanbar"
+    ],
+    "value": "29.1646931",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\frac {\\gamma _{\\mathrm {n} }}{2\\pi }}}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mfrac>\n            <msub>\n              <mi>&#x03B3;<!-- \u03b3 --></mi>\n              <mrow class=\"MJX-TeXAtom-ORD\">\n                <mrow class=\"MJX-TeXAtom-ORD\">\n                  <mi mathvariant=\"normal\">n</mi>\n                </mrow>\n              </mrow>\n            </msub>\n            <mrow>\n              <mn>2</mn>\n              <mi>&#x03C0;<!-- \u03c0 --></mi>\n            </mrow>\n          </mfrac>\n        </mrow>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\frac {\\gamma _{\\mathrm {n} }}{2\\pi }}}</annotation>\n  </semantics>\n</math>",
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {n} }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mover>\n                <mi>&#x03B3;<!-- \u03b3 --></mi>\n                <mo stretchy=\"false\">&#x007E;<!-- ~ --></mo>\n              </mover>\n            </mrow>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi mathvariant=\"normal\">n</mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle {\\tilde {\\gamma }}_{\\mathrm {n} }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q106764378",
+    "label": "muon mass",
+    "description": "physical constant",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:mmu"
+    ],
+    "value": "0.0000000000000000000000000001883531627",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {\\mu } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03BC;<!-- \u03bc --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {\\mu } }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q106764397",
+    "label": "tau mass",
+    "description": "physical constant",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:mtau"
+    ],
+    "value": "0.00000000000000000000000000316754",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle m_{\\mathrm {\\tau } }}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <msub>\n          <mi>m</mi>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mrow class=\"MJX-TeXAtom-ORD\">\n              <mi>&#x03C4;<!-- \u03c4 --></mi>\n            </mrow>\n          </mrow>\n        </msub>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle m_{\\mathrm {\\tau } }}</annotation>\n  </semantics>\n</math>"
+    ]
+  },
+  {
+    "curie": "Q108899308",
+    "label": "copper x unit",
+    "description": "unit of length",
+    "synonyms": [],
+    "xrefs": [
+      "goldbook:",
+      "nist.codata:xucukalph1"
+    ],
+    "value": "0.000000000000100207697",
+    "formula": null,
+    "symbols": [
+      "<math xmlns=\"http://www.w3.org/1998/Math/MathML\" display=\"block\" alttext=\"{\\displaystyle \\mathrm {xu} (\\mathrm {Cu} \\,\\mathrm {K\\alpha } _{1})}\">\n  <semantics>\n    <mrow class=\"MJX-TeXAtom-ORD\">\n      <mstyle displaystyle=\"true\" scriptlevel=\"0\">\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">x</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mo stretchy=\"false\">(</mo>\n        <mrow class=\"MJX-TeXAtom-ORD\">\n          <mi mathvariant=\"normal\">C</mi>\n          <mi mathvariant=\"normal\">u</mi>\n        </mrow>\n        <mspace width=\"thinmathspace\" />\n        <msub>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mi mathvariant=\"normal\">K</mi>\n            <mi>&#x03B1;<!-- \u03b1 --></mi>\n          </mrow>\n          <mrow class=\"MJX-TeXAtom-ORD\">\n            <mn>1</mn>\n          </mrow>\n        </msub>\n        <mo stretchy=\"false\">)</mo>\n      </mstyle>\n    </mrow>\n    <annotation encoding=\"application/x-tex\">{\\displaystyle \\mathrm {xu} (\\mathrm {Cu} \\,\\mathrm {K\\alpha } _{1})}</annotation>\n  </semantics>\n</math>"
+    ]
+  }
+]


### PR DESCRIPTION
This PR does the following:

1. Gets physical constants, their values, their defining formula, and more from Wikidata via a SPARQL query
2. Incorporates them into the DKG