### PR TITLE
Remove explicit handling of u. and p. prefixes for parameters in rate laws when converting stockflow acset to MIRA template models. 

### DIFF
--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -6,7 +6,9 @@ import sympy
 
 def get_parseable_expression(s: str) -> str:
     """Return an expression that can be parsed using sympy."""
-    return s.replace('lambda', 'XXlambdaXX').replace(".", "XX_XX")
+    import re
+    s = s.replace('lambda', 'XXlambdaXX')
+    return re.sub(r'\.(?=\D)', 'XX_XX', s)
 
 
 def revert_parseable_expression(s: str) -> str:

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -6,12 +6,12 @@ import sympy
 
 def get_parseable_expression(s: str) -> str:
     """Return an expression that can be parsed using sympy."""
-    return s.replace('lambda', 'XXlambdaXX').replace(".", "X_X")
+    return s.replace('lambda', 'XXlambdaXX').replace(".", "XX_XX")
 
 
 def revert_parseable_expression(s: str) -> str:
     """Return an expression to its original form."""
-    return s.replace('XXlambdaXX', 'lambda').replace("X_X", ".")
+    return s.replace('XXlambdaXX', 'lambda').replace("XX_XX", ".")
 
 
 def safe_parse_expr(s: str, local_dict=None) -> sympy.Expr:

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -6,12 +6,12 @@ import sympy
 
 def get_parseable_expression(s: str) -> str:
     """Return an expression that can be parsed using sympy."""
-    return s.replace('lambda', 'XXlambdaXX')
+    return s.replace('lambda', 'XXlambdaXX').replace(".", "X_X")
 
 
 def revert_parseable_expression(s: str) -> str:
     """Return an expression to its original form."""
-    return s.replace('XXlambdaXX', 'lambda')
+    return s.replace('XXlambdaXX', 'lambda').replace("X_X", ".")
 
 
 def safe_parse_expr(s: str, local_dict=None) -> sympy.Expr:

--- a/mira/modeling/acsets/stockflow.py
+++ b/mira/modeling/acsets/stockflow.py
@@ -35,24 +35,6 @@ class ACSetsStockFlowModel:
             rate_law_str = (
                 str(flow.template.rate_law) if flow.template.rate_law else None
             )
-            if rate_law_str:
-                for param_key, param_obj in model.parameters.items():
-                    if param_obj.placeholder:
-                        continue
-                    index = rate_law_str.find(param_key)
-                    if index < 0:
-                        continue
-                    rate_law_str = (
-                        rate_law_str[:index] + "p." + rate_law_str[index:]
-                    )
-
-                for var_obj in model.variables.values():
-                    index = rate_law_str.find(var_obj.concept.display_name)
-                    if index < 0:
-                        continue
-                    rate_law_str = (
-                        rate_law_str[:index] + "u." + rate_law_str[index:]
-                    )
 
             flow_dict = {
                 "_id": fid,

--- a/mira/modeling/acsets/stockflow.py
+++ b/mira/modeling/acsets/stockflow.py
@@ -4,6 +4,7 @@ connections between flows.
 """
 
 __all__ = ["ACSetsStockFlowModel", "template_model_to_stockflow_ascet_json"]
+
 from mira.modeling import Model
 from mira.metamodel import *
 

--- a/mira/sources/acsets/stockflow.py
+++ b/mira/sources/acsets/stockflow.py
@@ -77,7 +77,7 @@ def template_model_from_stockflow_ascet_json(model_json) -> TemplateModel:
         expression_str = flow["ϕf"].replace(".", "_")
 
         # identify all operands in expression
-        flow_operands = re.findall(r"\b\w+(?:\.\w+)*\b", expression_str)
+        flow_operands = re.findall(r'\b\w+\b', expression_str)
 
         # get the parameters (operands that aren't a stock or a number) in the flow expression
         params_in_expr = [


### PR DESCRIPTION
This pull request removes the need to explicitly extract parameters and stocks from rate laws based on the u. and p. prefix.