### PR TITLE
Handle non-standard unicode characters in models

### DIFF
--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -3,12 +3,15 @@ __all__ = ['get_parseable_expression', 'revert_parseable_expression',
 
 import sympy
 import re
+import unicodedata
 
 
 def get_parseable_expression(s: str) -> str:
     """Return an expression that can be parsed using sympy."""
     s = s.replace('lambda', 'XXlambdaXX')
-    return re.sub(r'\.(?=\D)', 'XX_XX', s)
+    s = re.sub(r'\.(?=\D)', 'XX_XX', s)
+    s = unicodedata.normalize('NFKC', s)
+    return s
 
 
 def revert_parseable_expression(s: str) -> str:

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -241,4 +241,6 @@ def test_from_askenet_petri_mathml():
 
 
 def test_safe_parse():
-    safe_parse_expr('ϵ', local_dict={'ϵ': sympy.Symbol('ϵ')})
+    eps = 'ϵ'
+    eps_sym = sympy.Symbol(eps)
+    assert safe_parse_expr(eps, local_dict={eps: eps_sym}) == eps_sym

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -238,3 +238,7 @@ def test_from_askenet_petri_mathml():
     mathml_str = sorted_json_str(mathml_tm.dict())
     org_str = sorted_json_str(tm.dict())
     assert mathml_str == org_str
+
+
+def test_safe_parse():
+    safe_parse_expr('ϵ', local_dict={'ϵ': sympy.Symbol('ϵ')})


### PR DESCRIPTION
This PR adds handling for non-standard Unicode characters (that aren't allowed to appear in Python variable names) in models. It does this by using NFKC normalization (which Python's eval uses internally) on expression strings before parsing them into sympy Expressions. This normalization is only applied locally when parsing an expression and otherwise preserves the original model's symbols.

Fixes #281 