### PR TITLE
Preprocess stella expressions for PySD parsing and add error handling for currently unparseable expressions

### DIFF
--- a/mira/sources/system_dynamics/pysd.py
+++ b/mira/sources/system_dynamics/pysd.py
@@ -152,6 +152,9 @@ def template_model_from_pysd_model(pysd_model, expression_map) -> TemplateModel:
         mira_initials[initial.concept.name] = initial
 
     # process parameters
+    # Currently cannot capture all parameters as some of them cannot have their expressions parsed
+    # Additionally, some auxiliary variables are added as parameters due to inability to parse
+    # the auxiliary expression and differentiate it from a parameter
     mira_parameters = {}
     for name, expression in processed_expression_map.items():
         # Sometimes parameter values reference a stock rather than being a number
@@ -168,7 +171,7 @@ def template_model_from_pysd_model(pysd_model, expression_map) -> TemplateModel:
             value = float(str(mira_initials[str_eval_expression].expression))
             is_initial = True
 
-        # Replace negative signs for placeholder parameter values for Aux structures
+        # Replace negative signs for placeholder parameter value for Aux structures
         # that cannot be parsed
         if str_eval_expression in mira_initials or (
             eval_expression != SYMPY_FLOW_RATE_PLACEHOLDER
@@ -211,7 +214,6 @@ def template_model_from_pysd_model(pysd_model, expression_map) -> TemplateModel:
                     param_unit.expression = param_unit.expression.subs(
                         old_unit_symbol, new_unit_symbol
                     )
-
     # construct transitions mapping that determine inputs and outputs states to a rate-law
     transition_map = {}
     auxiliaries = model_doc_df[

--- a/mira/sources/system_dynamics/stella.py
+++ b/mira/sources/system_dynamics/stella.py
@@ -79,7 +79,7 @@ def template_model_from_stella_model_url(url) -> TemplateModel:
         A MIRA Template Model
     """
 
-    xml_str = requests.get(url).content.decode("utf-8")
+    xml_str = requests.get(url).text
     return template_model_stella_model_string(xml_str)
 
 

--- a/mira/sources/system_dynamics/stella.py
+++ b/mira/sources/system_dynamics/stella.py
@@ -14,6 +14,7 @@ Website containing sample Stella models: https://www.vensim.com/documentation/sa
 __all__ = [
     "template_model_from_stella_model_file",
     "template_model_from_stella_model_url",
+    "process_file"
 ]
 
 import tempfile
@@ -68,14 +69,6 @@ def process_file(fname):
             xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
         if "pi" in tag.lower():
             xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-
-    # processes spaces in eqns
-    eqn_space_pattern = r"<eqn>(.*?)</eqn>"
-    xml_str = re.sub(
-        eqn_space_pattern,
-        lambda m: f'<eqn>{m.group(1).replace(" ", "")}</eqn>',
-        xml_str,
-    )
 
     # Comment preprocessing
     eqn_bracket_pattern = r"(<eqn>.*?)\{[^}]*\}(.*?</eqn>)"

--- a/mira/sources/system_dynamics/stella.py
+++ b/mira/sources/system_dynamics/stella.py
@@ -1,10 +1,13 @@
 """This module implements an API interface for retrieving Stella models by ISEE Systems
 denoted by the .xmile, .xml, or .stmx extension through a locally downloaded file or URL. We
-cannot process stella models with the .itmx extension. Additionally, the pysd library depends on
+cannot process stella models with the .itmx extension. Additionally, the PySD library depends on
 the parsimonious library which fails to parse a number of stella models with valid file
-extensions.  We then convert the Stella model into a generic pysd model object that will be
-parsed and converted to an equivalent MIRA template model. We preprocess the stella model file to
-extract variable expressions.
+extensions due to incompatible symbols and characters in equations for variables. We implemented
+preprocessing for stella models that fixes a number of these parsing
+errors when using PySD to ingest these models; however, a number of models still fail to be
+parsed by PySD's "read_xmile" method. We extract the contents of the model as a string,
+perform expression preprocessing, and then convert the Stella model into a generic pysd model
+object that will be converted to an equivalent MIRA template model.
 
 Landing page for Stella: https://www.iseesystems.com/store/products/stella-online.aspx
 
@@ -14,11 +17,10 @@ Website containing sample Stella models: https://www.vensim.com/documentation/sa
 __all__ = [
     "template_model_from_stella_model_file",
     "template_model_from_stella_model_url",
-    "process_file",
+    "template_model_stella_model_string",
 ]
 
 import tempfile
-from pathlib import Path
 import re
 
 import pysd
@@ -44,52 +46,8 @@ from mira.sources.system_dynamics.pysd import (
 PLACE_HOLDER_EQN = "<eqn>0</eqn>"
 
 
-def process_file(fname):
-    with open(fname) as f:
-        xml_str = f.read()
-
-    # commented out for current debugging
-    xml_str = xml_str.replace("\n", "")
-
-    # Conditional preprocessing
-    eqn_tags = re.findall(r"<eqn>.*?</eqn>", xml_str, re.DOTALL)
-    for tag in eqn_tags:
-        if all(word in tag.lower() for word in ["if", "then", "else"]):
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if all(word in tag.lower() for word in ["int", "mod", "(", ")"]):
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if all(word in tag.lower() for word in ["ln", "(", ")"]):
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if "sum" in tag.lower():
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if "//" in tag.lower():
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if "," in tag.lower():
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if "init" in tag.lower():
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if "nan" in tag.lower():
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-        if "pi" in tag.lower():
-            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
-
-    # Comment preprocessing
-    eqn_bracket_pattern = r"(<eqn>.*?)\{[^}]*\}(.*?</eqn>)"
-    eqn_bracket_sub = r"\1" + r"\2"
-    xml_str = re.sub(eqn_bracket_pattern, eqn_bracket_sub, xml_str)
-
-    with open(fname, "w") as f:
-        f.write(xml_str)
-
-    return fname
-
-
-def replace_backslash(name):
-    return name.replace("\\\\", "")
-
-
 def template_model_from_stella_model_file(fname) -> TemplateModel:
-    """Return a template model from a local Stella model file.
+    """Return a template model from a local Stella model file
 
     Parameters
     ----------
@@ -101,24 +59,19 @@ def template_model_from_stella_model_file(fname) -> TemplateModel:
     :
         A MIRA template model
     """
+    with open(fname) as f:
+        xml_str = f.read()
 
-    process_file(fname)
-
-    pysd_model = pysd.read_xmile(fname)
-    stella_model_file = XmileFile(fname)
-    stella_model_file.parse()
-
-    expression_map = extract_stella_variable_expressions(stella_model_file)
-    return template_model_from_pysd_model(pysd_model, expression_map)
+    return template_model_stella_model_string(xml_str)
 
 
 def template_model_from_stella_model_url(url) -> TemplateModel:
-    """Return a template model from a Stella model file provided by an url.
+    """Return a template model from a Stella model file provided by an url
 
     Parameters
     ----------
     url : str
-        The url to the Stella model file.
+        The url to the Stella model file
 
     Returns
     -------
@@ -126,16 +79,31 @@ def template_model_from_stella_model_url(url) -> TemplateModel:
         A MIRA Template Model
     """
 
-    file_extension = Path(url).suffix
-    data = requests.get(url).content
+    xml_str = requests.get(url).content.decode("utf-8")
+    return template_model_stella_model_string(xml_str)
+
+
+def template_model_stella_model_string(xml_str) -> TemplateModel:
+    """Returns a semantically equivalent template model to the stella model represented by the
+    xml string
+
+    Parameters
+    ----------
+    xml_str : The contents of the Stella model
+
+    Returns
+    -------
+    :
+        A MIRA template model
+    """
+    xml_str = process_string(xml_str)
     temp_file = tempfile.NamedTemporaryFile(
-        mode="w+b", suffix=file_extension, delete=False
+        mode="w+", suffix=".stmx", delete=False
     )
 
     with temp_file as file:
-        file.write(data)
+        file.write(xml_str)
 
-    process_file(temp_file.name)
     pysd_model = pysd.read_xmile(temp_file.name)
     stella_model_file = XmileFile(temp_file.name)
     stella_model_file.parse()
@@ -245,7 +213,7 @@ def extract_stella_variable_expressions(stella_model_file):
 
 
 def create_expression(expr_level_dict):
-    """When a variable's operators and operands are mapped, construct the string expression.
+    """When a variable's operators and operands are mapped, construct the string expression
 
     Parameters
     ----------
@@ -364,7 +332,7 @@ def parse_structures(operand, idx, name, operand_operator_per_level_var_map):
 
 def parse_aux_structure(structure):
     """If an Aux object's component method is not a reference structure, deconstruct the Aux object
-    to retrieve the primitive value that the auxiliary represents.
+    to retrieve the primitive value that the auxiliary represents
 
     Parameters
     ----------
@@ -385,3 +353,65 @@ def parse_aux_structure(structure):
         if isinstance(val, ReferenceStructure):
             val = replace_backslash(val.reference)
     return str(val)
+
+
+def process_string(xml_str):
+    """Helper method that removes incompatible characters from expressions for
+    variables such that the stella model file can be read by PySD's "read_xmile" method
+
+    Parameters
+    ----------
+    xml_str : str
+        The xml string representing the contents of the model
+
+    Returns
+    -------
+    : str
+        The xml string represent the contents of the model after expressions have been
+        preprocessed
+    """
+    xml_str = xml_str.replace("\n", "")
+
+    eqn_tags = re.findall(r"<eqn>.*?</eqn>", xml_str, re.DOTALL)
+    for tag in eqn_tags:
+        if all(word in tag.lower() for word in ["if", "then", "else"]):
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if all(word in tag.lower() for word in ["int", "mod", "(", ")"]):
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if all(word in tag.lower() for word in ["ln", "(", ")"]):
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if "sum" in tag.lower():
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if "//" in tag.lower():
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if "," in tag.lower():
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if "init" in tag.lower():
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if "nan" in tag.lower():
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+        if "pi" in tag.lower():
+            xml_str = xml_str.replace(tag, PLACE_HOLDER_EQN)
+
+    # Comment preprocessing
+    eqn_bracket_pattern = r"(<eqn>.*?)\{[^}]*\}(.*?</eqn>)"
+    eqn_bracket_sub = r"\1" + r"\2"
+    xml_str = re.sub(eqn_bracket_pattern, eqn_bracket_sub, xml_str)
+
+    return xml_str
+
+
+def replace_backslash(name):
+    """Helper method to remove backslashes from variable names
+
+    Parameters
+    ----------
+    name : str
+        The name of the variable
+
+    Returns
+    -------
+    : str
+        The name of the variable with backslashes removed
+    """
+    return name.replace("\\\\", "")

--- a/tests/test_system_dynamics.py
+++ b/tests/test_system_dynamics.py
@@ -19,6 +19,10 @@ MDL_TEA_URL = "https://raw.githubusercontent.com/SDXorg/test-models/master/sampl
 
 XMILE_SIR_URL = "https://raw.githubusercontent.com/SDXorg/test-models/master/samples/SIR/SIR.xmile"
 XMILE_TEA_URL = "https://raw.githubusercontent.com/SDXorg/test-models/master/samples/teacup/teacup.xmile"
+XMILE_COVID_URL = "https://exchange.iseesystems.com/model/isee/covid-19-model"
+XMILE_RESOURCES_POP_URL = (
+    "https://exchange.iseesystems.com/model/isee/resources-and-population"
+)
 
 HERE = Path(__file__).parent
 MDL_SIR_PATH = HERE / "SIR.mdl"
@@ -213,3 +217,126 @@ def tea_end_to_end_test(model, amr):
     assert amr_semantics_ode["initials"][0]["target"] == "teacup_temperature"
     assert float(amr_semantics_ode["initials"][0]["expression"]) == 180.0
 
+
+def test_stella_resources_pop_model():
+    tm = template_model_from_stella_model_url(XMILE_RESOURCES_POP_URL)
+    assert len(tm.initials) == 2
+    assert "natural_resources" in tm.initials
+    assert "population" in tm.initials
+
+    assert len(tm.templates) == 4
+
+    assert isinstance(tm.templates[0], NaturalProduction)
+    assert tm.templates[0].outcome.name == "population"
+
+    assert isinstance(tm.templates[1], NaturalDegradation)
+    assert tm.templates[1].subject.name == "natural_resources"
+
+    assert isinstance(tm.templates[2], NaturalDegradation)
+    assert tm.templates[2].subject.name == "population"
+
+    assert isinstance(tm.templates[3], NaturalProduction)
+    assert tm.templates[3].outcome.name == "natural_resources"
+
+
+def test_stella_covid19_model():
+    tm = template_model_from_stella_model_url(XMILE_COVID_URL)
+
+    assert len(tm.initials) == 15
+    assert "uninfected_at_risk" in tm.initials
+    assert "infected_not_contagious" in tm.initials
+    assert "asymptomatic_contagious" in tm.initials
+    assert "symptomatic_contagious" in tm.initials
+    assert "symptomatic_not_contagious" in tm.initials
+    assert "recovered" in tm.initials
+    assert "tested_infected_not_contagious" in tm.initials
+    assert "tested_asymptomatic_contagious" in tm.initials
+    assert "tested_symptomatic_contagious" in tm.initials
+    assert "tested_symptomatic_not_contagious" in tm.initials
+    assert "tested_infected" in tm.initials
+    assert "presumed_infected" in tm.initials
+    assert "cumulative_deaths" in tm.initials
+    assert "hospital_bed_days" in tm.initials
+    assert "cumulative_testing" in tm.initials
+
+    assert len(tm.templates) == 23
+
+    assert isinstance(tm.templates[0], NaturalProduction)
+    assert tm.templates[0].outcome.name == "cumulative_testing"
+
+    assert isinstance(tm.templates[1], NaturalProduction)
+    assert tm.templates[1].outcome.name == "cumulative_deaths"
+
+    assert isinstance(tm.templates[2], NaturalProduction)
+    assert tm.templates[2].outcome.name == "infected_not_contagious"
+
+    assert isinstance(tm.templates[3], NaturalConversion)
+    assert tm.templates[3].outcome.name == "symptomatic_contagious"
+
+    assert isinstance(tm.templates[4], NaturalConversion)
+    assert tm.templates[4].outcome.name == "asymptomatic_contagious"
+
+    assert isinstance(tm.templates[5], NaturalConversion)
+    assert tm.templates[5].subject.name == "tested_infected_not_contagious"
+    assert tm.templates[5].outcome.name == "tested_asymptomatic_contagious"
+
+    assert isinstance(tm.templates[6], NaturalDegradation)
+    assert tm.templates[6].subject.name == "symptomatic_contagious"
+
+    assert isinstance(tm.templates[7], NaturalProduction)
+    assert tm.templates[7].outcome.name == "hospital_bed_days"
+
+    assert isinstance(tm.templates[8], NaturalConversion)
+    assert tm.templates[8].subject.name == "symptomatic_contagious"
+    assert tm.templates[8].outcome.name == "symptomatic_not_contagious"
+
+    assert isinstance(tm.templates[9], NaturalConversion)
+    assert tm.templates[9].subject.name == "uninfected_at_risk"
+    assert tm.templates[9].outcome.name == "infected_not_contagious"
+
+    assert isinstance(tm.templates[10], NaturalDegradation)
+    assert tm.templates[10].subject.name == "symptomatic_not_contagious"
+
+    assert isinstance(tm.templates[11], NaturalProduction)
+    assert tm.templates[11].outcome.name == "presumed_infected"
+
+    assert isinstance(tm.templates[12], NaturalConversion)
+    assert tm.templates[12].subject.name == "symptomatic_not_contagious"
+    assert tm.templates[12].outcome.name == "recovered"
+
+    assert isinstance(tm.templates[13], NaturalConversion)
+    assert tm.templates[13].subject.name == "tested_asymptomatic_contagious"
+    assert tm.templates[13].outcome.name == "tested_symptomatic_contagious"
+
+    assert isinstance(tm.templates[14], NaturalDegradation)
+    assert tm.templates[14].subject.name == "tested_symptomatic_contagious"
+
+    assert isinstance(tm.templates[15], NaturalConversion)
+    assert tm.templates[15].subject.name == "tested_symptomatic_contagious"
+    assert tm.templates[15].outcome.name == "tested_symptomatic_not_contagious"
+
+    assert isinstance(tm.templates[16], NaturalDegradation)
+    assert tm.templates[16].subject.name == "tested_symptomatic_not_contagious"
+
+    assert isinstance(tm.templates[17], NaturalConversion)
+    assert tm.templates[17].subject.name == "tested_symptomatic_not_contagious"
+    assert tm.templates[17].outcome.name == "recovered"
+
+    assert isinstance(tm.templates[18], NaturalConversion)
+    assert tm.templates[18].subject.name == "asymptomatic_contagious"
+    assert tm.templates[18].outcome.name == "tested_asymptomatic_contagious"
+
+    assert isinstance(tm.templates[19], NaturalProduction)
+    assert tm.templates[19].outcome.name == "tested_infected"
+
+    assert isinstance(tm.templates[20], NaturalConversion)
+    assert tm.templates[20].subject.name == "infected_not_contagious"
+    assert tm.templates[20].outcome.name == "tested_infected_not_contagious"
+
+    assert isinstance(tm.templates[21], NaturalConversion)
+    assert tm.templates[21].subject.name == "symptomatic_contagious"
+    assert tm.templates[21].outcome.name == "tested_symptomatic_contagious"
+
+    assert isinstance(tm.templates[22], NaturalConversion)
+    assert tm.templates[22].subject.name == "symptomatic_not_contagious"
+    assert tm.templates[22].outcome.name == "tested_symptomatic_not_contagious"


### PR DESCRIPTION
This pull request preprocess expressions in Stella model files such that the PySD module can ingest these model files. Error handling is also included for currently unparseable Aux and Flow expressions for stella models. 

Currently out of the first 25 stella models listed with a valid `.stmx` file extension listed here: https://exchange.iseesystems.com/directory/isee,  21 are able to be parsed by PySD after text preprocessing. 19 of them are are able to be converted to mostly semantically equivalent MIRA template models. 2 are able to be parsed by PySD and converted to MIRA template models; however, they do not retain the correct structure of the stella model (incorrect number of templates, incorrect subject or outcome concepts). 

