### PR TITLE
Process SIF models and export to regnets

### DIFF
--- a/docs/source/sources.rst
+++ b/docs/source/sources.rst
@@ -78,26 +78,32 @@ ACSets DecaExpr extraction (:py:mod:`mira.sources.acsets.decapodes.deca_expr`)
     :members:
     :show-inheritance:
 
-Utility Methods (:py:mod:`mira.sources.util`)
----------------------------------------------
-.. automodule:: mira.sources.util
-    :members:
-    :show-inheritance:
-
-Vensim (:py:mod:`mira.sources.system_dynamics.vensim`)
-------------------------------------------------------
+Vensim models (:py:mod:`mira.sources.system_dynamics.vensim`)
+-------------------------------------------------------------
 .. automodule:: mira.sources.system_dynamics.vensim
     :members:
     :show-inheritance:
 
-Stella (:py:mod:`mira.sources.system_dynamics.stella`)
-------------------------------------------------------
+Stella models (:py:mod:`mira.sources.system_dynamics.stella`)
+-------------------------------------------------------------
 .. automodule:: mira.sources.system_dynamics.stella
     :members:
     :show-inheritance:
 
-PYSD Model Parsing (:py:mod:`mira.sources.system_dynamics.pysd`)
-----------------------------------------------------------------
+PySD models (:py:mod:`mira.sources.system_dynamics.pysd`)
+---------------------------------------------------------
 .. automodule:: mira.sources.system_dynamics.pysd
+    :members:
+    :show-inheritance:
+
+SIF networks (:py:mod:`mira.sources.sif`)
+-----------------------------------------
+.. automodule:: mira.sources.sif
+    :members:
+    :show-inheritance:
+
+Utility Methods (:py:mod:`mira.sources.util`)
+---------------------------------------------
+.. automodule:: mira.sources.util
     :members:
     :show-inheritance:

--- a/mira/sources/sif.py
+++ b/mira/sources/sif.py
@@ -44,9 +44,12 @@ def template_model_from_sif_edges(edges):
                         controllers=[source_concept, target_concept],
                         outcome=target_concept)
         elif rel == 'NEGATIVE':
-            t = ControlledDegradation(
-                    controller=source_concept,
-                    subject=target_concept)
+            if source == target:
+                t = NaturalDegradation(subject=source_concept)
+            else:
+                t = ControlledDegradation(
+                        controller=source_concept,
+                        subject=target_concept)
         templates.append(t)
     tm = TemplateModel(templates=templates)
     return tm

--- a/mira/sources/sif.py
+++ b/mira/sources/sif.py
@@ -34,11 +34,15 @@ def template_model_from_sif_edges(edges):
     for source, rel, target in edges:
         source_concept = Concept(name=source)
         target_concept = Concept(name=target)
-        # TODO: handle identical source and target
         if rel == 'POSITIVE':
