### PR TITLE
Improvements to regnet export

### DIFF
--- a/mira/modeling/amr/regnet.py
+++ b/mira/modeling/amr/regnet.py
@@ -2,7 +2,8 @@
 at https://github.com/DARPA-ASKEM/Model-Representations/tree/main/petrinet.
 """
 
-__all__ = ["AMRRegNetModel", "ModelSpecification"]
+__all__ = ["AMRRegNetModel", "ModelSpecification",
+           "template_model_to_regnet_json"]
 
 
 import json
@@ -288,6 +289,21 @@ class AMRRegNetModel:
                           model_version=model_version)
         with open(fname, 'w') as fh:
             json.dump(js, fh, **kwargs)
+
+
+def template_model_to_regnet_json(tm: TemplateModel):
+    """Convert a template model to a RegNet JSON dict.
+
+    Parameters
+    ----------
+    tm :
+        The template model to convert.
+
+    Returns
+    -------
+    A JSON dict representing the RegNet model.
+    """
+    return AMRRegNetModel(Model(tm)).to_json()
 
 
 class Initial(BaseModel):

--- a/tests/test_modeling/test_regnet.py
+++ b/tests/test_modeling/test_regnet.py
@@ -2,8 +2,8 @@ from mira.sources import amr
 from mira.modeling import Model
 from mira.metamodel.ops import stratify
 
-from mira.modeling.amr.petrinet import template_model_to_petrinet_json
-from mira.modeling.amr.regnet import AMRRegNetModel
+from mira.modeling.amr.regnet import AMRRegNetModel, \
+    template_model_to_regnet_json
 
 
 def test_regnet_end_to_end():
@@ -22,5 +22,7 @@ def test_regnet_end_to_end():
     )
 
     # Smoke tests to make sure exports work
-    AMRRegNetModel(Model(model)).to_json()
-    AMRRegNetModel(Model(model_2_city)).to_json()
+    ex1 = AMRRegNetModel(Model(model)).to_json()
+    ex2 = AMRRegNetModel(Model(model_2_city)).to_json()
+    assert ex1 == template_model_to_regnet_json(model)
+    assert ex2 == template_model_to_regnet_json(model_2_city)

--- a/tests/test_modeling/test_regnet.py
+++ b/tests/test_modeling/test_regnet.py
@@ -1,0 +1,26 @@
+from mira.sources import amr
+from mira.modeling import Model
+from mira.metamodel.ops import stratify
+
+from mira.modeling.amr.petrinet import template_model_to_petrinet_json
+from mira.modeling.amr.regnet import AMRRegNetModel
+
+
+def test_regnet_end_to_end():
+    url = 'https://raw.githubusercontent.com/DARPA-ASKEM/' \
+          'Model-Representations/main/regnet/examples/lotka_volterra.json'
+
+    model = amr.regnet.model_from_url(url)
+
+    model_2_city = stratify(
+        model,
+        key="city",
+        strata=[
+            "Toronto",
+            "Montreal",
+        ],
+    )
+
+    # Smoke tests to make sure exports work
+    AMRRegNetModel(Model(model)).to_json()
+    AMRRegNetModel(Model(model_2_city)).to_json()


### PR DESCRIPTION
This PR makes improvements based on #275 (@brandomr):
- We skip conversions that cannot be represented using the regnet framework when exporting from MIRA
- Added a new `template_model_to_regnet_json` to streamline export
- Added end-to-end tests for regnets to ensure no errors in the future