### PR TITLE
Improve DKG assembly of physical constants

### DIFF
--- a/mira/dkg/askemo/askemo.climate.json
+++ b/mira/dkg/askemo/askemo.climate.json
@@ -109,6 +109,24 @@
   },
   {
     "description": "",
+    "id": "askem.climate:0000202",
+    "name": "Lie derivative",
+    "parents": [
+      "askem.climate:0000009"
+    ],
+    "part_ofs": [
+      "askem.climate:0001006"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "ℒ"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "",
     "id": "askem.climate:0001001",
     "name": "Budyko Sellers",
     "parents": [
@@ -144,12 +162,33 @@
     "description": "",
     "id": "askem.climate:0001004",
     "name": "Momentum conservation equation",
+    "parents": [
+      "askem.climate:0000006"
+    ],
     "type": "class"
   },
   {
     "description": "",
     "id": "askem.climate:0001005",
     "name": "tracer conservation",
+    "parents": [
+      "askem.climate:0000006"
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Vegetation dynamics in semi-arid environments",
+    "id": "askem.climate:0001006",
+    "name": "Klausmeier",
+    "type": "class"
+  },
+  {
+    "description": "Composition of Halfar + Glen's law",
+    "id": "askem.climate:0001007",
+    "name": "Ice Dynamics",
+    "parents": [
+      "askem.climate:0000006"
+    ],
     "type": "class"
   },
   {
@@ -280,6 +319,26 @@
     ],
     "part_ofs": [
       "askem.climate:0001003"
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Water growth and dispursion in semi-arid environments",
+    "dimensionality": "kg m^-2",
+    "id": "askem.climate:0002010",
+    "name": "hydrodynamics",
+    "part_ofs": [
+      "askem.climate:0001006"
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Plant growth and dynamics in semi-arid environments",
+    "dimensionality": "kg m^-2",
+    "id": "askem.climate:0002011",
+    "name": "phytodynamics",
+    "part_ofs": [
+      "askem.climate:0001006"
     ],
     "type": "class"
   },
@@ -1019,6 +1078,118 @@
       {
         "type": "referenced_by_symbol",
         "value": "𝑆_𝑐"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "How much water is there in some area",
+    "dimensionality": "kg m^-2",
+    "id": "askem.climate:0003046",
+    "name": "water density",
+    "part_ofs": [
+      "askem.climate:0002010"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "w"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Water input to the model",
+    "dimensionality": "kg m^-2",
+    "id": "askem.climate:0003047",
+    "name": "water input",
+    "part_ofs": [
+      "askem.climate:0002010"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "a"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Also called water flow speed",
+    "dimensionality": "m s^-1",
+    "id": "askem.climate:0003048",
+    "name": "rate of water flow downhill",
+    "part_ofs": [
+      "askem.climate:0002010"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "ν"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "",
+    "id": "askem.climate:0003049",
+    "name": "change in water density in downhill direction",
+    "part_ofs": [
+      "askem.climate:0002010"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "ℒ(dX, w)"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "How much vegetable mass there is in some area",
+    "dimensionality": "kg m^-2",
+    "id": "askem.climate:0003050",
+    "name": "vegetation density",
+    "part_ofs": [
+      "askem.climate:0002011",
+      "askem.climate:0002010"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "n"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "Contributors to plant death, linear in plant density",
+    "dimensionality": "unitless",
+    "id": "askem.climate:0003051",
+    "name": "plant loss coefficient",
+    "part_ofs": [
+      "askem.climate:0002011"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "m"
+      }
+    ],
+    "type": "class"
+  },
+  {
+    "description": "",
+    "dimensionality": "kg m^-2",
+    "id": "askem.climate:0003052",
+    "name": "diffusion of vegetation",
+    "part_ofs": [
+      "askem.climate:0002011"
+    ],
+    "synonyms": [
+      {
+        "type": "referenced_by_symbol",
+        "value": "Δ(n)"
       }
     ],
     "type": "class"

--- a/mira/dkg/askemo/askemo_climate.py
+++ b/mira/dkg/askemo/askemo_climate.py
@@ -21,8 +21,7 @@ URL = (
 
 def get_askem_climate_terms() -> Dict[str, Term]:
     """Get ASKEM Climate ontology terms."""
-    # df = pd.read_csv(URL, sep="\t")
-    df = pd.read_excel("/Users/cthoyt/Downloads/ASKEM Climate Ontology.xlsx")
+    df = pd.read_csv(URL, sep="\t")
     df = df[df["curie"].notna()]
     df.columns = [c.lower() for c in df.columns]
 

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -557,6 +557,9 @@ def construct(
         node_sources[curie].add("wikidata")
         prop_predicates, prop_values = [], []
         if value:
+            prop_predicates.append("debio:0000042")
+            prop_values.append(str(value))
+        if formula:
             prop_predicates.append("debio:0000043")
             prop_values.append(str(formula))
         synonym_types, synonym_values = [], []

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -555,6 +555,7 @@ def construct(
         # TODO process mathml and make readable
         curie = f"wikidata:{wikidata_id}"
         node_sources[curie].add("wikidata")
+
         prop_predicates, prop_values = [], []
         if value:
             prop_predicates.append("debio:0000042")
@@ -562,6 +563,7 @@ def construct(
         if formula:
             prop_predicates.append("debio:0000043")
             prop_values.append(str(formula))
+
         synonym_types, synonym_values = [], []
         for syn in synonyms:
             synonym_values.append(syn)
@@ -569,11 +571,12 @@ def construct(
         for symbol in symbols:
             synonym_values.append(symbol)
             synonym_types.append("debio:0000031")
+
         nodes[curie] = NodeInfo(
             curie=curie,
             prefix="wikidata;constant",
             label=label,
-            synonyms=";".join(synonyms),
+            synonyms=";".join(synonym_values),
             synonym_types=";".join(synonym_types),
             deprecated="false",
             type="class",

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -551,7 +551,6 @@ def construct(
     for wikidata_id, label, description, synonyms, xrefs, value, formula, symbols in tqdm(
         get_physical_constant_terms(), desc="Physical Constants"
     ):
-        # TODO process mathml and make readable
         curie = f"wikidata:{wikidata_id}"
         node_sources[curie].add("wikidata")
 
@@ -559,9 +558,10 @@ def construct(
         if value:
             prop_predicates.append("debio:0000042")
             prop_values.append(str(value))
-        if formula:
-            prop_predicates.append("debio:0000043")
-            prop_values.append(str(formula))
+        # TODO process mathml and make readable
+        # if formula:
+        #     prop_predicates.append("debio:0000043")
+        #     prop_values.append(str(formula))
 
         synonym_types, synonym_values = [], []
         for syn in synonyms:

--- a/mira/dkg/construct.py
+++ b/mira/dkg/construct.py
@@ -551,7 +551,6 @@ def construct(
     for wikidata_id, label, description, synonyms, xrefs, value, formula, symbols in tqdm(
         get_physical_constant_terms(), desc="Physical Constants"
     ):
-        # TODO how to model value, formula?
         # TODO process mathml and make readable
         curie = f"wikidata:{wikidata_id}"
         node_sources[curie].add("wikidata")

--- a/mira/dkg/resources/cso.py
+++ b/mira/dkg/resources/cso.py
@@ -22,6 +22,7 @@ def get_cso_obo() -> Obo:
         description="An ontology for climate systems",
     )
     download(url=URL, path=PATH)
+    # use https://github.com/pyobo/pyobo/pull/159
     return from_obo_path(PATH, prefix="cso", default_prefix="cso", strict=False)
 
 

--- a/mira/dkg/resources/cso.py
+++ b/mira/dkg/resources/cso.py
@@ -1,3 +1,4 @@
+from pyobo import Obo
 from pyobo.reader import from_obo_path
 from pystow.utils import download
 import bioregistry
@@ -12,7 +13,7 @@ PATH = HERE.joinpath("cso.obo")
 URL = "https://raw.githubusercontent.com/cthoyt/Climate-System-Ontology-CSO/main/cso.obo"
 
 
-def get_cso_obo():
+def get_cso_obo() -> Obo:
     bioregistry.manager.synonyms["cso"] = "cso"
     bioregistry.manager.registry["cso"] = bioregistry.Resource(
         name="Climate Systems Ontology",


### PR DESCRIPTION
This PR does the following:

- Adds initial values to physical constant nodes using `debio:0000042` as a property (newly minted)
- Adds formulas to physical constant nodes using `debio:0000043` as a property (newly minted)
- Adds symbols as synonyms for physical constants
- Small cleanup of synonym type predicates in other places

When you call the API you now get

```
curl -X 'GET' \
  'http://localhost:8771/api/entity/wikidata%3AQ13534105' \
  -H 'accept: application/json'
```


```json
{
  "id": "wikidata:Q13534105",
  "name": "electron magnetic dipole moment",
  "type": "class",
  "obsolete": false,
  "description": "spin of an electron",
  "synonyms": [
    {
      "value": "electron magnetic moment",
      "type": "oboInOwl:hasExactSynonym"
    },
    {
      "value": "\\mu _{\\mathrm {e} }",
      "type": "debio:0000031"
    }
  ],
  "xrefs": [
    {
      "id": "nist.codata:muem",
      "type": "oboinowl:hasDbXref"
    }
  ],
  "labels": [
    "constant",
    "wikidata"
  ],
  "properties": {
    "debio:0000042": [
      "-0.0000000000000000000000092847647043"
    ]
  }
}
```