-            t = GroupedControlledProduction(
-                    controllers=[source_concept, target_concept],
-                    outcome=target_concept)
+            if source == target:
+                t = ControlledProduction(
+                        controller=source_concept,
+                        outcome=target_concept)
+            else:
+                t = GroupedControlledProduction(
+                        controllers=[source_concept, target_concept],
+                        outcome=target_concept)
         elif rel == 'NEGATIVE':
             t = ControlledDegradation(
                     controller=source_concept,

--- a/mira/sources/sif.py
+++ b/mira/sources/sif.py
@@ -1,0 +1,89 @@
+"""This module provides functions to create a MIRA TemplateModel from a
+Simple Interaction Format (SIF) file. The SIF format is a simple
+space-delimited format where each line represents a relationship
+between two entities. The first column is the source node, the second
+column is the relation, and the third column is the target node. The
+relation is a string that represents the type of interaction between
+the source and target nodes. SIF files are useful as a minimal representation
+of regulatory networks with positive/negative regulation."""
+
+__all__ = ['template_model_from_sif_edges',
+           'template_model_from_sif_file',
+           'template_model_from_sif_url']
+
+import requests
+from mira.metamodel import *
+
+
+def template_model_from_sif_edges(edges):
+    """Return TemplateModel from a list of SIF edges.
+
+    Parameters
+    ----------
+    edges : list
+        A list of tuples of the form (source, rel, target) where source and
+        target are strings representing the source and target nodes and rel
+        is a string representing the relation between them.
+
+    Returns
+    -------
+    TemplateModel
+        A MIRA TemplateModel.
+    """
+    templates = []
+    for source, rel, target in edges:
+        source_concept = Concept(name=source)
+        target_concept = Concept(name=target)
+        # TODO: handle identical source and target
+        if rel == 'POSITIVE':
+            t = GroupedControlledProduction(
+                    controllers=[source_concept, target_concept],
+                    outcome=target_concept)
+        elif rel == 'NEGATIVE':
+            t = ControlledDegradation(
+                    controller=source_concept,
+                    subject=target_concept)
+        templates.append(t)
+    tm = TemplateModel(templates=templates)
+    return tm
+
+
+def template_model_from_sif_file(fname):
+    """Return TemplateModel from a SIF file.
+
+    Parameters
+    ----------
+    fname : str
+        The path to the SIF file.
+
+    Returns
+    -------
+    TemplateModel
+        A MIRA TemplateModel.
+    """
+    with open(fname, 'r') as fh:
+        edges = [line.strip().split()
+                 for line in fh.readlines()
+                 if line and not line.startswith('#')]
+    return template_model_from_sif_edges(edges)
+
+
+def template_model_from_sif_url(url):
+    """Return TemplateModel from a SIF URL.
+
+    Parameters
+    ----------
+    url : str
+        The URL to the SIF file.
+
+    Returns
+    -------
+    TemplateModel
+        A MIRA TemplateModel.
+    """
+    res = requests.get(url)
+    res.raise_for_status()
+    edges = [line.strip().split()
+             for line in res.text.split('\n')
+             if line and not line.startswith('#')]
+    return template_model_from_sif_edges(edges)

--- a/scripts/covid19_diseasemaps/process_covid19_diseasemaps.py
+++ b/scripts/covid19_diseasemaps/process_covid19_diseasemaps.py
@@ -1,0 +1,25 @@
+import json
+import tqdm
+from mira.modeling.amr.regnet import template_model_to_regnet_json
+from mira.sources.sif import template_model_from_sif_url
+
+
+models = ['Apoptosis', 'Coagulation-pathway', 'ER_Stress', 'ETC', 'E_protein',
+          'HMOX1_Pathway', 'IFN-lambda', 'Interferon1', 'JNK_pathway',
+          'Kynurenine_pathway', 'NLRP3_Activation', 'Nsp14', 'Nsp4_Nsp6',
+          'Nsp9_protein', 'Orf10_Cul2_pathway', 'Orf3a', 'PAMP_signaling',
+          'Pyrimidine_deprivation', 'RTC-and-transcription',
+          'Renin_angiotensin', 'TGFB_pathway', 'Virus_replication_cycle']
+
+
+SIF_URL_BASE = ('https://git-r3lab.uni.lu/covid/models/-/raw/master/'
+                'Executable%20Modules/SBML_qual_build/sif')
+
+
+if __name__ == "__main__":
+    for model in tqdm.tqdm(models):
+        url = f'{SIF_URL_BASE}/{model}_stable.sif'
+        tm = template_model_from_sif_url(url)
+        regnet = template_model_to_regnet_json(tm)
+        with open(f'{model}.json', 'w') as fh:
+            json.dump(regnet, fh, indent=1)

--- a/tests/test_sif.py
+++ b/tests/test_sif.py
@@ -1,0 +1,16 @@
+from mira.sources.sif import template_model_from_sif_edges
+from mira.modeling.amr.regnet import template_model_to_regnet_json
+
+
+def test_sif_processing():
+    # Lotka volterra example
+    edges = [
+        ('prey', 'POSITIVE', 'predator'),
+        ('predator', 'NEGATIVE', 'prey'),
+        ('prey', 'POSITIVE', 'prey'),
+        ('predator', 'NEGATIVE', 'predator')
+    ]
+    tm = template_model_from_sif_edges(edges)
+    assert len(tm.templates) == 4
+    regnet = template_model_to_regnet_json(tm)
+    assert len(regnet['model']['edges']) == 2


### PR DESCRIPTION
This PR adds a new source module that can process SIF files into MIRA Template Models. These can (among other things) then be exported into Regnet AMRs. The PR also adds a script to process the COVID-19 Disease Maps models, exported as SIF into Regnet AMRs.