### PR TITLE
Add Regnet AMR export of COVID-19 Disease Map

### DIFF
--- a/mira/modeling/amr/regnet.py
+++ b/mira/modeling/amr/regnet.py
@@ -147,6 +147,8 @@ class AMRRegNetModel:
             self.transitions.append(transition_dict)
 
         for key, param in model.parameters.items():
+            if param.placeholder:
+                continue
             param_dict = {'id': str(key)}
             if param.value:
                 param_dict['value'] = param.value

--- a/scripts/covid19_diseasemaps/process_covid19_diseasemaps.py
+++ b/scripts/covid19_diseasemaps/process_covid19_diseasemaps.py
@@ -31,5 +31,5 @@ if __name__ == "__main__":
             references=["pubmed:34664389"]
         )
         regnet = template_model_to_regnet_json(tm)
-        with open(f'{model}.json', 'w') as fh:
+        with open(f'regnet_amr/{model}.json', 'w') as fh:
             json.dump(regnet, fh, indent=1)

--- a/scripts/covid19_diseasemaps/process_covid19_diseasemaps.py
+++ b/scripts/covid19_diseasemaps/process_covid19_diseasemaps.py
@@ -1,5 +1,6 @@
 import json
 import tqdm
+from mira.metamodel import Annotations
 from mira.modeling.amr.regnet import template_model_to_regnet_json
 from mira.sources.sif import template_model_from_sif_url
 
@@ -20,6 +21,15 @@ if __name__ == "__main__":
     for model in tqdm.tqdm(models):
         url = f'{SIF_URL_BASE}/{model}_stable.sif'
         tm = template_model_from_sif_url(url)
+        tm.annotations = Annotations(
+            name=model,
+            description=("A submodel of the COVID-10 Disease Map "
+                         f"focusing on {model}"),
+            pathogens=["ncbitaxon:2697049"],
+            diseases=["doid:0080600"],
+            hosts=["ncbitaxon:9606"],
+            references=["pubmed:34664389"]
+        )
         regnet = template_model_to_regnet_json(tm)
         with open(f'{model}.json', 'w') as fh:
             json.dump(regnet, fh, indent=1)

--- a/scripts/covid19_diseasemaps/regnet_amr/Apoptosis.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Apoptosis.json
@@ -1,0 +1,543 @@
+{
+ "header": {
+  "name": "Apoptosis",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Apoptosis",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "BAD/BBC3/BCL2L11_complex",
+    "name": "BAD/BBC3/BCL2L11_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2/MCL1/BCL2L1_complex",
+    "name": "BCL2/MCL1/BCL2L1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAX",
+    "name": "BAX",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a",
+    "name": "Orf7a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E",
+    "name": "E",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAD",
+    "name": "BAD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FAS/FASL_complex",
+    "name": "FAS/FASL_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FADD",
+    "name": "FADD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FASLG",
+    "name": "FASLG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TNF/TNFRSF1A_complex",
+    "name": "TNF/TNFRSF1A_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRADD/FADD_complex",
+    "name": "TRADD/FADD_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TNF",
+    "name": "TNF",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP8",
+    "name": "CASP8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRADD",
+    "name": "TRADD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Apoptosome_complex",
+    "name": "Apoptosome_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP9_cell_active",
+    "name": "CASP9_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CYCS",
+    "name": "CYCS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "APAF1",
+    "name": "APAF1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP9_cell",
+    "name": "CASP9_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AKT1",
+    "name": "AKT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M",
+    "name": "M",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BID",
+    "name": "BID",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK14",
+    "name": "MAPK14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a",
+    "name": "Orf3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP7",
+    "name": "CASP7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Apoptosis_phenotype",
+    "name": "Apoptosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP3",
+    "name": "CASP3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6",
+    "name": "Orf6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S",
+    "name": "S",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8a",
+    "name": "Orf8a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N",
+    "name": "N",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3b",
+    "name": "Orf3b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b",
+    "name": "Orf9b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "BAD/BBC3/BCL2L11_complex",
+    "target": "BCL2/MCL1/BCL2L1_complex",
+    "sign": false
+   },
+   {
+    "id": "t2",
+    "source": "BAX",
+    "target": "BCL2/MCL1/BCL2L1_complex",
+    "sign": false
+   },
+   {
+    "id": "t3",
+    "source": "BCL2/MCL1/BCL2L1_complex",
+    "target": "Orf7a",
+    "sign": false
+   },
+   {
+    "id": "t4",
+    "source": "BCL2/MCL1/BCL2L1_complex",
+    "target": "E",
+    "sign": false
+   },
+   {
+    "id": "t5",
+    "source": "BCL2/MCL1/BCL2L1_complex",
+    "target": "BAD",
+    "sign": false
+   },
+   {
+    "id": "t6",
+    "source": "FADD",
+    "target": "FAS/FASL_complex",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "FAS/FASL_complex",
+    "target": "FASLG",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "TRADD/FADD_complex",
+    "target": "TNF/TNFRSF1A_complex",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "TNF/TNFRSF1A_complex",
+    "target": "TNF",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "BAX",
+    "target": "BAD/BBC3/BCL2L11_complex",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "CASP8",
+    "target": "TRADD/FADD_complex",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "TRADD/FADD_complex",
+    "target": "FADD",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "CASP8",
+    "target": "FADD",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "TRADD/FADD_complex",
+    "target": "TRADD",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "CASP9_cell_active",
+    "target": "Apoptosome_complex",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "Apoptosome_complex",
+    "target": "CYCS",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "Apoptosome_complex",
+    "target": "APAF1",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "Apoptosome_complex",
+    "target": "CASP9_cell",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "Apoptosome_complex",
+    "target": "AKT1",
+    "sign": false
+   },
+   {
+    "id": "t20",
+    "source": "BAD",
+    "target": "AKT1",
+    "sign": false
+   },
+   {
+    "id": "t21",
+    "source": "CASP9_cell_active",
+    "target": "AKT1",
+    "sign": false
+   },
+   {
+    "id": "t22",
+    "source": "AKT1",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t23",
+    "source": "CYCS",
+    "target": "BAX",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "BAX",
+    "target": "BID",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "CYCS",
+    "target": "MAPK14",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "MAPK14",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "CASP8",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "Apoptosis_phenotype",
+    "target": "CASP7",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "CASP7",
+    "target": "CASP9_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "CASP3",
+    "target": "CASP9_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "CASP7",
+    "target": "CASP8",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "CASP3",
+    "target": "CASP8",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "BID",
+    "target": "CASP8",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "Apoptosis_phenotype",
+    "target": "CASP3",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "Apoptosis_phenotype",
+    "target": "Orf6",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "Apoptosis_phenotype",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "Apoptosis_phenotype",
+    "target": "Orf8a",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "Apoptosis_phenotype",
+    "target": "N",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "Apoptosis_phenotype",
+    "target": "Orf3b",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "Apoptosis_phenotype",
+    "target": "Orf9b",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Coagulation-pathway.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Coagulation-pathway.json
@@ -1,0 +1,2232 @@
+{
+ "header": {
+  "name": "Coagulation-pathway",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Coagulation-pathway",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "KNG1:KLKB1_complex",
+    "name": "KNG1:KLKB1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Kininogen",
+    "name": "Kininogen",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Kallikrein",
+    "name": "Kallikrein",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Bradykinin",
+    "name": "Bradykinin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "KLKB1",
+    "name": "KLKB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F12a",
+    "name": "F12a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Small_peptide",
+    "name": "Small_peptide",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Plasmin",
+    "name": "Plasmin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "KNG1",
+    "name": "KNG1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F5a:F10a_complex",
+    "name": "F5a:F10a_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thrombin_blood",
+    "name": "Thrombin_blood",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F10a",
+    "name": "F10a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F5a",
+    "name": "F5a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F9a",
+    "name": "F9a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F8:F9_complex",
+    "name": "F8:F9_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F8a",
+    "name": "F8a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SERPINE1",
+    "name": "SERPINE1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PLAT:SERPINE1_complex",
+    "name": "PLAT:SERPINE1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PLAT_blood_active",
+    "name": "PLAT_blood_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PLAU",
+    "name": "PLAU",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PLAT_blood",
+    "name": "PLAT_blood",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS-CoV-2_infection_phenotype",
+    "name": "SARS-CoV-2_infection_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fibrinogen_complex",
+    "name": "Fibrinogen_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAT_complex_complex",
+    "name": "TAT_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5b-9_complex_endothelium,_vascular",
+    "name": "C5b-9_complex_endothelium,_vascular",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "SERPINF2:Plasmin_complex",
+    "name": "SERPINF2:Plasmin_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F8",
+    "name": "F8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_II_simple_molecule",
+    "name": "angiotensin_II_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Antithrombin",
+    "name": "Antithrombin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PROC",
+    "name": "PROC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "D-dimer",
+    "name": "D-dimer",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TNF",
+    "name": "TNF",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL6",
+    "name": "IL6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL1B",
+    "name": "IL1B",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5a",
+    "name": "C5a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thrombomodulin",
+    "name": "Thrombomodulin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL8",
+    "name": "IL8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL2RA",
+    "name": "IL2RA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C4d",
+    "name": "C4d",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2_endothelium,_vascular",
+    "name": "ACE2_endothelium,_vascular",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fibrin_monomer",
+    "name": "Fibrin_monomer",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CRP",
+    "name": "CRP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "VWF",
+    "name": "VWF",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MASP2",
+    "name": "MASP2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "aldosterone_simple_molecule_blood",
+    "name": "aldosterone_simple_molecule_blood",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Hypokalemia_phenotype",
+    "name": "Hypokalemia_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fibrinogen:GP6_complex",
+    "name": "Fibrinogen:GP6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thrombin_blood_active",
+    "name": "Thrombin_blood_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thrombin:Thrombomodulin_complex",
+    "name": "Thrombin:Thrombomodulin_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F11",
+    "name": "F11",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F11a",
+    "name": "F11a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAFI",
+    "name": "TAFI",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5b:C6:C7:C8A:C8B:C8G_complex",
+    "name": "C5b:C6:C7:C8A:C8B:C8G_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5b:C6:C7_complex",
+    "name": "C5b:C6:C7_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C8A:C8B:C8G_complex",
+    "name": "C8A:C8B:C8G_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C3b:Bb:C3b_complex",
+    "name": "C3b:Bb:C3b_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5b",
+    "name": "C5b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C3b",
+    "name": "C3b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C3b:Bb_complex",
+    "name": "C3b:Bb_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C3a",
+    "name": "C3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5b:C6_complex",
+    "name": "C5b:C6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C7",
+    "name": "C7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Plasminogen",
+    "name": "Plasminogen",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thrombosis_phenotype_blood",
+    "name": "Thrombosis_phenotype_blood",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5b-9_deposition_phenotype",
+    "name": "C5b-9_deposition_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C9",
+    "name": "C9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C6",
+    "name": "C6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C2a:C4b_complex",
+    "name": "C2a:C4b_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C4b",
+    "name": "C4b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C2a",
+    "name": "C2a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2:Spike_complex",
+    "name": "ACE2:Spike_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS-CoV-2_viral_entry_phenotype",
+    "name": "SARS-CoV-2_viral_entry_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2_blood",
+    "name": "ACE2_blood",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S",
+    "name": "S",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SERPINF2",
+    "name": "SERPINF2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "platelet_activation_phenotype",
+    "name": "platelet_activation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GP6",
+    "name": "GP6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GP6:alpha2:beta1_complex",
+    "name": "GP6:alpha2:beta1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GP6:alpha2beta1:VWF_complex",
+    "name": "GP6:alpha2beta1:VWF_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ITGA2:ITGAB1_complex",
+    "name": "ITGA2:ITGAB1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F12",
+    "name": "F12",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F10",
+    "name": "F10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Bradykinin(1-5)",
+    "name": "Bradykinin(1-5)",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE",
+    "name": "ACE",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F9",
+    "name": "F9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Heparin_simple_molecule",
+    "name": "Heparin_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_I-7_simple_molecule",
+    "name": "angiotensin_I-7_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AGTR1_platelet",
+    "name": "AGTR1_platelet",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AGTR1_blood",
+    "name": "AGTR1_blood",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_I_simple_molecule",
+    "name": "angiotensin_I_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AGT",
+    "name": "AGT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "REN",
+    "name": "REN",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Prorenin",
+    "name": "Prorenin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "aldosterone_simple_molecule_endothelium,_vascular",
+    "name": "aldosterone_simple_molecule_endothelium,_vascular",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F5",
+    "name": "F5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Prothrombin",
+    "name": "Prothrombin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fibrin_polymer",
+    "name": "Fibrin_polymer",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAS1",
+    "name": "MAS1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NR3C2",
+    "name": "NR3C2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thrombosis_phenotype_human_host",
+    "name": "Thrombosis_phenotype_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cytokine_storm_phenotype",
+    "name": "cytokine_storm_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C5",
+    "name": "C5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C4d_deposition_phenotype",
+    "name": "C4d_deposition_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C3",
+    "name": "C3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MASP1",
+    "name": "MASP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C2b",
+    "name": "C2b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MBL2",
+    "name": "MBL2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C4",
+    "name": "C4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C4a",
+    "name": "C4a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MASP2_deposition_phenotype",
+    "name": "MASP2_deposition_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "C2",
+    "name": "C2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CFI",
+    "name": "CFI",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "septal_capillary_necrosis_phenotype",
+    "name": "septal_capillary_necrosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "apoptosis_phenotype",
+    "name": "apoptosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "platelet_aggregation_phenotype",
+    "name": "platelet_aggregation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F13a",
+    "name": "F13a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "thrombus_formation_phenotype",
+    "name": "thrombus_formation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "K+_ion",
+    "name": "K+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACTH_simple_molecule",
+    "name": "ACTH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "vascular_remodeling_phenotype",
+    "name": "vascular_remodeling_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "vascular_inflammation_phenotype",
+    "name": "vascular_inflammation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Kininogen",
+    "target": "KNG1:KLKB1_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "Kallikrein",
+    "target": "KNG1:KLKB1_complex",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "Bradykinin",
+    "target": "KNG1:KLKB1_complex",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "KNG1:KLKB1_complex",
+    "target": "KLKB1",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "F12a",
+    "target": "KLKB1",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "Small_peptide",
+    "target": "KLKB1",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "Plasmin",
+    "target": "KLKB1",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "Kallikrein",
+    "target": "KLKB1",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "KNG1:KLKB1_complex",
+    "target": "KNG1",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "Thrombin_blood",
+    "target": "F5a:F10a_complex",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "F5a:F10a_complex",
+    "target": "F10a",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "F5a:F10a_complex",
+    "target": "F5a",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "F8:F9_complex",
+    "target": "F9a",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "Small_peptide",
+    "target": "F9a",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "F10a",
+    "target": "F9a",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "F8:F9_complex",
+    "target": "F8a",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "PLAT:SERPINE1_complex",
+    "target": "SERPINE1",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "PLAT_blood_active",
+    "target": "SERPINE1",
+    "sign": false
+   },
+   {
+    "id": "t19",
+    "source": "PLAU",
+    "target": "SERPINE1",
+    "sign": false
+   },
+   {
+    "id": "t20",
+    "source": "PLAT:SERPINE1_complex",
+    "target": "PLAT_blood",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "PLAT_blood_active",
+    "target": "PLAT_blood",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "PLAT:SERPINE1_complex",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "Fibrinogen_complex",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "TAT_complex_complex",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "C5b-9_complex_endothelium,_vascular",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "SERPINF2:Plasmin_complex",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "F8",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "angiotensin_II_simple_molecule",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "Antithrombin",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t30",
+    "source": "PROC",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "D-dimer",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "TNF",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "IL6",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "IL1B",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "C5a",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "Thrombomodulin",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "IL8",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "IL2RA",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "C4d",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "ACE2_endothelium,_vascular",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t41",
+    "source": "Fibrin_monomer",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "CRP",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "VWF",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "MASP2",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "aldosterone_simple_molecule_blood",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "Hypokalemia_phenotype",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "Fibrinogen:GP6_complex",
+    "target": "Fibrinogen_complex",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "Fibrin_monomer",
+    "target": "Fibrinogen_complex",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "TAT_complex_complex",
+    "target": "Antithrombin",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "Small_peptide",
+    "target": "Antithrombin",
+    "sign": false
+   },
+   {
+    "id": "t51",
+    "source": "F10a",
+    "target": "Antithrombin",
+    "sign": false
+   },
+   {
+    "id": "t52",
+    "source": "Thrombin_blood_active",
+    "target": "Antithrombin",
+    "sign": false
+   },
+   {
+    "id": "t53",
+    "source": "TAT_complex_complex",
+    "target": "Thrombin_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "Thrombin:Thrombomodulin_complex",
+    "target": "Thrombin_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "Small_peptide",
+    "target": "Thrombin_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "F11",
+    "target": "Thrombin_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "F11a",
+    "target": "Thrombin_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "F8a",
+    "target": "Thrombin_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "TAFI",
+    "target": "Thrombin_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "F5a",
+    "target": "Thrombin:Thrombomodulin_complex",
+    "sign": false
+   },
+   {
+    "id": "t61",
+    "source": "Fibrin_monomer",
+    "target": "Thrombin:Thrombomodulin_complex",
+    "sign": false
+   },
+   {
+    "id": "t62",
+    "source": "Thrombin:Thrombomodulin_complex",
+    "target": "Thrombomodulin",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "C5b-9_complex_endothelium,_vascular",
+    "target": "C5b:C6:C7:C8A:C8B:C8G_complex",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "C5b:C6:C7:C8A:C8B:C8G_complex",
+    "target": "C5b:C6:C7_complex",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "C5b:C6:C7:C8A:C8B:C8G_complex",
+    "target": "C8A:C8B:C8G_complex",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "C5a",
+    "target": "C3b:Bb:C3b_complex",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "C5b",
+    "target": "C3b:Bb:C3b_complex",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "C3b:Bb:C3b_complex",
+    "target": "C3b",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "C3b:Bb:C3b_complex",
+    "target": "C3b:Bb_complex",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "C3a",
+    "target": "C3b:Bb_complex",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "C3b",
+    "target": "C3b:Bb_complex",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "C5b:C6:C7_complex",
+    "target": "C5b:C6_complex",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "C5b:C6:C7_complex",
+    "target": "C7",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "Plasminogen",
+    "target": "C5b-9_complex_endothelium,_vascular",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "C5b-9_complex_endothelium,_vascular",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "C5b-9_deposition_phenotype",
+    "target": "C5b-9_complex_endothelium,_vascular",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "C5b-9_complex_endothelium,_vascular",
+    "target": "C9",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "C5b:C6_complex",
+    "target": "C5b",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "C5b:C6_complex",
+    "target": "C6",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "C5a",
+    "target": "C2a:C4b_complex",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "C3a",
+    "target": "C2a:C4b_complex",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "C3b",
+    "target": "C2a:C4b_complex",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "C5b",
+    "target": "C2a:C4b_complex",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "C2a:C4b_complex",
+    "target": "C4b",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "C4d",
+    "target": "C4b",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "C2a:C4b_complex",
+    "target": "C2a",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "SARS-CoV-2_viral_entry_phenotype",
+    "target": "ACE2:Spike_complex",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "ACE2:Spike_complex",
+    "target": "ACE2_blood",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "ACE2_endothelium,_vascular",
+    "target": "ACE2_blood",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "ACE2:Spike_complex",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "C5b-9_complex_endothelium,_vascular",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "C4d",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "SERPINF2:Plasmin_complex",
+    "target": "Plasmin",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "D-dimer",
+    "target": "Plasmin",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "C5a",
+    "target": "Plasmin",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "SERPINF2:Plasmin_complex",
+    "target": "SERPINF2",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "platelet_activation_phenotype",
+    "target": "Fibrinogen:GP6_complex",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "Fibrinogen:GP6_complex",
+    "target": "GP6",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "GP6:alpha2:beta1_complex",
+    "target": "GP6",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "platelet_activation_phenotype",
+    "target": "GP6:alpha2beta1:VWF_complex",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "GP6:alpha2beta1:VWF_complex",
+    "target": "GP6:alpha2:beta1_complex",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "GP6:alpha2beta1:VWF_complex",
+    "target": "VWF",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "VWF",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "GP6:alpha2:beta1_complex",
+    "target": "ITGA2:ITGAB1_complex",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "F11",
+    "target": "F12a",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "F11a",
+    "target": "F12a",
+    "sign": true
+   },
+   {
+    "id": "t108",
+    "source": "Kallikrein",
+    "target": "F12a",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "F12a",
+    "target": "F12",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "Small_peptide",
+    "target": "F12",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "Small_peptide",
+    "target": "F10",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "F10a",
+    "target": "F10",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "Small_peptide",
+    "target": "F8",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "F8a",
+    "target": "F8",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "Small_peptide",
+    "target": "PROC",
+    "sign": false
+   },
+   {
+    "id": "t116",
+    "source": "F8a",
+    "target": "PROC",
+    "sign": false
+   },
+   {
+    "id": "t117",
+    "source": "F5a",
+    "target": "PROC",
+    "sign": false
+   },
+   {
+    "id": "t118",
+    "source": "PLAT_blood_active",
+    "target": "PROC",
+    "sign": false
+   },
+   {
+    "id": "t119",
+    "source": "Small_peptide",
+    "target": "Bradykinin",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "PLAT_blood_active",
+    "target": "Bradykinin",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "Bradykinin(1-5)",
+    "target": "Bradykinin",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "Small_peptide",
+    "target": "ACE",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "angiotensin_II_simple_molecule",
+    "target": "ACE",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "Bradykinin(1-5)",
+    "target": "ACE",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "F9a",
+    "target": "F11a",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "Plasmin",
+    "target": "F11a",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "F9a",
+    "target": "F9",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "Thrombin_blood_active",
+    "target": "Thrombin_blood",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "Fibrin_monomer",
+    "target": "Thrombin_blood",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "Thrombin_blood_active",
+    "target": "Heparin_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "PLAT_blood_active",
+    "target": "angiotensin_II_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "SERPINE1",
+    "target": "angiotensin_II_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "angiotensin_II_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "angiotensin_I-7_simple_molecule",
+    "target": "angiotensin_II_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "AGTR1_platelet",
+    "target": "angiotensin_II_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "aldosterone_simple_molecule_blood",
+    "target": "angiotensin_II_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "AGTR1_blood",
+    "target": "angiotensin_II_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "angiotensin_II_simple_molecule",
+    "target": "angiotensin_I_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t139",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "AGT",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "REN",
+    "sign": true
+   },
+   {
+    "id": "t141",
+    "source": "REN",
+    "target": "Prorenin",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "REN",
+    "target": "Kallikrein",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "ACE",
+    "target": "aldosterone_simple_molecule_blood",
+    "sign": true
+   },
+   {
+    "id": "t144",
+    "source": "SERPINE1",
+    "target": "aldosterone_simple_molecule_blood",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "aldosterone_simple_molecule_endothelium,_vascular",
+    "target": "aldosterone_simple_molecule_blood",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "Hypokalemia_phenotype",
+    "target": "aldosterone_simple_molecule_blood",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "F5a",
+    "target": "F5",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "Thrombin_blood",
+    "target": "Prothrombin",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "D-dimer",
+    "target": "Fibrin_polymer",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "D-dimer",
+    "target": "TAFI",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "Plasmin",
+    "target": "Plasminogen",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "Plasmin",
+    "target": "PLAT_blood_active",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "Plasmin",
+    "target": "PLAU",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "PLAT_blood_active",
+    "target": "angiotensin_I-7_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t155",
+    "source": "SERPINE1",
+    "target": "angiotensin_I-7_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t156",
+    "source": "MAS1",
+    "target": "angiotensin_I-7_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "SERPINE1",
+    "target": "IL6",
+    "sign": true
+   },
+   {
+    "id": "t158",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "IL6",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "SERPINE1",
+    "target": "AGTR1_blood",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "aldosterone_simple_molecule_blood",
+    "target": "AGTR1_blood",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "NR3C2",
+    "target": "AGTR1_blood",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "Thrombosis_phenotype_human_host",
+    "target": "AGTR1_blood",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "TNF",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "TNF",
+    "target": "cytokine_storm_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t165",
+    "source": "IL6",
+    "target": "cytokine_storm_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t166",
+    "source": "IL1B",
+    "target": "cytokine_storm_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t167",
+    "source": "IL8",
+    "target": "cytokine_storm_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t168",
+    "source": "IL2RA",
+    "target": "cytokine_storm_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t169",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "IL1B",
+    "sign": true
+   },
+   {
+    "id": "t170",
+    "source": "C5a",
+    "target": "C5",
+    "sign": true
+   },
+   {
+    "id": "t171",
+    "source": "C5b",
+    "target": "C5",
+    "sign": true
+   },
+   {
+    "id": "t172",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "IL8",
+    "sign": true
+   },
+   {
+    "id": "t173",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "IL2RA",
+    "sign": true
+   },
+   {
+    "id": "t174",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "CRP",
+    "sign": true
+   },
+   {
+    "id": "t175",
+    "source": "Thrombosis_phenotype_blood",
+    "target": "C4d",
+    "sign": true
+   },
+   {
+    "id": "t176",
+    "source": "C4d_deposition_phenotype",
+    "target": "C4d",
+    "sign": true
+   },
+   {
+    "id": "t177",
+    "source": "C3a",
+    "target": "C3",
+    "sign": true
+   },
+   {
+    "id": "t178",
+    "source": "C3b",
+    "target": "C3",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "C2a",
+    "target": "MASP1",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "C2b",
+    "target": "MASP1",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "MASP1",
+    "target": "MBL2",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "C4a",
+    "target": "C4",
+    "sign": true
+   },
+   {
+    "id": "t183",
+    "source": "C4b",
+    "target": "C4",
+    "sign": true
+   },
+   {
+    "id": "t184",
+    "source": "C4a",
+    "target": "MASP2",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "C4b",
+    "target": "MASP2",
+    "sign": true
+   },
+   {
+    "id": "t186",
+    "source": "MASP2_deposition_phenotype",
+    "target": "MASP2",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "C2a",
+    "target": "C2",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "C2b",
+    "target": "C2",
+    "sign": true
+   },
+   {
+    "id": "t189",
+    "source": "C4d",
+    "target": "CFI",
+    "sign": true
+   },
+   {
+    "id": "t190",
+    "source": "septal_capillary_necrosis_phenotype",
+    "target": "C4d_deposition_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t191",
+    "source": "apoptosis_phenotype",
+    "target": "C5b-9_deposition_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t192",
+    "source": "platelet_aggregation_phenotype",
+    "target": "C5b-9_deposition_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t193",
+    "source": "angiotensin_I-7_simple_molecule",
+    "target": "ACE2_endothelium,_vascular",
+    "sign": true
+   },
+   {
+    "id": "t194",
+    "source": "Fibrin_polymer",
+    "target": "Fibrin_monomer",
+    "sign": true
+   },
+   {
+    "id": "t195",
+    "source": "Fibrin_polymer",
+    "target": "F13a",
+    "sign": true
+   },
+   {
+    "id": "t196",
+    "source": "thrombus_formation_phenotype",
+    "target": "platelet_activation_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t197",
+    "source": "thrombus_formation_phenotype",
+    "target": "MAS1",
+    "sign": false
+   },
+   {
+    "id": "t198",
+    "source": "thrombus_formation_phenotype",
+    "target": "AGTR1_platelet",
+    "sign": true
+   },
+   {
+    "id": "t199",
+    "source": "aldosterone_simple_molecule_blood",
+    "target": "K+_ion",
+    "sign": true
+   },
+   {
+    "id": "t200",
+    "source": "aldosterone_simple_molecule_blood",
+    "target": "ACTH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t201",
+    "source": "NR3C2",
+    "target": "aldosterone_simple_molecule_endothelium,_vascular",
+    "sign": true
+   },
+   {
+    "id": "t202",
+    "source": "vascular_remodeling_phenotype",
+    "target": "aldosterone_simple_molecule_endothelium,_vascular",
+    "sign": true
+   },
+   {
+    "id": "t203",
+    "source": "vascular_inflammation_phenotype",
+    "target": "aldosterone_simple_molecule_endothelium,_vascular",
+    "sign": true
+   },
+   {
+    "id": "t204",
+    "source": "Thrombosis_phenotype_human_host",
+    "target": "NR3C2",
+    "sign": true
+   },
+   {
+    "id": "t205",
+    "source": "K+_ion",
+    "target": "Hypokalemia_phenotype",
+    "sign": false
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/ER_Stress.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/ER_Stress.json
@@ -1,0 +1,3058 @@
+{
+ "header": {
+  "name": "ER_Stress",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on ER_Stress",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "EIF2-P:GDP_complex",
+    "name": "EIF2-P:GDP_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATF4_rna",
+    "name": "ATF4_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2S1_phosphorylated",
+    "name": "EIF2S1_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2S1",
+    "name": "EIF2S1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2S2",
+    "name": "EIF2S2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2:GDP_complex",
+    "name": "EIF2:GDP_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2S3:GDP_complex",
+    "name": "EIF2S3:GDP_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF2:ERN1_complex",
+    "name": "TRAF2:ERN1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF2",
+    "name": "TRAF2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "UPR_phenotype",
+    "name": "UPR_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "XBP1_rna",
+    "name": "XBP1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP3K5_phosphorylated",
+    "name": "MAP3K5_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERN1:Unfolded_space_protein_complex",
+    "name": "ERN1:Unfolded_space_protein_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAK1:ERN1_complex",
+    "name": "BAK1:ERN1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAX:ERN1_complex",
+    "name": "BAX:ERN1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2",
+    "name": "BCL2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2L1",
+    "name": "BCL2L1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Persistant_space_ER_space_Stress_phenotype_endoplasmic_reticulum",
+    "name": "Persistant_space_ER_space_Stress_phenotype_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "name": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK3:EIF2AK3_complex",
+    "name": "EIF2AK3:EIF2AK3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAX_endoplasmic_reticulum",
+    "name": "BAX_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAK1",
+    "name": "BAK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1:ITPR3_complex",
+    "name": "SIGMAR1:ITPR3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+_ion_mitochondrion",
+    "name": "Ca2+_ion_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "name": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ER_space_stress_phenotype",
+    "name": "ER_space_stress_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Apoptosis_phenotype_endoplasmic_reticulum",
+    "name": "Apoptosis_phenotype_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ITPR3",
+    "name": "ITPR3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "autophagy_phenotype",
+    "name": "autophagy_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HSPA5_endoplasmic_reticulum",
+    "name": "HSPA5_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "unfolded_space_protein_space_response_space_(UPR)_phenotype",
+    "name": "unfolded_space_protein_space_response_space_(UPR)_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MFN2_endoplasmic_reticulum",
+    "name": "MFN2_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+space_ER_space_depletion_phenotype",
+    "name": "Ca2+space_ER_space_depletion_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2:GDP:Met-tRNA_complex",
+    "name": "EIF2:GDP:Met-tRNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ternary_space_Complex_complex",
+    "name": "Ternary_space_Complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GDP_simple_molecule",
+    "name": "GDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Met-tRNA_rna",
+    "name": "Met-tRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GTP_simple_molecule",
+    "name": "GTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Translation_space_initiation_phenotype",
+    "name": "Translation_space_initiation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Apoptosis_phenotype_cell",
+    "name": "Apoptosis_phenotype_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP8:CASP8-ubq:FADD_complex",
+    "name": "CASP8:CASP8-ubq:FADD_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SQSTM1_space_",
+    "name": "SQSTM1_space_",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP1LC3A",
+    "name": "MAP1LC3A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATG5",
+    "name": "ATG5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM13",
+    "name": "TRIM13",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERN1_endoplasmic_reticulum",
+    "name": "ERN1_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Unfolded_space_protein",
+    "name": "Unfolded_space_protein",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATF6_endoplasmic_reticulum",
+    "name": "ATF6_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "accumulation_space_of_space_misfolded_space_protein_space_in_space_ER_phenotype",
+    "name": "accumulation_space_of_space_misfolded_space_protein_space_in_space_ER_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1:HSPA5_complex",
+    "name": "SIGMAR1:HSPA5_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_endoplasmic_reticulum",
+    "name": "SIGMAR1_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "endoplasmic_space_reticulum_space_calcium_space_ion_space_homeostasis_phenotype",
+    "name": "endoplasmic_space_reticulum_space_calcium_space_ion_space_homeostasis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "VAPB:RMDN3_complex",
+    "name": "VAPB:RMDN3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "name": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "VAPB",
+    "name": "VAPB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+space_mitochondrial_space_concentration_phenotype",
+    "name": "Ca2+space_mitochondrial_space_concentration_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+space_cytosolic_space_concentration_phenotype",
+    "name": "Ca2+space_cytosolic_space_concentration_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RMDN3",
+    "name": "RMDN3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2B_complex",
+    "name": "EIF2B_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PACS2-ADAM17_space_interaction_complex",
+    "name": "PACS2-ADAM17_space_interaction_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADAM17_cell",
+    "name": "ADAM17_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PACS2_early_space_endosome",
+    "name": "PACS2_early_space_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADAM17_early_space_endosome",
+    "name": "ADAM17_early_space_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FIS1:BCAP31_complex",
+    "name": "FIS1:BCAP31_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCAP31",
+    "name": "BCAP31",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "p20",
+    "name": "p20",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FIS1",
+    "name": "FIS1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mitochondrial_space_outer_space_membrane_space_depolarization_phenotype",
+    "name": "mitochondrial_space_outer_space_membrane_space_depolarization_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MFN2:MFN2_complex",
+    "name": "MFN2:MFN2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MFN1:MFN2_complex",
+    "name": "MFN1:MFN2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "endoplasmic_space_reticulum_space_organization_phenotype",
+    "name": "endoplasmic_space_reticulum_space_organization_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MFN2_mitochondrion",
+    "name": "MFN2_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERN1:BBC3_complex",
+    "name": "ERN1:BBC3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERN1:BCL2L11_complex",
+    "name": "ERN1:BCL2L11_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BBC3",
+    "name": "BBC3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Persistant_space_ER_space_Stress_phenotype_cell",
+    "name": "Persistant_space_ER_space_Stress_phenotype_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDIT3_rna",
+    "name": "DDIT3_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MFN1",
+    "name": "MFN1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MCU:MICU1:MICU2:SMDT1_complex",
+    "name": "MCU:MICU1:MICU2:SMDT1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mitochondrial_space_calcium_space_uniporter_space_complex_complex",
+    "name": "Mitochondrial_space_calcium_space_uniporter_space_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MCU",
+    "name": "MCU",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SMDT1",
+    "name": "SMDT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MCU2",
+    "name": "MCU2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MCU1",
+    "name": "MCU1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2L11_endoplasmic_reticulum",
+    "name": "BCL2L11_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CAPN1:Ca2+_complex",
+    "name": "CAPN1:Ca2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cleaved~CASP4",
+    "name": "cleaved~CASP4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CAPN1",
+    "name": "CAPN1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+_ion_cell",
+    "name": "Ca2+_ion_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "high_space_Ca2+space_cytosolic_space_concentration_phenotype",
+    "name": "high_space_Ca2+space_cytosolic_space_concentration_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "retrograde_space_transport_space_from_space_ER_space_to_space_cytosol_phenotype",
+    "name": "retrograde_space_transport_space_from_space_ER_space_to_space_cytosol_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK3",
+    "name": "EIF2AK3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+_ion_mitochondrial_matrix",
+    "name": "Ca2+_ion_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mitochondrial_space_calcium_space_ion_space_transmembrane_space_transport_phenotype",
+    "name": "mitochondrial_space_calcium_space_ion_space_transmembrane_space_transport_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2",
+    "name": "ACE2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2:Spike_complex",
+    "name": "ACE2:Spike_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HSPA5_rna",
+    "name": "HSPA5_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2,_space_soluble",
+    "name": "ACE2,_space_soluble",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2,_space_membrane-bound",
+    "name": "ACE2,_space_membrane-bound",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pulmonary_fibrosis_phenotype",
+    "name": "pulmonary_fibrosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "viral_RNA_genome_replication_phenotype",
+    "name": "viral_RNA_genome_replication_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S",
+    "name": "S",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HSPA5-Spike_interaction_complex",
+    "name": "HSPA5-Spike_interaction_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2-SARS-CoV_interaction_complex",
+    "name": "ACE2-SARS-CoV_interaction_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "viral_entry_into_host_cell_phenotype",
+    "name": "viral_entry_into_host_cell_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HSPA5_default_compartment",
+    "name": "HSPA5_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPP1R15A_rna",
+    "name": "PPP1R15A_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPP1R15A",
+    "name": "PPP1R15A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPP1R15A_gene",
+    "name": "PPP1R15A_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATF4",
+    "name": "ATF4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDIT3",
+    "name": "DDIT3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDIT3_phosphorylated",
+    "name": "DDIT3_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIB3_rna",
+    "name": "TRIB3_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP-1_phosphorylated_phosphorylated",
+    "name": "AP-1_phosphorylated_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERO1A_rna",
+    "name": "ERO1A_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "release_space_of_space_ER_space_Ca2+_phenotype",
+    "name": "release_space_of_space_ER_space_Ca2+_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAX_phosphorylated",
+    "name": "BAX_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATF6_Golgi_apparatus",
+    "name": "ATF6_Golgi_apparatus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "ATF6_nucleus",
+    "name": "ATF6_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ER_space_Stress_phenotype",
+    "name": "ER_space_Stress_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CDK5",
+    "name": "CDK5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "protein_space_ubiquitination_space_and_space_destruction_phenotype",
+    "name": "protein_space_ubiquitination_space_and_space_destruction_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MBTPS2",
+    "name": "MBTPS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MBTPS1",
+    "name": "MBTPS1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2_rna",
+    "name": "BCL2_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK14_phosphorylated",
+    "name": "MAPK14_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATF6:HSPA5_complex",
+    "name": "ATF6:HSPA5_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ITPR",
+    "name": "ITPR",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "TMBIM6",
+    "name": "TMBIM6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERO1A_endoplasmic_reticulum",
+    "name": "ERO1A_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "hyperoxidation_phenotype",
+    "name": "hyperoxidation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HSPA5_gene",
+    "name": "HSPA5_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "XBP1",
+    "name": "XBP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERAD_phenotype",
+    "name": "ERAD_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mitochondrial_space_fission_phenotype",
+    "name": "mitochondrial_space_fission_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mitochondria_space_fragmentation_phenotype",
+    "name": "mitochondria_space_fragmentation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PACS2_endoplasmic_reticulum",
+    "name": "PACS2_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK2",
+    "name": "EIF2AK2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "DNAJC3",
+    "name": "DNAJC3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNAJC3_rna",
+    "name": "DNAJC3_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDIT3_gene",
+    "name": "DDIT3_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HYOU1_rna",
+    "name": "HYOU1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATF4_gene",
+    "name": "ATF4_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2L11_cell",
+    "name": "BCL2L11_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2L11_phosphorylated",
+    "name": "BCL2L11_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPP2CA",
+    "name": "PPP2CA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIB3",
+    "name": "TRIB3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIB3_gene",
+    "name": "TRIB3_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+_ion_endoplasmic_reticulum",
+    "name": "Ca2+_ion_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ITPR3:HSPA9:VDAC1_complex",
+    "name": "ITPR3:HSPA9:VDAC1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERO1A_cell",
+    "name": "ERO1A_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK1",
+    "name": "EIF2AK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cleaved~CASP9",
+    "name": "cleaved~CASP9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP9",
+    "name": "CASP9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cleaved~CASP3",
+    "name": "cleaved~CASP3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "XBP1_gene",
+    "name": "XBP1_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2_gene",
+    "name": "BCL2_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP3K4_phosphorylated",
+    "name": "MAP3K4_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK14",
+    "name": "MAPK14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK8_phosphorylated",
+    "name": "MAPK8_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cell_space_survival_phenotype",
+    "name": "Cell_space_survival_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "presence_space_of_space_dsRNA_phenotype",
+    "name": "presence_space_of_space_dsRNA_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAX_cell",
+    "name": "BAX_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BID_phosphorylated",
+    "name": "BID_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK8",
+    "name": "MAPK8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BID",
+    "name": "BID",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP4",
+    "name": "CASP4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HYOU1",
+    "name": "HYOU1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP3",
+    "name": "CASP3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GCN2:ATP_complex",
+    "name": "GCN2:ATP_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP-1",
+    "name": "AP-1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RYR1",
+    "name": "RYR1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP3K5",
+    "name": "MAP3K5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNAJC3_gene",
+    "name": "DNAJC3_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MFN2_rna",
+    "name": "MFN2_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MFN2_gene",
+    "name": "MFN2_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP3K4",
+    "name": "MAP3K4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HYOU1_gene",
+    "name": "HYOU1_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERO1A_gene",
+    "name": "ERO1A_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2_rna",
+    "name": "ACE2_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS-CoV_infection_phenotype",
+    "name": "SARS-CoV_infection_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "ATF4_rna",
+    "target": "EIF2-P:GDP_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "EIF2-P:GDP_complex",
+    "target": "EIF2S1_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "EIF2S1",
+    "target": "EIF2S1_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "EIF2-P:GDP_complex",
+    "target": "EIF2S2",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "EIF2:GDP_complex",
+    "target": "EIF2S2",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "EIF2-P:GDP_complex",
+    "target": "EIF2S3:GDP_complex",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "EIF2:GDP_complex",
+    "target": "EIF2S3:GDP_complex",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "TRAF2",
+    "target": "TRAF2:ERN1_complex",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "UPR_phenotype",
+    "target": "TRAF2:ERN1_complex",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "XBP1_rna",
+    "target": "TRAF2:ERN1_complex",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "MAP3K5_phosphorylated",
+    "target": "TRAF2:ERN1_complex",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "TRAF2:ERN1_complex",
+    "target": "ERN1:Unfolded_space_protein_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "TRAF2:ERN1_complex",
+    "target": "TRAF2",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "MAP3K5_phosphorylated",
+    "target": "TRAF2",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "TRAF2:ERN1_complex",
+    "target": "BAK1:ERN1_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "TRAF2:ERN1_complex",
+    "target": "BAX:ERN1_complex",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "TRAF2:ERN1_complex",
+    "target": "BCL2",
+    "sign": false
+   },
+   {
+    "id": "t19",
+    "source": "TRAF2:ERN1_complex",
+    "target": "BCL2L1",
+    "sign": false
+   },
+   {
+    "id": "t20",
+    "source": "TRAF2:ERN1_complex",
+    "target": "Persistant_space_ER_space_Stress_phenotype_endoplasmic_reticulum",
+    "sign": false
+   },
+   {
+    "id": "t21",
+    "source": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "target": "Persistant_space_ER_space_Stress_phenotype_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "EIF2AK3:EIF2AK3_complex",
+    "target": "Persistant_space_ER_space_Stress_phenotype_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "TRAF2:ERN1_complex",
+    "target": "BAX_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "TRAF2:ERN1_complex",
+    "target": "BAK1",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "Ca2+_ion_mitochondrion",
+    "target": "SIGMAR1:ITPR3_complex",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "SIGMAR1:ITPR3_complex",
+    "target": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "ER_space_stress_phenotype",
+    "target": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "sign": false
+   },
+   {
+    "id": "t28",
+    "source": "Apoptosis_phenotype_endoplasmic_reticulum",
+    "target": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "sign": false
+   },
+   {
+    "id": "t29",
+    "source": "SIGMAR1:ITPR3_complex",
+    "target": "ITPR3",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "autophagy_phenotype",
+    "target": "ITPR3",
+    "sign": false
+   },
+   {
+    "id": "t31",
+    "source": "SIGMAR1:ITPR3_complex",
+    "target": "ER_space_stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "HSPA5_endoplasmic_reticulum",
+    "target": "ER_space_stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "target": "ER_space_stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "unfolded_space_protein_space_response_space_(UPR)_phenotype",
+    "target": "ER_space_stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "Apoptosis_phenotype_endoplasmic_reticulum",
+    "target": "ER_space_stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "MFN2_endoplasmic_reticulum",
+    "target": "ER_space_stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "SIGMAR1:ITPR3_complex",
+    "target": "Ca2+space_ER_space_depletion_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "HSPA5_endoplasmic_reticulum",
+    "target": "Ca2+space_ER_space_depletion_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "target": "Ca2+space_ER_space_depletion_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "Ternary_space_Complex_complex",
+    "target": "EIF2:GDP:Met-tRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "GDP_simple_molecule",
+    "target": "EIF2:GDP:Met-tRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "EIF2:GDP:Met-tRNA_complex",
+    "target": "Met-tRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "EIF2:GDP:Met-tRNA_complex",
+    "target": "EIF2:GDP_complex",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "EIF2:GDP:Met-tRNA_complex",
+    "target": "Ternary_space_Complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "GTP_simple_molecule",
+    "target": "Ternary_space_Complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "Translation_space_initiation_phenotype",
+    "target": "Ternary_space_Complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "EIF2:GDP:Met-tRNA_complex",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "GTP_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "target": "CASP8:CASP8-ubq:FADD_complex",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "target": "SQSTM1_space_",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "target": "MAP1LC3A",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "target": "ATG5",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "CASP8:FADD:MAP1LC3A:SQSTM1:ATG5_complex",
+    "target": "TRIM13",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "ERN1:Unfolded_space_protein_complex",
+    "target": "ERN1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "ERN1:Unfolded_space_protein_complex",
+    "target": "Unfolded_space_protein",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "EIF2AK3:EIF2AK3_complex",
+    "target": "Unfolded_space_protein",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "HSPA5_endoplasmic_reticulum",
+    "target": "Unfolded_space_protein",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "ATF6_endoplasmic_reticulum",
+    "target": "Unfolded_space_protein",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "accumulation_space_of_space_misfolded_space_protein_space_in_space_ER_phenotype",
+    "target": "Unfolded_space_protein",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "HSPA5_endoplasmic_reticulum",
+    "target": "SIGMAR1:HSPA5_complex",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "SIGMAR1_mitochondria-associated_endoplasmic_reticulum_membrane",
+    "target": "SIGMAR1:HSPA5_complex",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "SIGMAR1:HSPA5_complex",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "SIGMAR1:HSPA5_complex",
+    "target": "HSPA5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "endoplasmic_space_reticulum_space_calcium_space_ion_space_homeostasis_phenotype",
+    "target": "HSPA5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "target": "VAPB:RMDN3_complex",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "VAPB:RMDN3_complex",
+    "target": "VAPB",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "Ca2+space_mitochondrial_space_concentration_phenotype",
+    "target": "VAPB",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "autophagy_phenotype",
+    "target": "VAPB",
+    "sign": false
+   },
+   {
+    "id": "t70",
+    "source": "Ca2+space_cytosolic_space_concentration_phenotype",
+    "target": "VAPB",
+    "sign": false
+   },
+   {
+    "id": "t71",
+    "source": "VAPB:RMDN3_complex",
+    "target": "RMDN3",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "Ca2+space_mitochondrial_space_concentration_phenotype",
+    "target": "RMDN3",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "autophagy_phenotype",
+    "target": "RMDN3",
+    "sign": false
+   },
+   {
+    "id": "t74",
+    "source": "Ca2+space_cytosolic_space_concentration_phenotype",
+    "target": "RMDN3",
+    "sign": false
+   },
+   {
+    "id": "t75",
+    "source": "Ternary_space_Complex_complex",
+    "target": "GTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "GDP_simple_molecule",
+    "target": "GTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "Ternary_space_Complex_complex",
+    "target": "EIF2B_complex",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "GDP_simple_molecule",
+    "target": "EIF2B_complex",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "ADAM17_cell",
+    "target": "PACS2-ADAM17_space_interaction_complex",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "PACS2-ADAM17_space_interaction_complex",
+    "target": "PACS2_early_space_endosome",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "PACS2-ADAM17_space_interaction_complex",
+    "target": "ADAM17_early_space_endosome",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "target": "FIS1:BCAP31_complex",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "FIS1:BCAP31_complex",
+    "target": "BCAP31",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "p20",
+    "target": "BCAP31",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "FIS1:BCAP31_complex",
+    "target": "FIS1",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "Ca2+space_mitochondrial_space_concentration_phenotype",
+    "target": "FIS1",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "mitochondrial_space_outer_space_membrane_space_depolarization_phenotype",
+    "target": "FIS1",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "target": "MFN2:MFN2_complex",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "MFN2:MFN2_complex",
+    "target": "MFN2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "MFN1:MFN2_complex",
+    "target": "MFN2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "endoplasmic_space_reticulum_space_organization_phenotype",
+    "target": "MFN2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "unfolded_space_protein_space_response_space_(UPR)_phenotype",
+    "target": "MFN2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "ER_space_stress_phenotype",
+    "target": "MFN2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "Apoptosis_phenotype_endoplasmic_reticulum",
+    "target": "MFN2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "endoplasmic_space_reticulum_space_calcium_space_ion_space_homeostasis_phenotype",
+    "target": "MFN2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "MFN2:MFN2_complex",
+    "target": "MFN2_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "XBP1_rna",
+    "target": "ERN1:BBC3_complex",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "ERN1:BBC3_complex",
+    "target": "ERN1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "ERN1:BCL2L11_complex",
+    "target": "ERN1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "ERN1:BBC3_complex",
+    "target": "BBC3",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "ERN1:BBC3_complex",
+    "target": "Persistant_space_ER_space_Stress_phenotype_cell",
+    "sign": false
+   },
+   {
+    "id": "t102",
+    "source": "ERN1:BCL2L11_complex",
+    "target": "Persistant_space_ER_space_Stress_phenotype_cell",
+    "sign": false
+   },
+   {
+    "id": "t103",
+    "source": "DDIT3_rna",
+    "target": "Persistant_space_ER_space_Stress_phenotype_cell",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "EIF2:GDP_complex",
+    "target": "EIF2S1",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "EIF2S1_phosphorylated",
+    "target": "EIF2S1",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "target": "MFN1:MFN2_complex",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "MFN1:MFN2_complex",
+    "target": "MFN1",
+    "sign": true
+   },
+   {
+    "id": "t108",
+    "source": "Mitochondrial_space_calcium_space_uniporter_space_complex_complex",
+    "target": "MCU:MICU1:MICU2:SMDT1_complex",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "MCU:MICU1:MICU2:SMDT1_complex",
+    "target": "MCU",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "MCU:MICU1:MICU2:SMDT1_complex",
+    "target": "SMDT1",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "MCU:MICU1:MICU2:SMDT1_complex",
+    "target": "MCU2",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "MCU:MICU1:MICU2:SMDT1_complex",
+    "target": "MCU1",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "XBP1_rna",
+    "target": "ERN1:BCL2L11_complex",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "ERN1:BCL2L11_complex",
+    "target": "BCL2L11_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "cleaved~CASP4",
+    "target": "CAPN1:Ca2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "CAPN1:Ca2+_complex",
+    "target": "CAPN1",
+    "sign": true
+   },
+   {
+    "id": "t117",
+    "source": "CAPN1:Ca2+_complex",
+    "target": "Ca2+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "high_space_Ca2+space_cytosolic_space_concentration_phenotype",
+    "target": "Ca2+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "CAPN1:Ca2+_complex",
+    "target": "high_space_Ca2+space_cytosolic_space_concentration_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "UPR_phenotype",
+    "target": "EIF2AK3:EIF2AK3_complex",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "retrograde_space_transport_space_from_space_ER_space_to_space_cytosol_phenotype",
+    "target": "EIF2AK3:EIF2AK3_complex",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "EIF2S1_phosphorylated",
+    "target": "EIF2AK3:EIF2AK3_complex",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "EIF2AK3:EIF2AK3_complex",
+    "target": "EIF2AK3",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "Ca2+_ion_mitochondrial_matrix",
+    "target": "Mitochondrial_space_calcium_space_uniporter_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "mitochondrial_space_calcium_space_ion_space_transmembrane_space_transport_phenotype",
+    "target": "Mitochondrial_space_calcium_space_uniporter_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "ACE2:Spike_complex",
+    "target": "ACE2",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "HSPA5_endoplasmic_reticulum",
+    "target": "ACE2",
+    "sign": false
+   },
+   {
+    "id": "t128",
+    "source": "HSPA5_rna",
+    "target": "ACE2",
+    "sign": false
+   },
+   {
+    "id": "t129",
+    "source": "ER_space_stress_phenotype",
+    "target": "ACE2",
+    "sign": false
+   },
+   {
+    "id": "t130",
+    "source": "ACE2,_space_soluble",
+    "target": "ACE2",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "ACE2,_space_membrane-bound",
+    "target": "ACE2",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "pulmonary_fibrosis_phenotype",
+    "target": "ACE2",
+    "sign": false
+   },
+   {
+    "id": "t133",
+    "source": "viral_RNA_genome_replication_phenotype",
+    "target": "ACE2",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "ACE2:Spike_complex",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "HSPA5-Spike_interaction_complex",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "ACE2-SARS-CoV_interaction_complex",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "HSPA5_rna",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "viral_entry_into_host_cell_phenotype",
+    "target": "HSPA5-Spike_interaction_complex",
+    "sign": true
+   },
+   {
+    "id": "t139",
+    "source": "HSPA5-Spike_interaction_complex",
+    "target": "HSPA5_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "viral_entry_into_host_cell_phenotype",
+    "target": "ACE2-SARS-CoV_interaction_complex",
+    "sign": true
+   },
+   {
+    "id": "t141",
+    "source": "ACE2-SARS-CoV_interaction_complex",
+    "target": "ACE2,_space_membrane-bound",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "ACE2-SARS-CoV_interaction_complex",
+    "target": "ACE2,_space_soluble",
+    "sign": false
+   },
+   {
+    "id": "t143",
+    "source": "viral_entry_into_host_cell_phenotype",
+    "target": "ACE2,_space_soluble",
+    "sign": false
+   },
+   {
+    "id": "t144",
+    "source": "PPP1R15A",
+    "target": "PPP1R15A_rna",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "PPP1R15A_rna",
+    "target": "PPP1R15A_gene",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "PPP1R15A_rna",
+    "target": "ATF4",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "DDIT3_rna",
+    "target": "ATF4",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "PPP1R15A_rna",
+    "target": "DDIT3",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "DDIT3_phosphorylated",
+    "target": "DDIT3",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "TRIB3_rna",
+    "target": "DDIT3",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "AP-1_phosphorylated_phosphorylated",
+    "target": "DDIT3",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "ERO1A_rna",
+    "target": "DDIT3",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "high_space_Ca2+space_cytosolic_space_concentration_phenotype",
+    "target": "release_space_of_space_ER_space_Ca2+_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "release_space_of_space_ER_space_Ca2+_phenotype",
+    "target": "BAX_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "BAX_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "UPR_phenotype",
+    "target": "ATF6_Golgi_apparatus",
+    "sign": true
+   },
+   {
+    "id": "t158",
+    "source": "ATF6_nucleus",
+    "target": "ATF6_Golgi_apparatus",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "ATF6_Golgi_apparatus",
+    "target": "ATF6_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "retrograde_space_transport_space_from_space_ER_space_to_space_cytosol_phenotype",
+    "target": "ATF6_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "ATF6_Golgi_apparatus",
+    "target": "ER_space_Stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "CDK5",
+    "target": "ER_space_Stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "Persistant_space_ER_space_Stress_phenotype_endoplasmic_reticulum",
+    "target": "ER_space_Stress_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "ATF6_Golgi_apparatus",
+    "target": "retrograde_space_transport_space_from_space_ER_space_to_space_cytosol_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t165",
+    "source": "protein_space_ubiquitination_space_and_space_destruction_phenotype",
+    "target": "retrograde_space_transport_space_from_space_ER_space_to_space_cytosol_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t166",
+    "source": "ATF6_Golgi_apparatus",
+    "target": "MBTPS2",
+    "sign": true
+   },
+   {
+    "id": "t167",
+    "source": "ATF6_Golgi_apparatus",
+    "target": "MBTPS1",
+    "sign": true
+   },
+   {
+    "id": "t168",
+    "source": "BCL2_rna",
+    "target": "DDIT3_phosphorylated",
+    "sign": false
+   },
+   {
+    "id": "t169",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "DDIT3_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t170",
+    "source": "DDIT3_phosphorylated",
+    "target": "MAPK14_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t171",
+    "source": "BAX_phosphorylated",
+    "target": "MAPK14_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t172",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "MAPK14_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t173",
+    "source": "HSPA5_endoplasmic_reticulum",
+    "target": "ATF6:HSPA5_complex",
+    "sign": true
+   },
+   {
+    "id": "t174",
+    "source": "ATF6_endoplasmic_reticulum",
+    "target": "ATF6:HSPA5_complex",
+    "sign": true
+   },
+   {
+    "id": "t175",
+    "source": "HSPA5_endoplasmic_reticulum",
+    "target": "HSPA5_rna",
+    "sign": true
+   },
+   {
+    "id": "t177",
+    "source": "Ca2+_ion_cell",
+    "target": "ITPR",
+    "sign": true
+   },
+   {
+    "id": "t178",
+    "source": "ITPR",
+    "target": "TMBIM6",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "Ca2+_ion_cell",
+    "target": "TMBIM6",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "ITPR",
+    "target": "ERO1A_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "hyperoxidation_phenotype",
+    "target": "ERO1A_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "HSPA5_rna",
+    "target": "HSPA5_gene",
+    "sign": true
+   },
+   {
+    "id": "t183",
+    "source": "UPR_phenotype",
+    "target": "XBP1",
+    "sign": true
+   },
+   {
+    "id": "t184",
+    "source": "DDIT3_rna",
+    "target": "XBP1",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "ERAD_phenotype",
+    "target": "XBP1",
+    "sign": true
+   },
+   {
+    "id": "t186",
+    "source": "UPR_phenotype",
+    "target": "accumulation_space_of_space_misfolded_space_protein_space_in_space_ER_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "ER_space_Stress_phenotype",
+    "target": "accumulation_space_of_space_misfolded_space_protein_space_in_space_ER_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "mitochondria_space_fragmentation_phenotype",
+    "target": "mitochondrial_space_fission_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t189",
+    "source": "mitochondrial_space_fission_phenotype",
+    "target": "PACS2_endoplasmic_reticulum",
+    "sign": false
+   },
+   {
+    "id": "t190",
+    "source": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "target": "PACS2_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t191",
+    "source": "p20",
+    "target": "PACS2_endoplasmic_reticulum",
+    "sign": false
+   },
+   {
+    "id": "t192",
+    "source": "EIF2AK2",
+    "target": "DNAJC3",
+    "sign": false
+   },
+   {
+    "id": "t193",
+    "source": "EIF2S1_phosphorylated",
+    "target": "DNAJC3",
+    "sign": false
+   },
+   {
+    "id": "t194",
+    "source": "DNAJC3",
+    "target": "DNAJC3_rna",
+    "sign": true
+   },
+   {
+    "id": "t195",
+    "source": "DDIT3",
+    "target": "DDIT3_rna",
+    "sign": true
+   },
+   {
+    "id": "t196",
+    "source": "DDIT3_rna",
+    "target": "DDIT3_gene",
+    "sign": true
+   },
+   {
+    "id": "t197",
+    "source": "DDIT3_rna",
+    "target": "ATF6_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t198",
+    "source": "XBP1_rna",
+    "target": "ATF6_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t199",
+    "source": "DNAJC3_rna",
+    "target": "ATF6_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t200",
+    "source": "HYOU1_rna",
+    "target": "ATF6_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t201",
+    "source": "ERO1A_rna",
+    "target": "ATF6_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t202",
+    "source": "ATF4",
+    "target": "ATF4_rna",
+    "sign": true
+   },
+   {
+    "id": "t203",
+    "source": "ATF4_rna",
+    "target": "ATF4_gene",
+    "sign": true
+   },
+   {
+    "id": "t204",
+    "source": "BCL2L11_phosphorylated",
+    "target": "BCL2L11_cell",
+    "sign": true
+   },
+   {
+    "id": "t205",
+    "source": "BCL2L11_cell",
+    "target": "BCL2L11_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t206",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "BCL2L11_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t207",
+    "source": "BCL2L11_cell",
+    "target": "PPP2CA",
+    "sign": true
+   },
+   {
+    "id": "t208",
+    "source": "TRIB3",
+    "target": "TRIB3_rna",
+    "sign": true
+   },
+   {
+    "id": "t209",
+    "source": "TRIB3_rna",
+    "target": "TRIB3_gene",
+    "sign": true
+   },
+   {
+    "id": "t210",
+    "source": "Ca2+_ion_mitochondrial_matrix",
+    "target": "Ca2+_ion_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t211",
+    "source": "Ca2+_ion_mitochondrion",
+    "target": "Ca2+_ion_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t212",
+    "source": "Ca2+_ion_cell",
+    "target": "Ca2+_ion_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t213",
+    "source": "Ca2+_ion_mitochondrion",
+    "target": "ITPR3:HSPA9:VDAC1_complex",
+    "sign": true
+   },
+   {
+    "id": "t214",
+    "source": "ERO1A_endoplasmic_reticulum",
+    "target": "ERO1A_cell",
+    "sign": true
+   },
+   {
+    "id": "t215",
+    "source": "EIF2S1",
+    "target": "PPP1R15A",
+    "sign": true
+   },
+   {
+    "id": "t216",
+    "source": "EIF2S1",
+    "target": "EIF2AK1",
+    "sign": true
+   },
+   {
+    "id": "t217",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "cleaved~CASP9",
+    "sign": true
+   },
+   {
+    "id": "t218",
+    "source": "cleaved~CASP9",
+    "target": "CASP9",
+    "sign": true
+   },
+   {
+    "id": "t219",
+    "source": "cleaved~CASP9",
+    "target": "cleaved~CASP4",
+    "sign": true
+   },
+   {
+    "id": "t220",
+    "source": "cleaved~CASP3",
+    "target": "cleaved~CASP4",
+    "sign": true
+   },
+   {
+    "id": "t221",
+    "source": "autophagy_phenotype",
+    "target": "mitochondrion-endoplasmic_space_reticulum_space_membrane_space_tethering_space__phenotype",
+    "sign": false
+   },
+   {
+    "id": "t222",
+    "source": "XBP1",
+    "target": "XBP1_rna",
+    "sign": true
+   },
+   {
+    "id": "t223",
+    "source": "XBP1_rna",
+    "target": "XBP1_gene",
+    "sign": true
+   },
+   {
+    "id": "t224",
+    "source": "accumulation_space_of_space_misfolded_space_protein_space_in_space_ER_phenotype",
+    "target": "ERAD_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t225",
+    "source": "BCL2_rna",
+    "target": "BCL2_gene",
+    "sign": true
+   },
+   {
+    "id": "t227",
+    "source": "MAP3K4_phosphorylated",
+    "target": "CDK5",
+    "sign": true
+   },
+   {
+    "id": "t228",
+    "source": "MAPK14_phosphorylated",
+    "target": "MAPK14",
+    "sign": true
+   },
+   {
+    "id": "t229",
+    "source": "MAPK14_phosphorylated",
+    "target": "MAP3K5_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t230",
+    "source": "MAPK8_phosphorylated",
+    "target": "MAP3K5_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t231",
+    "source": "ERO1A_cell",
+    "target": "ERO1A_rna",
+    "sign": true
+   },
+   {
+    "id": "t232",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "Cell_space_survival_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t233",
+    "source": "Cell_space_survival_phenotype",
+    "target": "Apoptosis_phenotype_cell",
+    "sign": true
+   },
+   {
+    "id": "t234",
+    "source": "unfolded_space_protein_space_response_space_(UPR)_phenotype",
+    "target": "p20",
+    "sign": true
+   },
+   {
+    "id": "t236",
+    "source": "EIF2S1_phosphorylated",
+    "target": "EIF2AK2",
+    "sign": true
+   },
+   {
+    "id": "t237",
+    "source": "EIF2AK2",
+    "target": "presence_space_of_space_dsRNA_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t238",
+    "source": "BAX_phosphorylated",
+    "target": "BAX_cell",
+    "sign": true
+   },
+   {
+    "id": "t239",
+    "source": "BAX_phosphorylated",
+    "target": "MAPK8_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t240",
+    "source": "BID_phosphorylated",
+    "target": "MAPK8_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t241",
+    "source": "AP-1_phosphorylated_phosphorylated",
+    "target": "MAPK8_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t242",
+    "source": "BCL2L11_phosphorylated",
+    "target": "MAPK8_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t243",
+    "source": "MAPK8_phosphorylated",
+    "target": "MAPK8",
+    "sign": true
+   },
+   {
+    "id": "t244",
+    "source": "MAPK8_phosphorylated",
+    "target": "MAP3K4_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t245",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "BID_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t246",
+    "source": "BID_phosphorylated",
+    "target": "BID",
+    "sign": true
+   },
+   {
+    "id": "t247",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "TRIB3",
+    "sign": true
+   },
+   {
+    "id": "t248",
+    "source": "cleaved~CASP4",
+    "target": "CASP4",
+    "sign": true
+   },
+   {
+    "id": "t249",
+    "source": "HYOU1",
+    "target": "HYOU1_rna",
+    "sign": true
+   },
+   {
+    "id": "t250",
+    "source": "Apoptosis_phenotype_cell",
+    "target": "cleaved~CASP3",
+    "sign": true
+   },
+   {
+    "id": "t251",
+    "source": "cleaved~CASP3",
+    "target": "CASP3",
+    "sign": true
+   },
+   {
+    "id": "t252",
+    "source": "EIF2S1_phosphorylated",
+    "target": "GCN2:ATP_complex",
+    "sign": true
+   },
+   {
+    "id": "t253",
+    "source": "AP-1_phosphorylated_phosphorylated",
+    "target": "AP-1",
+    "sign": true
+   },
+   {
+    "id": "t254",
+    "source": "Ca2+_ion_cell",
+    "target": "RYR1",
+    "sign": true
+   },
+   {
+    "id": "t255",
+    "source": "p20",
+    "target": "Apoptosis_phenotype_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t256",
+    "source": "MAP3K5_phosphorylated",
+    "target": "MAP3K5",
+    "sign": true
+   },
+   {
+    "id": "t257",
+    "source": "DNAJC3_rna",
+    "target": "DNAJC3_gene",
+    "sign": true
+   },
+   {
+    "id": "t258",
+    "source": "MFN2_endoplasmic_reticulum",
+    "target": "MFN2_rna",
+    "sign": true
+   },
+   {
+    "id": "t259",
+    "source": "ACE2,_space_soluble",
+    "target": "ADAM17_cell",
+    "sign": true
+   },
+   {
+    "id": "t260",
+    "source": "ACE2,_space_membrane-bound",
+    "target": "ADAM17_cell",
+    "sign": true
+   },
+   {
+    "id": "t261",
+    "source": "MFN2_rna",
+    "target": "MFN2_gene",
+    "sign": true
+   },
+   {
+    "id": "t262",
+    "source": "MAP3K4_phosphorylated",
+    "target": "MAP3K4",
+    "sign": true
+   },
+   {
+    "id": "t263",
+    "source": "HYOU1_rna",
+    "target": "HYOU1_gene",
+    "sign": true
+   },
+   {
+    "id": "t264",
+    "source": "ERO1A_rna",
+    "target": "ERO1A_gene",
+    "sign": true
+   },
+   {
+    "id": "t265",
+    "source": "ACE2_rna",
+    "target": "viral_entry_into_host_cell_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t266",
+    "source": "viral_entry_into_host_cell_phenotype",
+    "target": "SARS-CoV_infection_phenotype",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/ETC.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/ETC.json
@@ -1,0 +1,1630 @@
+{
+ "header": {
+  "name": "ETC",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on ETC",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "TIM_space_complex:Nsp4_complex",
+    "name": "TIM_space_complex:Nsp4_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "precursor_space_protein_space_N-terminus_space_binding",
+    "name": "precursor_space_protein_space_N-terminus_space_binding",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_mitochondrion",
+    "name": "Nsp4_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TIM_space_complex_complex",
+    "name": "TIM_space_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_space_Synthase_complex",
+    "name": "ATP_space_Synthase_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_mitochondrial_matrix",
+    "name": "H+_ion_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule",
+    "name": "ATP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F-ATPase_complex_mitochondrial_matrix",
+    "name": "F-ATPase_complex_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp6",
+    "name": "Nsp6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F-ATPase:Nsp6_complex",
+    "name": "F-ATPase:Nsp6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_mitochondrion",
+    "name": "H+_ion_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mt_space_mRNA_rna",
+    "name": "mt_space_mRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "name": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mt_space_translation_complex",
+    "name": "Mt_space_translation_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mt_space_ribosomal_space_proteins_complex",
+    "name": "Mt_space_ribosomal_space_proteins_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp8-affected_Mt_ribosomal_proteins_complex",
+    "name": "Nsp8-affected_Mt_ribosomal_proteins_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Complex_space_1_complex",
+    "name": "Complex_space_1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "complex_space_2_complex_mitochondrial_matrix",
+    "name": "complex_space_2_complex_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "complex_space_3_complex",
+    "name": "complex_space_3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "paraquat_simple_molecule",
+    "name": "paraquat_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "name": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAD+_simple_molecule",
+    "name": "NAD+_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADH_simple_molecule",
+    "name": "NADH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NDUFA1",
+    "name": "NDUFA1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NDUFB9",
+    "name": "NDUFB9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OXPHOS_space_factors_complex",
+    "name": "OXPHOS_space_factors_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "complex_space_4_complex",
+    "name": "complex_space_4_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP5MG",
+    "name": "ATP5MG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACAD9",
+    "name": "ACAD9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ECSIT",
+    "name": "ECSIT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NDUFAF7",
+    "name": "NDUFAF7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Q_simple_molecule_mitochondrial_matrix",
+    "name": "Q_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIRT3",
+    "name": "SIRT3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SOD2",
+    "name": "SOD2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2-_simple_molecule",
+    "name": "O2-_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CYCS_mitochondrial_matrix",
+    "name": "CYCS_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "TCA_phenotype",
+    "name": "TCA_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mt_space_DNA_gene",
+    "name": "mt_space_DNA_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MT_space_tRNAs_complex",
+    "name": "MT_space_tRNAs_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "damaged_space_mt_space_DNA_gene",
+    "name": "damaged_space_mt_space_DNA_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mt-tRNA_space_synthetase_complex",
+    "name": "Mt-tRNA_space_synthetase_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRMT1",
+    "name": "TRMT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp8",
+    "name": "Nsp8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "paraquat_space_dication_complex",
+    "name": "paraquat_space_dication_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "superoxide_simple_molecule",
+    "name": "superoxide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2_simple_molecule",
+    "name": "O2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_cell",
+    "name": "Nsp4_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4:DNAJC11_complex",
+    "name": "Nsp4:DNAJC11_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNAJC11",
+    "name": "DNAJC11",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe3+_ion",
+    "name": "Fe3+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe2+_ion",
+    "name": "Fe2+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "hydroxide_simple_molecule",
+    "name": "hydroxide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule",
+    "name": "H2O_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ROS_simple_molecule",
+    "name": "ROS_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HO_simple_molecule",
+    "name": "HO_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O2_simple_molecule",
+    "name": "H2O2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXN2",
+    "name": "TXN2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "glutathione_space_disulfide_simple_molecule",
+    "name": "glutathione_space_disulfide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TFAM",
+    "name": "TFAM",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mt_space_DNA_space_replication_phenotype",
+    "name": "mt_space_DNA_space_replication_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MT_space_transcription_complex",
+    "name": "MT_space_transcription_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9c",
+    "name": "Orf9c",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SOD1",
+    "name": "SOD1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mt_space_DNA_space_damage_phenotype",
+    "name": "mt_space_DNA_space_damage_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mt-DNA_space_repair_complex",
+    "name": "Mt-DNA_space_repair_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mt-dNTP_space_pool_complex",
+    "name": "Mt-dNTP_space_pool_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "glutathione_simple_molecule",
+    "name": "glutathione_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GPX4",
+    "name": "GPX4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GPX1",
+    "name": "GPX1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CAT",
+    "name": "CAT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADP(+)_simple_molecule",
+    "name": "NADP(+)_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRDX_complex",
+    "name": "PRDX_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADPH_simple_molecule",
+    "name": "NADPH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXNRD2",
+    "name": "TXNRD2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GSR",
+    "name": "GSR",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP_simple_molecule",
+    "name": "ADP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pi_simple_molecule",
+    "name": "Pi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mt_space_replication_complex",
+    "name": "Mt_space_replication_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TOM_space_complex_complex_mitochondrion",
+    "name": "TOM_space_complex_complex_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b",
+    "name": "Orf9b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TIM23_space_complex_complex",
+    "name": "TIM23_space_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp7",
+    "name": "Nsp7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "precursor_space_protein_space_N-terminus_space_binding",
+    "target": "TIM_space_complex:Nsp4_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "TIM_space_complex:Nsp4_complex",
+    "target": "Nsp4_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "TIM_space_complex:Nsp4_complex",
+    "target": "TIM_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "precursor_space_protein_space_N-terminus_space_binding",
+    "target": "TIM_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "ATP_space_Synthase_complex",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "ATP_simple_molecule",
+    "target": "ATP_space_Synthase_complex",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "ATP_space_Synthase_complex",
+    "target": "F-ATPase_complex_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "ATP_space_Synthase_complex",
+    "target": "Nsp6",
+    "sign": false
+   },
+   {
+    "id": "t9",
+    "source": "F-ATPase:Nsp6_complex",
+    "target": "Nsp6",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "ATP_space_Synthase_complex",
+    "target": "H+_ion_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "target": "mt_space_mRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "target": "Mt_space_translation_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "target": "Mt_space_ribosomal_space_proteins_complex",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "target": "Nsp8-affected_Mt_ribosomal_proteins_complex",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "complex_space_2_complex_mitochondrial_matrix",
+    "target": "Complex_space_1_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "complex_space_3_complex",
+    "target": "Complex_space_1_complex",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "paraquat_simple_molecule",
+    "target": "Complex_space_1_complex",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "Complex_space_1_complex",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "H+_ion_mitochondrion",
+    "target": "Complex_space_1_complex",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "target": "Complex_space_1_complex",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "NAD+_simple_molecule",
+    "target": "Complex_space_1_complex",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "Complex_space_1_complex",
+    "target": "NADH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "NADH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "NAD+_simple_molecule",
+    "target": "NADH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "Complex_space_1_complex",
+    "target": "NDUFA1",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "Complex_space_1_complex",
+    "target": "NDUFB9",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "Complex_space_1_complex",
+    "target": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "Complex_space_1_complex",
+    "target": "OXPHOS_space_factors_complex",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "complex_space_2_complex_mitochondrial_matrix",
+    "target": "OXPHOS_space_factors_complex",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "complex_space_3_complex",
+    "target": "OXPHOS_space_factors_complex",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "complex_space_4_complex",
+    "target": "OXPHOS_space_factors_complex",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "F-ATPase_complex_mitochondrial_matrix",
+    "target": "ATP5MG",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "F-ATPase:Nsp6_complex",
+    "target": "ATP5MG",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "OXPHOS_space_factors_complex",
+    "target": "ACAD9",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "OXPHOS_space_factors_complex",
+    "target": "ECSIT",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "OXPHOS_space_factors_complex",
+    "target": "NDUFAF7",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "target": "complex_space_2_complex_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "complex_space_2_complex_mitochondrial_matrix",
+    "target": "Q_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "complex_space_3_complex",
+    "target": "Q_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "target": "Q_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "complex_space_2_complex_mitochondrial_matrix",
+    "target": "SIRT3",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "SOD2",
+    "target": "SIRT3",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "complex_space_4_complex",
+    "target": "complex_space_3_complex",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "Q_simple_molecule_mitochondrial_matrix",
+    "target": "complex_space_3_complex",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "H+_ion_mitochondrion",
+    "target": "complex_space_3_complex",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "O2-_simple_molecule",
+    "target": "complex_space_3_complex",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "CYCS_mitochondrial_matrix",
+    "target": "complex_space_3_complex",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "complex_space_3_complex",
+    "target": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "complex_space_4_complex",
+    "target": "mtDNA_space_encoded_space_OXPHOS_space_units_complex_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "complex_space_2_complex_mitochondrial_matrix",
+    "target": "TCA_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "MT_space_tRNAs_complex",
+    "target": "mt_space_DNA_gene",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "mt_space_mRNA_rna",
+    "target": "mt_space_DNA_gene",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "damaged_space_mt_space_DNA_gene",
+    "target": "mt_space_DNA_gene",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "MT_space_tRNAs_complex",
+    "target": "Mt-tRNA_space_synthetase_complex",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "MT_space_tRNAs_complex",
+    "target": "TRMT1",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "Nsp8-affected_Mt_ribosomal_proteins_complex",
+    "target": "Nsp8",
+    "sign": false
+   },
+   {
+    "id": "t60",
+    "source": "paraquat_simple_molecule",
+    "target": "paraquat_space_dication_complex",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "paraquat_space_dication_complex",
+    "target": "paraquat_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "superoxide_simple_molecule",
+    "target": "paraquat_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "paraquat_space_dication_complex",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "Q_simple_molecule_mitochondrial_matrix",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "H+_ion_mitochondrion",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "superoxide_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "O2-_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "CYCS_mitochondrial_matrix",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "complex_space_4_complex",
+    "target": "CYCS_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "Nsp4:DNAJC11_complex",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "Nsp4_mitochondrion",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "Nsp4:DNAJC11_complex",
+    "target": "DNAJC11",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "Fe3+_ion",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "Fe2+_ion",
+    "target": "Fe3+_ion",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "O2_simple_molecule",
+    "target": "Fe3+_ion",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "Fe3+_ion",
+    "target": "hydroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "hydroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "H2O_simple_molecule",
+    "target": "hydroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "ROS_simple_molecule",
+    "target": "hydroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "HO_simple_molecule",
+    "target": "hydroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "superoxide_simple_molecule",
+    "target": "hydroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "Fe3+_ion",
+    "target": "Fe2+_ion",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "HO_simple_molecule",
+    "target": "Fe2+_ion",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "hydroxide_simple_molecule",
+    "target": "Fe2+_ion",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "Fe3+_ion",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "H2O_simple_molecule",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "ROS_simple_molecule",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "TXN2",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "HO_simple_molecule",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "superoxide_simple_molecule",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "hydroxide_simple_molecule",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "glutathione_space_disulfide_simple_molecule",
+    "target": "H2O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "paraquat_simple_molecule",
+    "target": "superoxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "H2O2_simple_molecule",
+    "target": "superoxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "superoxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "Fe2+_ion",
+    "target": "superoxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "ROS_simple_molecule",
+    "target": "superoxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "O2_simple_molecule",
+    "target": "superoxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "mt_space_mRNA_rna",
+    "target": "TFAM",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "mt_space_DNA_gene",
+    "target": "TFAM",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "mt_space_DNA_space_replication_phenotype",
+    "target": "TFAM",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "mt_space_mRNA_rna",
+    "target": "MT_space_transcription_complex",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "mt_space_mRNA_rna",
+    "target": "damaged_space_mt_space_DNA_gene",
+    "sign": false
+   },
+   {
+    "id": "t105",
+    "source": "mt_space_DNA_gene",
+    "target": "damaged_space_mt_space_DNA_gene",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "ECSIT",
+    "target": "Orf9c",
+    "sign": false
+   },
+   {
+    "id": "t107",
+    "source": "NDUFA1",
+    "target": "Orf9c",
+    "sign": false
+   },
+   {
+    "id": "t108",
+    "source": "NDUFB9",
+    "target": "Orf9c",
+    "sign": false
+   },
+   {
+    "id": "t109",
+    "source": "ACAD9",
+    "target": "Orf9c",
+    "sign": false
+   },
+   {
+    "id": "t110",
+    "source": "H2O2_simple_molecule",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "Q_simple_molecule_mitochondrial_matrix",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "H+_ion_mitochondrion",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "ATP_simple_molecule",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "O2-_simple_molecule",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "CYCS_mitochondrial_matrix",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "H2O2_simple_molecule",
+    "target": "SOD1",
+    "sign": true
+   },
+   {
+    "id": "t117",
+    "source": "H2O2_simple_molecule",
+    "target": "SOD2",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "mt_space_DNA_gene",
+    "target": "mt_space_DNA_space_damage_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t119",
+    "source": "damaged_space_mt_space_DNA_gene",
+    "target": "mt_space_DNA_space_damage_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "mt_space_DNA_gene",
+    "target": "mt_space_DNA_space_replication_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "mt_space_DNA_gene",
+    "target": "Mt-DNA_space_repair_complex",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "mt_space_DNA_gene",
+    "target": "Mt-dNTP_space_pool_complex",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "mt_space_DNA_space_replication_phenotype",
+    "target": "Mt-dNTP_space_pool_complex",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "H2O_simple_molecule",
+    "target": "glutathione_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "glutathione_space_disulfide_simple_molecule",
+    "target": "glutathione_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "H2O_simple_molecule",
+    "target": "GPX4",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "glutathione_space_disulfide_simple_molecule",
+    "target": "GPX4",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "H2O_simple_molecule",
+    "target": "GPX1",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "glutathione_space_disulfide_simple_molecule",
+    "target": "GPX1",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "H2O_simple_molecule",
+    "target": "CAT",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "H2O_simple_molecule",
+    "target": "TXN2",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "NADP(+)_simple_molecule",
+    "target": "TXN2",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "H2O_simple_molecule",
+    "target": "PRDX_complex",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "TXN2",
+    "target": "PRDX_complex",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "Q_simple_molecule_mitochondrial_matrix",
+    "target": "CYCS_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "H+_ion_mitochondrion",
+    "target": "CYCS_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "O2-_simple_molecule",
+    "target": "CYCS_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "Q_simple_molecule_mitochondrial_matrix",
+    "target": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t141",
+    "source": "H+_ion_mitochondrion",
+    "target": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "O2-_simple_molecule",
+    "target": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "CYCS_mitochondrial_matrix",
+    "target": "ubiquinol_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t144",
+    "source": "TXN2",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "NADP(+)_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "glutathione_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "TXN2",
+    "target": "TXNRD2",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "NADP(+)_simple_molecule",
+    "target": "TXNRD2",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "NADP(+)_simple_molecule",
+    "target": "glutathione_space_disulfide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "glutathione_simple_molecule",
+    "target": "glutathione_space_disulfide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "NADP(+)_simple_molecule",
+    "target": "GSR",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "glutathione_simple_molecule",
+    "target": "GSR",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "ATP_simple_molecule",
+    "target": "ADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "ATP_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "mt_space_DNA_space_replication_phenotype",
+    "target": "Mt_space_replication_complex",
+    "sign": true
+   },
+   {
+    "id": "t156",
+    "source": "precursor_space_protein_space_N-terminus_space_binding",
+    "target": "TOM_space_complex_complex_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "precursor_space_protein_space_N-terminus_space_binding",
+    "target": "Orf9b",
+    "sign": false
+   },
+   {
+    "id": "t158",
+    "source": "precursor_space_protein_space_N-terminus_space_binding",
+    "target": "TIM23_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "NDUFAF7",
+    "target": "Nsp7",
+    "sign": false
+   },
+   {
+    "id": "t160",
+    "source": "Nsp4_mitochondrion",
+    "target": "TOM_space_complex_complex_mitochondrion",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/E_protein.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/E_protein.json
@@ -1,0 +1,542 @@
+{
+ "header": {
+  "name": "E_protein",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on E_protein",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "histone_complex_nucleus",
+    "name": "histone_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Chromatin_organization_phenotype",
+    "name": "Chromatin_organization_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BRD4",
+    "name": "BRD4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "CDK9",
+    "name": "CDK9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "CCNT1",
+    "name": "CCNT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "BRD2",
+    "name": "BRD2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "TBP",
+    "name": "TBP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "H4C14",
+    "name": "H4C14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H4-16",
+    "name": "H4-16",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H4C1",
+    "name": "H4C1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H3C15",
+    "name": "H3C15",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H3C1",
+    "name": "H3C1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H4C9",
+    "name": "H4C9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2BC21",
+    "name": "H2BC21",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2A",
+    "name": "H2A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CRB3:PALS1:PATJ_complex_complex",
+    "name": "CRB3:PALS1:PATJ_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Maintenance_of_tight_junction_phenotype",
+    "name": "Maintenance_of_tight_junction_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MPP5",
+    "name": "MPP5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "E-PALS1_complex",
+    "name": "E-PALS1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CRB3",
+    "name": "CRB3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "PATJ",
+    "name": "PATJ",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "ASIC1_trimer:H+:STOML3_complex",
+    "name": "ASIC1_trimer:H+:STOML3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Activity_of_sodium_channels_phenotype",
+    "name": "Activity_of_sodium_channels_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ASIC1",
+    "name": "ASIC1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STOML3",
+    "name": "STOML3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_cell",
+    "name": "E_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP1A:ATP1B:FXYDs_complex",
+    "name": "ATP1A:ATP1B:FXYDs_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "K+_ion",
+    "name": "K+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Na+_ion",
+    "name": "Na+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "P-TEFb_complex",
+    "name": "P-TEFb_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RNA_Polymerase_II-dependent_Transcription__phenotype",
+    "name": "RNA_Polymerase_II-dependent_Transcription__phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_nucleus",
+    "name": "E_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "JQ-1_simple_molecule",
+    "name": "JQ-1_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion",
+    "name": "H+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Chromatin_organization_phenotype",
+    "target": "histone_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "histone_complex_nucleus",
+    "target": "BRD4",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "CDK9",
+    "target": "BRD4",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "CCNT1",
+    "target": "BRD4",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "histone_complex_nucleus",
+    "target": "BRD2",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "TBP",
+    "target": "BRD2",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "histone_complex_nucleus",
+    "target": "H4C14",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "histone_complex_nucleus",
+    "target": "H4-16",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "histone_complex_nucleus",
+    "target": "H4C1",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "histone_complex_nucleus",
+    "target": "H3C15",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "histone_complex_nucleus",
+    "target": "H3C1",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "histone_complex_nucleus",
+    "target": "H4C9",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "histone_complex_nucleus",
+    "target": "H2BC21",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "histone_complex_nucleus",
+    "target": "H2A",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "Maintenance_of_tight_junction_phenotype",
+    "target": "CRB3:PALS1:PATJ_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "CRB3:PALS1:PATJ_complex_complex",
+    "target": "MPP5",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "E-PALS1_complex",
+    "target": "MPP5",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "CRB3:PALS1:PATJ_complex_complex",
+    "target": "CRB3",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "CRB3:PALS1:PATJ_complex_complex",
+    "target": "PATJ",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "Activity_of_sodium_channels_phenotype",
+    "target": "ASIC1_trimer:H+:STOML3_complex",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "ASIC1_trimer:H+:STOML3_complex",
+    "target": "ASIC1",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "ASIC1_trimer:H+:STOML3_complex",
+    "target": "STOML3",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "Activity_of_sodium_channels_phenotype",
+    "target": "STOML3",
+    "sign": false
+   },
+   {
+    "id": "t30",
+    "source": "ASIC1_trimer:H+:STOML3_complex",
+    "target": "E_cell",
+    "sign": false
+   },
+   {
+    "id": "t31",
+    "source": "ATP1A:ATP1B:FXYDs_complex",
+    "target": "E_cell",
+    "sign": false
+   },
+   {
+    "id": "t32",
+    "source": "E-PALS1_complex",
+    "target": "E_cell",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "K+_ion",
+    "target": "ATP1A:ATP1B:FXYDs_complex",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "Na+_ion",
+    "target": "ATP1A:ATP1B:FXYDs_complex",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "Activity_of_sodium_channels_phenotype",
+    "target": "ATP1A:ATP1B:FXYDs_complex",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "Maintenance_of_tight_junction_phenotype",
+    "target": "E-PALS1_complex",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "RNA_Polymerase_II-dependent_Transcription__phenotype",
+    "target": "P-TEFb_complex",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "P-TEFb_complex",
+    "target": "CDK9",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "P-TEFb_complex",
+    "target": "CCNT1",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "BRD4",
+    "target": "E_nucleus",
+    "sign": false
+   },
+   {
+    "id": "t43",
+    "source": "BRD2",
+    "target": "E_nucleus",
+    "sign": false
+   },
+   {
+    "id": "t45",
+    "source": "BRD2",
+    "target": "JQ-1_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t46",
+    "source": "ASIC1",
+    "target": "H+_ion",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/HMOX1_Pathway.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/HMOX1_Pathway.json
@@ -1,0 +1,2600 @@
+{
+ "header": {
+  "name": "HMOX1_Pathway",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on HMOX1_Pathway",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "Nrf2/Maf_complex",
+    "name": "Nrf2/Maf_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMOX1_rna",
+    "name": "HMOX1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NRF2_phosphorylated_nucleus",
+    "name": "NRF2_phosphorylated_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC40A1_rna",
+    "name": "SLC40A1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FTH1_rna",
+    "name": "FTH1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FTL_rna",
+    "name": "FTL_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FECH_rna",
+    "name": "FECH_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BLVRA_rna",
+    "name": "BLVRA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BLVRB_rna",
+    "name": "BLVRB_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAF",
+    "name": "MAF",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BACH1/Maf_complex",
+    "name": "BACH1/Maf_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BACH1",
+    "name": "BACH1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ubiquitin_Ligase_Complex_complex_cell",
+    "name": "Ubiquitin_Ligase_Complex_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "E2_ubiquitinated",
+    "name": "E2_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NRF2_ubiquitinated",
+    "name": "NRF2_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NRF2:KEAP1_complex",
+    "name": "NRF2:KEAP1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NRF2_empty",
+    "name": "NRF2_empty",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NRF2_phosphorylated_cell",
+    "name": "NRF2_phosphorylated_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "KEAP1",
+    "name": "KEAP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Dimethly_fumarate_drug",
+    "name": "Dimethly_fumarate_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Neddylated_CUL3:RBX1_complex",
+    "name": "Neddylated_CUL3:RBX1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CUL3:RBX1_complex",
+    "name": "CUL3:RBX1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC40A1:CP:Cu2+_complex",
+    "name": "SLC40A1:CP:Cu2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe2+_ion_default_compartment",
+    "name": "Fe2+_ion_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe3+_ion_default_compartment",
+    "name": "Fe3+_ion_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_default_compartment",
+    "name": "H2O_simple_molecule_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CAND1",
+    "name": "CAND1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "holoTF_complex",
+    "name": "holoTF_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TFRC:holoTF_complex_cell",
+    "name": "TFRC:holoTF_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Transferrin",
+    "name": "Transferrin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TFRC:holoTF_complex_endosome",
+    "name": "TFRC:holoTF_complex_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TFRC",
+    "name": "TFRC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TFRC:TF_complex_endosome",
+    "name": "TFRC:TF_complex_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe3+_ion_endosome",
+    "name": "Fe3+_ion_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TFRC:TF_complex_cell",
+    "name": "TFRC:TF_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXNIP:NLRP3_complex",
+    "name": "TXNIP:NLRP3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_cell_active",
+    "name": "NLRP3_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_cell",
+    "name": "NLRP3_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3:SUGT1:HSP90_complex",
+    "name": "NLRP3:SUGT1:HSP90_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXNIP",
+    "name": "TXNIP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thioredoxin:TXNIP_complex",
+    "name": "Thioredoxin:TXNIP_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SUGT1:HSP90AB1_complex",
+    "name": "SUGT1:HSP90AB1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BLVRA:Zn2+_complex",
+    "name": "BLVRA:Zn2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADP+_simple_molecule",
+    "name": "NADP+_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Bilirubin_simple_molecule_cell",
+    "name": "Bilirubin_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXN_cell",
+    "name": "TXN_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Pyrin_trimer_complex",
+    "name": "Pyrin_trimer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PSTPIP1_trimer:Pyrin_trimer_complex",
+    "name": "PSTPIP1_trimer:Pyrin_trimer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pyrin_trimer:ASC_complex",
+    "name": "Pyrin_trimer:ASC_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PSTPIP1",
+    "name": "PSTPIP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_oligomer:ASC_complex",
+    "name": "NLRP3_oligomer:ASC_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_oligomer:ASC:Caspase1_complex",
+    "name": "NLRP3_oligomer:ASC:Caspase1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ASC",
+    "name": "ASC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP1_cell",
+    "name": "CASP1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTSG",
+    "name": "CTSG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ferritin_complex",
+    "name": "Ferritin_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe(3+)O(OH)_simple_molecule",
+    "name": "Fe(3+)O(OH)_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Bilirubin_simple_molecule_default_compartment",
+    "name": "Bilirubin_simple_molecule_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ALB/BIL_complex",
+    "name": "ALB/BIL_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ALB",
+    "name": "ALB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Caspase-1_Tetramer_complex",
+    "name": "Caspase-1_Tetramer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "proIL-1B_cell",
+    "name": "proIL-1B_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "proIL-18_cell",
+    "name": "proIL-18_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IL-1B_cell",
+    "name": "IL-1B_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL-18_cell",
+    "name": "IL-18_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP1(120-197):CASP1(317-404)_complex",
+    "name": "CASP1(120-197):CASP1(317-404)_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Heme_simple_molecule_cell",
+    "name": "Heme_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Biliverdin_simple_molecule",
+    "name": "Biliverdin_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_cell",
+    "name": "H2O_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe2+_ion_cell",
+    "name": "Fe2+_ion_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "CO_simple_molecule",
+    "name": "CO_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Heme_simple_molecule_default_compartment",
+    "name": "Heme_simple_molecule_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP_simple_molecule",
+    "name": "ADP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pi_simple_molecule",
+    "name": "Pi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Heme_simple_molecule_mitochondrial_matrix",
+    "name": "Heme_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dALA_simple_molecule_mitochondrial_matrix",
+    "name": "dALA_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CO2_simple_molecule_mitochondrial_matrix",
+    "name": "CO2_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CoA-SH_simple_molecule",
+    "name": "CoA-SH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FLVCR1-2",
+    "name": "FLVCR1-2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2_simple_molecule_cell",
+    "name": "O2_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADPH_simple_molecule",
+    "name": "NADPH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMOX1_cell_active",
+    "name": "HMOX1_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRIN9_simple_molecule_mitochondrial_matrix",
+    "name": "PRIN9_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_mitochondrial_matrix",
+    "name": "H+_ion_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe2+_ion_mitochondrial_matrix",
+    "name": "Fe2+_ion_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FECH",
+    "name": "FECH",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pb2+_ion",
+    "name": "Pb2+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMBL_simple_molecule",
+    "name": "HMBL_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NH4+_ion",
+    "name": "NH4+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dALA_simple_molecule_cell",
+    "name": "dALA_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PBG_simple_molecule",
+    "name": "PBG_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_cell",
+    "name": "H+_ion_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ALAD:Zn2+_complex",
+    "name": "ALAD:Zn2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BLVRB",
+    "name": "BLVRB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Reactive_Oxygen_Species_simple_molecule",
+    "name": "Reactive_Oxygen_Species_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC11A2",
+    "name": "SLC11A2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe2+_ion_endosome",
+    "name": "Fe2+_ion_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MCOLN1",
+    "name": "MCOLN1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMOX1_cell",
+    "name": "HMOX1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ABCC1",
+    "name": "ABCC1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ORF9c",
+    "name": "ORF9c",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "miRNA-155_rna",
+    "name": "miRNA-155_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRIN9_simple_molecule_mitochondrion",
+    "name": "PRIN9_simple_molecule_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SUCC-CoA_simple_molecule",
+    "name": "SUCC-CoA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Gly_simple_molecule",
+    "name": "Gly_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ALAS1:ALAS2_complex",
+    "name": "ALAS1:ALAS2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Panhematin_drug",
+    "name": "Panhematin_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "URO3_simple_molecule",
+    "name": "URO3_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMBS:DIPY_complex",
+    "name": "HMBS:DIPY_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPRO3_simple_molecule_cell",
+    "name": "COPRO3_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UROS",
+    "name": "UROS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPRO3_simple_molecule_mitochondrion",
+    "name": "COPRO3_simple_molecule_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UROD",
+    "name": "UROD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPGEN9_simple_molecule",
+    "name": "PPGEN9_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CO2_simple_molecule_mitochondrion",
+    "name": "CO2_simple_molecule_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O2_simple_molecule",
+    "name": "H2O2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2_simple_molecule_mitochondrion",
+    "name": "O2_simple_molecule_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CPOX",
+    "name": "CPOX",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPO:FAD_complex",
+    "name": "PPO:FAD_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Lipid_Peroxide_simple_molecule",
+    "name": "Lipid_Peroxide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ferroptosis_phenotype",
+    "name": "Ferroptosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Lipid_alcohol_simple_molecule",
+    "name": "Lipid_alcohol_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Poly-unsaturated_fatty_acid_simple_molecule",
+    "name": "Poly-unsaturated_fatty_acid_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC40A1:HEPH:Cu2+_complex",
+    "name": "SLC40A1:HEPH:Cu2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "e-_ion_default_compartment",
+    "name": "e-_ion_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CYBRD1:Heme_complex",
+    "name": "CYBRD1:Heme_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2_simple_molecule_default_compartment",
+    "name": "O2_simple_molecule_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_default_compartment",
+    "name": "H+_ion_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GPX4",
+    "name": "GPX4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ORF3a",
+    "name": "ORF3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PKC",
+    "name": "PKC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CK2",
+    "name": "CK2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FLVCR1-1",
+    "name": "FLVCR1-1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule",
+    "name": "ATP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ABCG2",
+    "name": "ABCG2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "e-_ion_endosome",
+    "name": "e-_ion_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STEAP3",
+    "name": "STEAP3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_rna",
+    "name": "NLRP3_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nf-KB_Complex_complex",
+    "name": "Nf-KB_Complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL-1B_default_compartment",
+    "name": "IL-1B_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL-18_default_compartment",
+    "name": "IL-18_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS_E",
+    "name": "SARS_E",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PAMPs_phenotype",
+    "name": "PAMPs_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DAMPs_phenotype",
+    "name": "DAMPs_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS_Orf3a",
+    "name": "SARS_Orf3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_Elicitor_Small_Molecules_simple_molecule",
+    "name": "NLRP3_Elicitor_Small_Molecules_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_Elicitor_Proteins",
+    "name": "NLRP3_Elicitor_Proteins",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "HMOX1_rna",
+    "target": "Nrf2/Maf_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "Nrf2/Maf_complex",
+    "target": "NRF2_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "SLC40A1_rna",
+    "target": "NRF2_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "FTH1_rna",
+    "target": "NRF2_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "FTL_rna",
+    "target": "NRF2_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "FECH_rna",
+    "target": "NRF2_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "BLVRA_rna",
+    "target": "NRF2_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "BLVRB_rna",
+    "target": "NRF2_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "Nrf2/Maf_complex",
+    "target": "MAF",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "BACH1/Maf_complex",
+    "target": "MAF",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "HMOX1_rna",
+    "target": "BACH1/Maf_complex",
+    "sign": false
+   },
+   {
+    "id": "t12",
+    "source": "BACH1/Maf_complex",
+    "target": "BACH1",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "Ubiquitin_Ligase_Complex_complex_cell",
+    "target": "E2_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "NRF2_ubiquitinated",
+    "target": "Ubiquitin_Ligase_Complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "Ubiquitin_Ligase_Complex_complex_cell",
+    "target": "NRF2:KEAP1_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "NRF2:KEAP1_complex",
+    "target": "NRF2_empty",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "NRF2_phosphorylated_cell",
+    "target": "NRF2_empty",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "NRF2:KEAP1_complex",
+    "target": "KEAP1",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "NRF2:KEAP1_complex",
+    "target": "Dimethly_fumarate_drug",
+    "sign": false
+   },
+   {
+    "id": "t21",
+    "source": "Ubiquitin_Ligase_Complex_complex_cell",
+    "target": "Neddylated_CUL3:RBX1_complex",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "Neddylated_CUL3:RBX1_complex",
+    "target": "CUL3:RBX1_complex",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "Fe2+_ion_default_compartment",
+    "target": "SLC40A1:CP:Cu2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "Fe3+_ion_default_compartment",
+    "target": "SLC40A1:CP:Cu2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "H2O_simple_molecule_default_compartment",
+    "target": "SLC40A1:CP:Cu2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "SLC40A1:CP:Cu2+_complex",
+    "target": "SLC40A1_rna",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "Ubiquitin_Ligase_Complex_complex_cell",
+    "target": "CAND1",
+    "sign": false
+   },
+   {
+    "id": "t28",
+    "source": "TFRC:holoTF_complex_cell",
+    "target": "holoTF_complex",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "holoTF_complex",
+    "target": "Fe3+_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "Fe2+_ion_default_compartment",
+    "target": "Fe3+_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "holoTF_complex",
+    "target": "Transferrin",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "TFRC:holoTF_complex_endosome",
+    "target": "TFRC:holoTF_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "TFRC:holoTF_complex_cell",
+    "target": "TFRC",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "TFRC:TF_complex_endosome",
+    "target": "TFRC:holoTF_complex_endosome",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "Fe3+_ion_endosome",
+    "target": "TFRC:holoTF_complex_endosome",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "TFRC:TF_complex_cell",
+    "target": "TFRC:TF_complex_endosome",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "Transferrin",
+    "target": "TFRC:TF_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "TFRC",
+    "target": "TFRC:TF_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "NLRP3_cell_active",
+    "target": "TXNIP:NLRP3_complex",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "TXNIP:NLRP3_complex",
+    "target": "NLRP3_cell",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "NLRP3:SUGT1:HSP90_complex",
+    "target": "NLRP3_cell",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "NLRP3_cell_active",
+    "target": "NLRP3_cell",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "TXNIP:NLRP3_complex",
+    "target": "TXNIP",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "Thioredoxin:TXNIP_complex",
+    "target": "TXNIP",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "NLRP3:SUGT1:HSP90_complex",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "NLRP3_cell",
+    "target": "NLRP3:SUGT1:HSP90_complex",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "NLRP3:SUGT1:HSP90_complex",
+    "target": "SUGT1:HSP90AB1_complex",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "NADP+_simple_molecule",
+    "target": "BLVRA:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "Bilirubin_simple_molecule_cell",
+    "target": "BLVRA:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "BLVRA:Zn2+_complex",
+    "target": "BLVRA_rna",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "TXNIP",
+    "target": "Thioredoxin:TXNIP_complex",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "TXN_cell",
+    "target": "Thioredoxin:TXNIP_complex",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "Thioredoxin:TXNIP_complex",
+    "target": "TXN_cell",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "PSTPIP1_trimer:Pyrin_trimer_complex",
+    "target": "Pyrin_trimer_complex",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "Pyrin_trimer:ASC_complex",
+    "target": "Pyrin_trimer_complex",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "PSTPIP1_trimer:Pyrin_trimer_complex",
+    "target": "PSTPIP1",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "NLRP3_oligomer:ASC:Caspase1_complex",
+    "target": "NLRP3_oligomer:ASC_complex",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "NLRP3_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "ASC",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "Pyrin_trimer:ASC_complex",
+    "target": "ASC",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "NLRP3_oligomer:ASC:Caspase1_complex",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "CASP1_cell",
+    "target": "NLRP3_oligomer:ASC:Caspase1_complex",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "CTSG",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "CASP1_cell",
+    "target": "CTSG",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "NLRP3_oligomer:ASC:Caspase1_complex",
+    "target": "CASP1_cell",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "Fe(3+)O(OH)_simple_molecule",
+    "target": "Ferritin_complex",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "Ferritin_complex",
+    "target": "FTH1_rna",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "Ferritin_complex",
+    "target": "FTL_rna",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "ALB/BIL_complex",
+    "target": "Bilirubin_simple_molecule_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "ALB/BIL_complex",
+    "target": "ALB",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "proIL-1B_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "proIL-18_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "IL-1B_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "IL-18_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "Caspase-1_Tetramer_complex",
+    "target": "CASP1(120-197):CASP1(317-404)_complex",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "CASP1(120-197):CASP1(317-404)_complex",
+    "target": "CASP1_cell",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "Biliverdin_simple_molecule",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "H2O_simple_molecule_cell",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "NADP+_simple_molecule",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "Fe2+_ion_cell",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "CO_simple_molecule",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "Heme_simple_molecule_default_compartment",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "ADP_simple_molecule",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "Pi_simple_molecule",
+    "target": "Heme_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "Heme_simple_molecule_cell",
+    "target": "Heme_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "dALA_simple_molecule_mitochondrial_matrix",
+    "target": "Heme_simple_molecule_mitochondrial_matrix",
+    "sign": false
+   },
+   {
+    "id": "t88",
+    "source": "CO2_simple_molecule_mitochondrial_matrix",
+    "target": "Heme_simple_molecule_mitochondrial_matrix",
+    "sign": false
+   },
+   {
+    "id": "t89",
+    "source": "CoA-SH_simple_molecule",
+    "target": "Heme_simple_molecule_mitochondrial_matrix",
+    "sign": false
+   },
+   {
+    "id": "t90",
+    "source": "Heme_simple_molecule_cell",
+    "target": "FLVCR1-2",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "NADP+_simple_molecule",
+    "target": "Biliverdin_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "Bilirubin_simple_molecule_cell",
+    "target": "Biliverdin_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "Biliverdin_simple_molecule",
+    "target": "O2_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "H2O_simple_molecule_cell",
+    "target": "O2_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "NADP+_simple_molecule",
+    "target": "O2_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "Fe2+_ion_cell",
+    "target": "O2_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "CO_simple_molecule",
+    "target": "O2_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "Fe(3+)O(OH)_simple_molecule",
+    "target": "O2_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "Biliverdin_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "H2O_simple_molecule_cell",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "NADP+_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "Fe2+_ion_cell",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "CO_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "Bilirubin_simple_molecule_cell",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "Biliverdin_simple_molecule",
+    "target": "HMOX1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "H2O_simple_molecule_cell",
+    "target": "HMOX1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "NADP+_simple_molecule",
+    "target": "HMOX1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t108",
+    "source": "Fe2+_ion_cell",
+    "target": "HMOX1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "CO_simple_molecule",
+    "target": "HMOX1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "Heme_simple_molecule_mitochondrial_matrix",
+    "target": "PRIN9_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "PRIN9_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "Heme_simple_molecule_mitochondrial_matrix",
+    "target": "Fe2+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "Fe2+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "Heme_simple_molecule_mitochondrial_matrix",
+    "target": "FECH",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "FECH",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "Heme_simple_molecule_mitochondrial_matrix",
+    "target": "Pb2+_ion",
+    "sign": false
+   },
+   {
+    "id": "t117",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "Pb2+_ion",
+    "sign": false
+   },
+   {
+    "id": "t118",
+    "source": "HMBL_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "NH4+_ion",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "Heme_simple_molecule_default_compartment",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "ADP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "Pi_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "H2O_simple_molecule_cell",
+    "target": "dALA_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "PBG_simple_molecule",
+    "target": "dALA_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "H+_ion_cell",
+    "target": "dALA_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "H2O_simple_molecule_cell",
+    "target": "ALAD:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "PBG_simple_molecule",
+    "target": "ALAD:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "H+_ion_cell",
+    "target": "ALAD:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "NADP+_simple_molecule",
+    "target": "BLVRB",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "Bilirubin_simple_molecule_cell",
+    "target": "BLVRB",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "Fe2+_ion_default_compartment",
+    "target": "Fe2+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "Fe(3+)O(OH)_simple_molecule",
+    "target": "Fe2+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "Reactive_Oxygen_Species_simple_molecule",
+    "target": "Fe2+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "Fe2+_ion_cell",
+    "target": "Fe2+_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "Fe3+_ion_default_compartment",
+    "target": "Fe2+_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "H2O_simple_molecule_default_compartment",
+    "target": "Fe2+_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "Fe2+_ion_cell",
+    "target": "SLC11A2",
+    "sign": true
+   },
+   {
+    "id": "t139",
+    "source": "Fe2+_ion_cell",
+    "target": "Fe2+_ion_endosome",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "Fe2+_ion_cell",
+    "target": "MCOLN1",
+    "sign": true
+   },
+   {
+    "id": "t141",
+    "source": "HMOX1_cell_active",
+    "target": "HMOX1_cell",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "HMOX1_cell",
+    "target": "HMOX1_rna",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "Reactive_Oxygen_Species_simple_molecule",
+    "target": "CO_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t144",
+    "source": "Bilirubin_simple_molecule_default_compartment",
+    "target": "Bilirubin_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "BLVRB",
+    "target": "BLVRB_rna",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "Bilirubin_simple_molecule_default_compartment",
+    "target": "ABCC1",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "ABCC1",
+    "target": "ORF9c",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "NRF2_phosphorylated_nucleus",
+    "target": "NRF2_phosphorylated_cell",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "BACH1",
+    "target": "miRNA-155_rna",
+    "sign": false
+   },
+   {
+    "id": "t150",
+    "source": "FECH",
+    "target": "FECH_rna",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "PRIN9_simple_molecule_mitochondrial_matrix",
+    "target": "PRIN9_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "dALA_simple_molecule_mitochondrial_matrix",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "CO2_simple_molecule_mitochondrial_matrix",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "CoA-SH_simple_molecule",
+    "target": "H+_ion_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "dALA_simple_molecule_cell",
+    "target": "dALA_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t156",
+    "source": "dALA_simple_molecule_mitochondrial_matrix",
+    "target": "SUCC-CoA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "CO2_simple_molecule_mitochondrial_matrix",
+    "target": "SUCC-CoA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t158",
+    "source": "CoA-SH_simple_molecule",
+    "target": "SUCC-CoA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "dALA_simple_molecule_mitochondrial_matrix",
+    "target": "Gly_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "CO2_simple_molecule_mitochondrial_matrix",
+    "target": "Gly_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "CoA-SH_simple_molecule",
+    "target": "Gly_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "dALA_simple_molecule_mitochondrial_matrix",
+    "target": "ALAS1:ALAS2_complex",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "CO2_simple_molecule_mitochondrial_matrix",
+    "target": "ALAS1:ALAS2_complex",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "CoA-SH_simple_molecule",
+    "target": "ALAS1:ALAS2_complex",
+    "sign": true
+   },
+   {
+    "id": "t165",
+    "source": "dALA_simple_molecule_mitochondrial_matrix",
+    "target": "Panhematin_drug",
+    "sign": false
+   },
+   {
+    "id": "t166",
+    "source": "CO2_simple_molecule_mitochondrial_matrix",
+    "target": "Panhematin_drug",
+    "sign": false
+   },
+   {
+    "id": "t167",
+    "source": "CoA-SH_simple_molecule",
+    "target": "Panhematin_drug",
+    "sign": false
+   },
+   {
+    "id": "t168",
+    "source": "HMBL_simple_molecule",
+    "target": "PBG_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t169",
+    "source": "NH4+_ion",
+    "target": "PBG_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t170",
+    "source": "Fe(3+)O(OH)_simple_molecule",
+    "target": "H+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t171",
+    "source": "URO3_simple_molecule",
+    "target": "HMBL_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t172",
+    "source": "HMBL_simple_molecule",
+    "target": "HMBS:DIPY_complex",
+    "sign": true
+   },
+   {
+    "id": "t173",
+    "source": "NH4+_ion",
+    "target": "HMBS:DIPY_complex",
+    "sign": true
+   },
+   {
+    "id": "t174",
+    "source": "COPRO3_simple_molecule_cell",
+    "target": "URO3_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t175",
+    "source": "URO3_simple_molecule",
+    "target": "UROS",
+    "sign": true
+   },
+   {
+    "id": "t176",
+    "source": "COPRO3_simple_molecule_mitochondrion",
+    "target": "COPRO3_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t177",
+    "source": "COPRO3_simple_molecule_cell",
+    "target": "UROD",
+    "sign": true
+   },
+   {
+    "id": "t178",
+    "source": "PPGEN9_simple_molecule",
+    "target": "COPRO3_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "CO2_simple_molecule_mitochondrion",
+    "target": "COPRO3_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "H2O2_simple_molecule",
+    "target": "COPRO3_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "PRIN9_simple_molecule_mitochondrion",
+    "target": "PPGEN9_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "H2O2_simple_molecule",
+    "target": "PPGEN9_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t183",
+    "source": "PPGEN9_simple_molecule",
+    "target": "O2_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t184",
+    "source": "PRIN9_simple_molecule_mitochondrion",
+    "target": "O2_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "CO2_simple_molecule_mitochondrion",
+    "target": "O2_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t186",
+    "source": "H2O2_simple_molecule",
+    "target": "O2_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "PPGEN9_simple_molecule",
+    "target": "CPOX",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "CO2_simple_molecule_mitochondrion",
+    "target": "CPOX",
+    "sign": true
+   },
+   {
+    "id": "t189",
+    "source": "H2O2_simple_molecule",
+    "target": "CPOX",
+    "sign": true
+   },
+   {
+    "id": "t190",
+    "source": "PRIN9_simple_molecule_mitochondrion",
+    "target": "PPO:FAD_complex",
+    "sign": true
+   },
+   {
+    "id": "t191",
+    "source": "H2O2_simple_molecule",
+    "target": "PPO:FAD_complex",
+    "sign": true
+   },
+   {
+    "id": "t192",
+    "source": "Ferroptosis_phenotype",
+    "target": "Lipid_Peroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t193",
+    "source": "Lipid_alcohol_simple_molecule",
+    "target": "Lipid_Peroxide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t194",
+    "source": "Lipid_Peroxide_simple_molecule",
+    "target": "Poly-unsaturated_fatty_acid_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t195",
+    "source": "Lipid_Peroxide_simple_molecule",
+    "target": "Reactive_Oxygen_Species_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t196",
+    "source": "TXNIP",
+    "target": "Reactive_Oxygen_Species_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t197",
+    "source": "TXN_cell",
+    "target": "Reactive_Oxygen_Species_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t198",
+    "source": "NLRP3_cell_active",
+    "target": "Reactive_Oxygen_Species_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t199",
+    "source": "Fe2+_ion_default_compartment",
+    "target": "SLC40A1:HEPH:Cu2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t200",
+    "source": "Fe3+_ion_default_compartment",
+    "target": "SLC40A1:HEPH:Cu2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t201",
+    "source": "H2O_simple_molecule_default_compartment",
+    "target": "SLC40A1:HEPH:Cu2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t202",
+    "source": "Fe2+_ion_default_compartment",
+    "target": "e-_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t203",
+    "source": "Fe2+_ion_default_compartment",
+    "target": "CYBRD1:Heme_complex",
+    "sign": true
+   },
+   {
+    "id": "t204",
+    "source": "Fe3+_ion_default_compartment",
+    "target": "O2_simple_molecule_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t205",
+    "source": "H2O_simple_molecule_default_compartment",
+    "target": "O2_simple_molecule_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t206",
+    "source": "Fe3+_ion_default_compartment",
+    "target": "H+_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t207",
+    "source": "H2O_simple_molecule_default_compartment",
+    "target": "H+_ion_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t208",
+    "source": "Lipid_alcohol_simple_molecule",
+    "target": "GPX4",
+    "sign": true
+   },
+   {
+    "id": "t209",
+    "source": "HMOX1_cell_active",
+    "target": "ORF3a",
+    "sign": true
+   },
+   {
+    "id": "t210",
+    "source": "NRF2_phosphorylated_cell",
+    "target": "PKC",
+    "sign": true
+   },
+   {
+    "id": "t211",
+    "source": "NRF2_phosphorylated_cell",
+    "target": "CK2",
+    "sign": true
+   },
+   {
+    "id": "t212",
+    "source": "Heme_simple_molecule_default_compartment",
+    "target": "FLVCR1-1",
+    "sign": true
+   },
+   {
+    "id": "t213",
+    "source": "Heme_simple_molecule_default_compartment",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t214",
+    "source": "ADP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t215",
+    "source": "Pi_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t216",
+    "source": "Heme_simple_molecule_default_compartment",
+    "target": "ABCG2",
+    "sign": true
+   },
+   {
+    "id": "t217",
+    "source": "ADP_simple_molecule",
+    "target": "ABCG2",
+    "sign": true
+   },
+   {
+    "id": "t218",
+    "source": "Pi_simple_molecule",
+    "target": "ABCG2",
+    "sign": true
+   },
+   {
+    "id": "t219",
+    "source": "Fe2+_ion_endosome",
+    "target": "Fe3+_ion_endosome",
+    "sign": true
+   },
+   {
+    "id": "t220",
+    "source": "Fe2+_ion_endosome",
+    "target": "e-_ion_endosome",
+    "sign": true
+   },
+   {
+    "id": "t221",
+    "source": "Fe2+_ion_endosome",
+    "target": "STEAP3",
+    "sign": true
+   },
+   {
+    "id": "t222",
+    "source": "NLRP3_cell",
+    "target": "NLRP3_rna",
+    "sign": true
+   },
+   {
+    "id": "t223",
+    "source": "NLRP3_rna",
+    "target": "Nf-KB_Complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t225",
+    "source": "IL-1B_cell",
+    "target": "proIL-1B_cell",
+    "sign": true
+   },
+   {
+    "id": "t227",
+    "source": "IL-18_cell",
+    "target": "proIL-18_cell",
+    "sign": true
+   },
+   {
+    "id": "t228",
+    "source": "IL-1B_default_compartment",
+    "target": "IL-1B_cell",
+    "sign": true
+   },
+   {
+    "id": "t229",
+    "source": "IL-18_default_compartment",
+    "target": "IL-18_cell",
+    "sign": true
+   },
+   {
+    "id": "t230",
+    "source": "NLRP3_cell_active",
+    "target": "SARS_E",
+    "sign": true
+   },
+   {
+    "id": "t231",
+    "source": "NLRP3_cell_active",
+    "target": "PAMPs_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t232",
+    "source": "NLRP3_cell_active",
+    "target": "DAMPs_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t233",
+    "source": "NLRP3_cell_active",
+    "target": "SARS_Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t234",
+    "source": "NLRP3_cell_active",
+    "target": "NLRP3_Elicitor_Small_Molecules_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t235",
+    "source": "NLRP3_cell_active",
+    "target": "NLRP3_Elicitor_Proteins",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/IFN-lambda.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/IFN-lambda.json
@@ -1,0 +1,695 @@
+{
+ "header": {
+  "name": "IFN-lambda",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on IFN-lambda",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "receptor_complex_complex_cell",
+    "name": "receptor_complex_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Ifn_lambda_complex",
+    "name": "Ifn_lambda_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STAT1_phosphorylated",
+    "name": "STAT1_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STAT2_phosphorylated",
+    "name": "STAT2_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISGF3_complex",
+    "name": "ISGF3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISGs_rna",
+    "name": "ISGs_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISGF3_precursor_complex",
+    "name": "ISGF3_precursor_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Inhibited_ISGF3_precursor_complex",
+    "name": "Inhibited_ISGF3_precursor_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF9",
+    "name": "IRF9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SOCS3",
+    "name": "SOCS3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STAT3",
+    "name": "STAT3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "p38-NFkB_complex",
+    "name": "p38-NFkB_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFN-III_rna",
+    "name": "IFN-III_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF3_phosphorylated",
+    "name": "IRF3_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ribosomal_40S_subunit_complex",
+    "name": "ribosomal_40S_subunit_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "inhibited_ribosomal_40S_SU_complex",
+    "name": "inhibited_ribosomal_40S_SU_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "80S_ribosome_complex",
+    "name": "80S_ribosome_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp1",
+    "name": "Nsp1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "inhibited_80S_ribosome_complex",
+    "name": "inhibited_80S_ribosome_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNs_complex",
+    "name": "IFNs_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "antiviral_proteins_complex",
+    "name": "antiviral_proteins_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIG-I-MAVS_complex_mitochondrion",
+    "name": "RIG-I-MAVS_complex_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIG-I-mitoMAVS_complex",
+    "name": "RIG-I-mitoMAVS_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKK-TBK1_complex",
+    "name": "IKK-TBK1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIG-I:dsRNA_complex_mitochondrion",
+    "name": "RIG-I:dsRNA_complex_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "MAVS",
+    "name": "MAVS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIG-I-MAVS_complex_peroxisome",
+    "name": "RIG-I-MAVS_complex_peroxisome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF1_phosphorylated",
+    "name": "IRF1_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dsRNA_rna",
+    "name": "dsRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dsRNA_vesicle_rna",
+    "name": "dsRNA_vesicle_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ribosomal_60S_subunit_complex",
+    "name": "ribosomal_60S_subunit_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M",
+    "name": "M",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIG-1_M-Protein_complex",
+    "name": "RIG-1_M-Protein_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIG-I",
+    "name": "RIG-I",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PLPro",
+    "name": "PLPro",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Riplet:TRIM25_complex",
+    "name": "Riplet:TRIM25_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SOCS1",
+    "name": "SOCS1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFN-III",
+    "name": "IFN-III",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFN-sensitive-response-element_gene",
+    "name": "IFN-sensitive-response-element_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "viral_RNA+N-methyl-Guanine_rna",
+    "name": "viral_RNA+N-methyl-Guanine_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "5'cap-viral-RNA_rna",
+    "name": "5'cap-viral-RNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "viral_RNA_rna",
+    "name": "viral_RNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp14",
+    "name": "nsp14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp16",
+    "name": "nsp16",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RNA_rna",
+    "name": "RNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t2",
+    "source": "Ifn_lambda_complex",
+    "target": "receptor_complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "STAT1_phosphorylated",
+    "target": "receptor_complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "STAT2_phosphorylated",
+    "target": "receptor_complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "receptor_complex_complex_cell",
+    "target": "Ifn_lambda_complex",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "ISGs_rna",
+    "target": "ISGF3_complex",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "ISGF3_complex",
+    "target": "ISGF3_precursor_complex",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "Inhibited_ISGF3_precursor_complex",
+    "target": "ISGF3_precursor_complex",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "ISGF3_complex",
+    "target": "IRF9",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "receptor_complex_complex_cell",
+    "target": "SOCS3",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "Inhibited_ISGF3_precursor_complex",
+    "target": "STAT3",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "IFN-III_rna",
+    "target": "p38-NFkB_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "p38-NFkB_complex",
+    "target": "IRF3_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "inhibited_ribosomal_40S_SU_complex",
+    "target": "ribosomal_40S_subunit_complex",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "80S_ribosome_complex",
+    "target": "ribosomal_40S_subunit_complex",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "inhibited_ribosomal_40S_SU_complex",
+    "target": "Nsp1",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "inhibited_80S_ribosome_complex",
+    "target": "Nsp1",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "inhibited_80S_ribosome_complex",
+    "target": "80S_ribosome_complex",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "IFNs_complex",
+    "target": "80S_ribosome_complex",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "antiviral_proteins_complex",
+    "target": "80S_ribosome_complex",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "IRF3_phosphorylated",
+    "target": "RIG-I-MAVS_complex_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "RIG-I-MAVS_complex_mitochondrion",
+    "target": "RIG-I-mitoMAVS_complex",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "RIG-I-MAVS_complex_mitochondrion",
+    "target": "IKK-TBK1_complex",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "RIG-I-mitoMAVS_complex",
+    "target": "RIG-I:dsRNA_complex_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "RIG-I-mitoMAVS_complex",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "ISGF3_precursor_complex",
+    "target": "STAT1_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "ISGF3_precursor_complex",
+    "target": "STAT2_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "IRF1_phosphorylated",
+    "target": "RIG-I-MAVS_complex_peroxisome",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "RIG-I-MAVS_complex_peroxisome",
+    "target": "dsRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "RIG-I:dsRNA_complex_mitochondrion",
+    "target": "dsRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "dsRNA_vesicle_rna",
+    "target": "dsRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "80S_ribosome_complex",
+    "target": "ribosomal_60S_subunit_complex",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "RIG-1_M-Protein_complex",
+    "target": "M",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "RIG-1_M-Protein_complex",
+    "target": "RIG-I",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "RIG-I:dsRNA_complex_mitochondrion",
+    "target": "RIG-I",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "RIG-I:dsRNA_complex_mitochondrion",
+    "target": "PLPro",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "RIG-I:dsRNA_complex_mitochondrion",
+    "target": "Riplet:TRIM25_complex",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "IFNs_complex",
+    "target": "ISGs_rna",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "antiviral_proteins_complex",
+    "target": "ISGs_rna",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "receptor_complex_complex_cell",
+    "target": "SOCS1",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "Ifn_lambda_complex",
+    "target": "IFN-III",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "ISGs_rna",
+    "target": "IFN-sensitive-response-element_gene",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "5'cap-viral-RNA_rna",
+    "target": "viral_RNA+N-methyl-Guanine_rna",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "viral_RNA+N-methyl-Guanine_rna",
+    "target": "viral_RNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "viral_RNA+N-methyl-Guanine_rna",
+    "target": "nsp14",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "5'cap-viral-RNA_rna",
+    "target": "nsp16",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "dsRNA_rna",
+    "target": "dsRNA_vesicle_rna",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "dsRNA_rna",
+    "target": "RNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "IFN-III_rna",
+    "target": "IRF1_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "IFN-III",
+    "target": "IFN-III_rna",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Interferon1.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Interferon1.json
@@ -1,0 +1,2101 @@
+{
+ "header": {
+  "name": "Interferon1",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Interferon1",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "IFNA1_IFNAR_complex",
+    "name": "IFNA1_IFNAR_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "JAK1_TYK2_complex",
+    "name": "JAK1_TYK2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNAR_complex",
+    "name": "IFNAR_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNB1_IFNAR_complex",
+    "name": "IFNB1_IFNAR_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNA1_extracellular_space",
+    "name": "IFNA1_extracellular_space",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Viral_dsRNA_rna_cell",
+    "name": "Viral_dsRNA_rna_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "type_I_IFN_response_phenotype",
+    "name": "type_I_IFN_response_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR4_TRIF_TRAM_complex",
+    "name": "TLR4_TRIF_TRAM_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAP1",
+    "name": "NAP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRAK1/4",
+    "name": "IRAK1/4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MYD88_TRAM_complex",
+    "name": "MYD88_TRAM_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIF",
+    "name": "TRIF",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR3_TRIF_complex",
+    "name": "TLR3_TRIF_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNB1_extracellular_space",
+    "name": "IFNB1_extracellular_space",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STAT1/2_IRF9_complex",
+    "name": "STAT1/2_IRF9_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISRE_complex",
+    "name": "ISRE_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STAT1_phosphorylated",
+    "name": "STAT1_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF9",
+    "name": "IRF9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STAT2_phosphorylated",
+    "name": "STAT2_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6",
+    "name": "Orf6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF3_homodimer_complex_nucleus",
+    "name": "IRF3_homodimer_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF3_phosphorylated",
+    "name": "IRF3_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TREML4",
+    "name": "TREML4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp5",
+    "name": "Nsp5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDX58_ubiquitinated",
+    "name": "DDX58_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS1_rna",
+    "name": "OAS1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK_rna",
+    "name": "EIF2AK_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS2_rna",
+    "name": "OAS2_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS3_rna",
+    "name": "OAS3_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISG15_rna",
+    "name": "ISG15_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "JAK1",
+    "name": "JAK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TYK2",
+    "name": "TYK2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP-1_complex_cell",
+    "name": "AP-1_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP-1_complex_nucleus",
+    "name": "AP-1_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "JUN",
+    "name": "JUN",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FOS",
+    "name": "FOS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E",
+    "name": "E",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_inflammasome_complex",
+    "name": "NLRP3_inflammasome_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK8/14_complex",
+    "name": "MAPK8/14_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "p50_p65_complex_cell",
+    "name": "p50_p65_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "p50_p65_complex_nucleus",
+    "name": "p50_p65_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IkB_p50_p65_complex_cell",
+    "name": "IkB_p50_p65_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IkB_phosphorylated",
+    "name": "IkB_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS1_EIF2AK_complex",
+    "name": "OAS1_EIF2AK_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISG_expression_antiviral_response_phenotype",
+    "name": "ISG_expression_antiviral_response_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS1_cell_active",
+    "name": "OAS1_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS3_cell_active",
+    "name": "OAS3_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK",
+    "name": "EIF2AK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS2_cell_active",
+    "name": "OAS2_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TBK1_IKBKE_complex",
+    "name": "TBK1_IKBKE_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3_TBK1_IKBKE_complex_cell",
+    "name": "TRAF3_TBK1_IKBKE_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TBK1",
+    "name": "TBK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKBKE",
+    "name": "IKBKE",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3",
+    "name": "TRAF3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp3",
+    "name": "Nsp3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISG15_Nsp3_complex",
+    "name": "ISG15_Nsp3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF6_ubiquitinated",
+    "name": "TRAF6_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Azithromycin_drug",
+    "name": "Azithromycin_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNB1_rna",
+    "name": "IFNB1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFIH1",
+    "name": "IFIH1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MYD88",
+    "name": "MYD88",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR7",
+    "name": "TLR7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR9",
+    "name": "TLR9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Viral_dsRNA_rna_endosome",
+    "name": "Viral_dsRNA_rna_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "name": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF7_phosphorylated",
+    "name": "IRF7_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3_TBK1_IKBKE_complex_cell_active",
+    "name": "TRAF3_TBK1_IKBKE_complex_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TANK",
+    "name": "TANK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR3_TRIF_RIPK1_complex",
+    "name": "TLR3_TRIF_RIPK1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAVS",
+    "name": "MAVS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STING1_ubiquitinated",
+    "name": "STING1_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M",
+    "name": "M",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIG1_MDA5_complex",
+    "name": "RIG1_MDA5_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1ab",
+    "name": "pp1ab",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N",
+    "name": "N",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp10",
+    "name": "Nsp10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp14",
+    "name": "Nsp14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp16",
+    "name": "Nsp16",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp15",
+    "name": "Nsp15",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Proinflammatory_cytokine_expression_Inflammation_phenotype",
+    "name": "Proinflammatory_cytokine_expression_Inflammation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNA1_rna",
+    "name": "IFNA1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MNS_drug",
+    "name": "MNS_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK14",
+    "name": "MAPK14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK8",
+    "name": "MAPK8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP3K7",
+    "name": "MAP3K7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAB1/2_TRAF6_TAK1_complex",
+    "name": "TAB1/2_TRAF6_TAK1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RIP1",
+    "name": "RIP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKKa_IKKb_NEMO_complex",
+    "name": "IKKa_IKKb_NEMO_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAB1",
+    "name": "TAB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAB2",
+    "name": "TAB2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAK1",
+    "name": "TAK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEMO",
+    "name": "NEMO",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKKa",
+    "name": "IKKa",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKKb",
+    "name": "IKKb",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RELA",
+    "name": "RELA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKB1",
+    "name": "NFKB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IkB",
+    "name": "IkB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF3_homodimer_complex_cell",
+    "name": "IRF3_homodimer_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF7_homodimer_complex",
+    "name": "IRF7_homodimer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ISG15",
+    "name": "ISG15",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GRL0617_drug",
+    "name": "GRL0617_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNB1_cell",
+    "name": "IFNB1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNA1_cell",
+    "name": "IFNA1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS1_cell",
+    "name": "OAS1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ITCH",
+    "name": "ITCH",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp13",
+    "name": "Nsp13",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp1",
+    "name": "Nsp1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b",
+    "name": "Orf7b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a",
+    "name": "Orf3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6",
+    "name": "Nsp6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a",
+    "name": "Orf7a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS2_cell",
+    "name": "OAS2_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "OAS3_cell",
+    "name": "OAS3_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_complex",
+    "name": "Orf8_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b",
+    "name": "Orf9b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM25",
+    "name": "TRIM25",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RNF135",
+    "name": "RNF135",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Viral_replication_phenotype",
+    "name": "Viral_replication_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "JAK1_TYK2_complex",
+    "target": "IFNA1_IFNAR_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "IFNA1_IFNAR_complex",
+    "target": "IFNAR_complex",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "IFNB1_IFNAR_complex",
+    "target": "IFNAR_complex",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "IFNA1_IFNAR_complex",
+    "target": "IFNA1_extracellular_space",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "Viral_dsRNA_rna_cell",
+    "target": "IFNA1_extracellular_space",
+    "sign": false
+   },
+   {
+    "id": "t6",
+    "source": "type_I_IFN_response_phenotype",
+    "target": "IFNA1_extracellular_space",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "NAP1",
+    "target": "TLR4_TRIF_TRAM_complex",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "TLR4_TRIF_TRAM_complex",
+    "target": "IRAK1/4",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "MYD88_TRAM_complex",
+    "target": "IRAK1/4",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "TLR4_TRIF_TRAM_complex",
+    "target": "TRIF",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "TLR3_TRIF_complex",
+    "target": "TRIF",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "JAK1_TYK2_complex",
+    "target": "IFNB1_IFNAR_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "IFNB1_IFNAR_complex",
+    "target": "IFNB1_extracellular_space",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "Viral_dsRNA_rna_cell",
+    "target": "IFNB1_extracellular_space",
+    "sign": false
+   },
+   {
+    "id": "t15",
+    "source": "type_I_IFN_response_phenotype",
+    "target": "IFNB1_extracellular_space",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "ISRE_complex",
+    "target": "STAT1/2_IRF9_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "STAT1/2_IRF9_complex",
+    "target": "STAT1_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "STAT1/2_IRF9_complex",
+    "target": "IRF9",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "STAT1/2_IRF9_complex",
+    "target": "STAT2_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "STAT1/2_IRF9_complex",
+    "target": "Orf6",
+    "sign": false
+   },
+   {
+    "id": "t21",
+    "source": "ISRE_complex",
+    "target": "Orf6",
+    "sign": false
+   },
+   {
+    "id": "t22",
+    "source": "IRF3_homodimer_complex_nucleus",
+    "target": "Orf6",
+    "sign": false
+   },
+   {
+    "id": "t23",
+    "source": "IRF3_phosphorylated",
+    "target": "Orf6",
+    "sign": false
+   },
+   {
+    "id": "t24",
+    "source": "STAT1/2_IRF9_complex",
+    "target": "TREML4",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "MYD88_TRAM_complex",
+    "target": "TREML4",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "STAT1/2_IRF9_complex",
+    "target": "JAK1_TYK2_complex",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "STAT1/2_IRF9_complex",
+    "target": "Nsp5",
+    "sign": false
+   },
+   {
+    "id": "t28",
+    "source": "DDX58_ubiquitinated",
+    "target": "Nsp5",
+    "sign": false
+   },
+   {
+    "id": "t29",
+    "source": "OAS1_rna",
+    "target": "ISRE_complex",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "EIF2AK_rna",
+    "target": "ISRE_complex",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "OAS2_rna",
+    "target": "ISRE_complex",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "OAS3_rna",
+    "target": "ISRE_complex",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "ISG15_rna",
+    "target": "ISRE_complex",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "JAK1_TYK2_complex",
+    "target": "JAK1",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "JAK1_TYK2_complex",
+    "target": "TYK2",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "AP-1_complex_nucleus",
+    "target": "AP-1_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "AP-1_complex_cell",
+    "target": "JUN",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "AP-1_complex_cell",
+    "target": "FOS",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "AP-1_complex_cell",
+    "target": "E",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "NLRP3_inflammasome_complex",
+    "target": "E",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "AP-1_complex_cell",
+    "target": "MAPK8/14_complex",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "p50_p65_complex_nucleus",
+    "target": "p50_p65_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "p50_p65_complex_cell",
+    "target": "IkB_p50_p65_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "IkB_phosphorylated",
+    "target": "IkB_p50_p65_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "ISG_expression_antiviral_response_phenotype",
+    "target": "OAS1_EIF2AK_complex",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "OAS1_EIF2AK_complex",
+    "target": "OAS1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "OAS1_EIF2AK_complex",
+    "target": "OAS3_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "OAS1_EIF2AK_complex",
+    "target": "EIF2AK",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "OAS1_EIF2AK_complex",
+    "target": "OAS2_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "TRAF3_TBK1_IKBKE_complex_cell",
+    "target": "TBK1_IKBKE_complex",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "TBK1_IKBKE_complex",
+    "target": "TBK1",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "MAPK8/14_complex",
+    "target": "TBK1",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "IKBKE",
+    "target": "TBK1",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "TBK1_IKBKE_complex",
+    "target": "IKBKE",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "TBK1",
+    "target": "IKBKE",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "TBK1_IKBKE_complex",
+    "target": "TRAF3",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "TRAF3_TBK1_IKBKE_complex_cell",
+    "target": "TRAF3",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "TBK1_IKBKE_complex",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t59",
+    "source": "ISG15_Nsp3_complex",
+    "target": "Nsp3",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "TRAF6_ubiquitinated",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t61",
+    "source": "ISG_expression_antiviral_response_phenotype",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t62",
+    "source": "TRAF3",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t63",
+    "source": "IKBKE",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t64",
+    "source": "IRF3_phosphorylated",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t65",
+    "source": "TBK1_IKBKE_complex",
+    "target": "NAP1",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "TBK1_IKBKE_complex",
+    "target": "Azithromycin_drug",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "TLR3_TRIF_complex",
+    "target": "Azithromycin_drug",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "IFNB1_rna",
+    "target": "Azithromycin_drug",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "ISG_expression_antiviral_response_phenotype",
+    "target": "Azithromycin_drug",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "IFIH1",
+    "target": "Azithromycin_drug",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "DDX58_ubiquitinated",
+    "target": "Azithromycin_drug",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "TRAF6_ubiquitinated",
+    "target": "MYD88_TRAM_complex",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "TRAF3",
+    "target": "MYD88_TRAM_complex",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "MYD88_TRAM_complex",
+    "target": "MYD88",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "MYD88_TRAM_complex",
+    "target": "TLR7",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "MYD88_TRAM_complex",
+    "target": "TLR9",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "MYD88_TRAM_complex",
+    "target": "Viral_dsRNA_rna_endosome",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "TLR3_TRIF_complex",
+    "target": "Viral_dsRNA_rna_endosome",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "IRF3_phosphorylated",
+    "target": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "IRF7_phosphorylated",
+    "target": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "target": "TRAF3_TBK1_IKBKE_complex_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "target": "TANK",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "target": "TLR3_TRIF_complex",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "TLR3_TRIF_RIPK1_complex",
+    "target": "TLR3_TRIF_complex",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "TBK1",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "IRF3_phosphorylated",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "STING1_ubiquitinated",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "TRAF3_TANK_TBK1_IKKepsilon_complex",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t90",
+    "source": "RIG1_MDA5_complex",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t91",
+    "source": "STAT1_phosphorylated",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t92",
+    "source": "TRAF3_TBK1_IKBKE_complex_cell_active",
+    "target": "TRAF3_TBK1_IKBKE_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "TRAF3_TBK1_IKBKE_complex_cell",
+    "target": "pp1ab",
+    "sign": false
+   },
+   {
+    "id": "t94",
+    "source": "TRAF3_TBK1_IKBKE_complex_cell_active",
+    "target": "pp1ab",
+    "sign": false
+   },
+   {
+    "id": "t95",
+    "source": "IRF3_phosphorylated",
+    "target": "pp1ab",
+    "sign": false
+   },
+   {
+    "id": "t96",
+    "source": "STING1_ubiquitinated",
+    "target": "pp1ab",
+    "sign": false
+   },
+   {
+    "id": "t97",
+    "source": "TRAF3_TBK1_IKBKE_complex_cell_active",
+    "target": "STING1_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "TBK1",
+    "target": "STING1_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "MAVS",
+    "target": "RIG1_MDA5_complex",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "RIG1_MDA5_complex",
+    "target": "DDX58_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "RIG1_MDA5_complex",
+    "target": "IFIH1",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "RIG1_MDA5_complex",
+    "target": "Viral_dsRNA_rna_cell",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "RIG1_MDA5_complex",
+    "target": "N",
+    "sign": false
+   },
+   {
+    "id": "t105",
+    "source": "IRF3_phosphorylated",
+    "target": "N",
+    "sign": false
+   },
+   {
+    "id": "t106",
+    "source": "DDX58_ubiquitinated",
+    "target": "N",
+    "sign": false
+   },
+   {
+    "id": "t107",
+    "source": "RIG1_MDA5_complex",
+    "target": "Nsp10",
+    "sign": false
+   },
+   {
+    "id": "t108",
+    "source": "RIG1_MDA5_complex",
+    "target": "Nsp14",
+    "sign": false
+   },
+   {
+    "id": "t109",
+    "source": "RIG1_MDA5_complex",
+    "target": "Nsp16",
+    "sign": false
+   },
+   {
+    "id": "t110",
+    "source": "RIG1_MDA5_complex",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t111",
+    "source": "OAS1_cell_active",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t112",
+    "source": "EIF2AK",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t113",
+    "source": "OAS2_cell_active",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t114",
+    "source": "OAS3_cell_active",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t115",
+    "source": "IRF3_phosphorylated",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t116",
+    "source": "IFIH1",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t117",
+    "source": "Proinflammatory_cytokine_expression_Inflammation_phenotype",
+    "target": "NLRP3_inflammasome_complex",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "NLRP3_inflammasome_complex",
+    "target": "p50_p65_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "IFNB1_rna",
+    "target": "p50_p65_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "IFNA1_rna",
+    "target": "p50_p65_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "ISG_expression_antiviral_response_phenotype",
+    "target": "p50_p65_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "Proinflammatory_cytokine_expression_Inflammation_phenotype",
+    "target": "p50_p65_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "NLRP3_inflammasome_complex",
+    "target": "MNS_drug",
+    "sign": false
+   },
+   {
+    "id": "t124",
+    "source": "MAPK8/14_complex",
+    "target": "MAPK14",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "MAPK8/14_complex",
+    "target": "MAPK8",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "MAPK8/14_complex",
+    "target": "MAP3K7",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "IFNB1_rna",
+    "target": "AP-1_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "IFNA1_rna",
+    "target": "AP-1_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "TAB1/2_TRAF6_TAK1_complex",
+    "target": "TLR3_TRIF_RIPK1_complex",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "TLR3_TRIF_RIPK1_complex",
+    "target": "RIP1",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "IKKa_IKKb_NEMO_complex",
+    "target": "TAB1/2_TRAF6_TAK1_complex",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "TAB1/2_TRAF6_TAK1_complex",
+    "target": "TAB1",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "TAB1/2_TRAF6_TAK1_complex",
+    "target": "TAB2",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "TAB1/2_TRAF6_TAK1_complex",
+    "target": "TRAF6_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "MAP3K7",
+    "target": "TRAF6_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "TAB1/2_TRAF6_TAK1_complex",
+    "target": "TAK1",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "IkB_p50_p65_complex_cell",
+    "target": "IKKa_IKKb_NEMO_complex",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "IKKa_IKKb_NEMO_complex",
+    "target": "NEMO",
+    "sign": true
+   },
+   {
+    "id": "t139",
+    "source": "IKKa_IKKb_NEMO_complex",
+    "target": "IKKa",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "IKKa_IKKb_NEMO_complex",
+    "target": "IKKb",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "IkB_p50_p65_complex_cell",
+    "target": "RELA",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "IkB_p50_p65_complex_cell",
+    "target": "NFKB1",
+    "sign": true
+   },
+   {
+    "id": "t144",
+    "source": "IkB_p50_p65_complex_cell",
+    "target": "IkB",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "IFNB1_rna",
+    "target": "IRF3_homodimer_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "OAS1_rna",
+    "target": "IRF3_homodimer_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "EIF2AK_rna",
+    "target": "IRF3_homodimer_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "OAS2_rna",
+    "target": "IRF3_homodimer_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "OAS3_rna",
+    "target": "IRF3_homodimer_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "IRF3_homodimer_complex_nucleus",
+    "target": "IRF3_homodimer_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "IRF3_homodimer_complex_cell",
+    "target": "IRF3_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "IFNB1_rna",
+    "target": "IRF7_homodimer_complex",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "IFNA1_rna",
+    "target": "IRF7_homodimer_complex",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "IRF7_homodimer_complex",
+    "target": "IRF7_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "ISG15_Nsp3_complex",
+    "target": "ISG15",
+    "sign": true
+   },
+   {
+    "id": "t156",
+    "source": "ISG_expression_antiviral_response_phenotype",
+    "target": "ISG15",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "ISG15_Nsp3_complex",
+    "target": "GRL0617_drug",
+    "sign": false
+   },
+   {
+    "id": "t158",
+    "source": "IFNB1_extracellular_space",
+    "target": "IFNB1_cell",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "IFNB1_cell",
+    "target": "IFNB1_rna",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "IFNA1_extracellular_space",
+    "target": "IFNA1_cell",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "IFNA1_cell",
+    "target": "IFNA1_rna",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "OAS1_cell",
+    "target": "OAS1_rna",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "EIF2AK",
+    "target": "EIF2AK_rna",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "OAS1_cell_active",
+    "target": "OAS1_cell",
+    "sign": true
+   },
+   {
+    "id": "t165",
+    "source": "TRAF6_ubiquitinated",
+    "target": "ITCH",
+    "sign": false
+   },
+   {
+    "id": "t166",
+    "source": "MAVS",
+    "target": "ITCH",
+    "sign": false
+   },
+   {
+    "id": "t167",
+    "source": "TBK1",
+    "target": "Nsp13",
+    "sign": false
+   },
+   {
+    "id": "t168",
+    "source": "STAT1_phosphorylated",
+    "target": "Nsp13",
+    "sign": false
+   },
+   {
+    "id": "t169",
+    "source": "STAT2_phosphorylated",
+    "target": "Nsp13",
+    "sign": false
+   },
+   {
+    "id": "t170",
+    "source": "STAT1_phosphorylated",
+    "target": "Nsp1",
+    "sign": false
+   },
+   {
+    "id": "t171",
+    "source": "STAT1_phosphorylated",
+    "target": "Orf7b",
+    "sign": false
+   },
+   {
+    "id": "t172",
+    "source": "STAT2_phosphorylated",
+    "target": "Orf7b",
+    "sign": false
+   },
+   {
+    "id": "t173",
+    "source": "STAT1_phosphorylated",
+    "target": "Orf3a",
+    "sign": false
+   },
+   {
+    "id": "t174",
+    "source": "STAT1_phosphorylated",
+    "target": "Nsp6",
+    "sign": false
+   },
+   {
+    "id": "t175",
+    "source": "STAT2_phosphorylated",
+    "target": "Nsp6",
+    "sign": false
+   },
+   {
+    "id": "t176",
+    "source": "IRF3_phosphorylated",
+    "target": "Nsp6",
+    "sign": false
+   },
+   {
+    "id": "t177",
+    "source": "STAT2_phosphorylated",
+    "target": "Orf7a",
+    "sign": false
+   },
+   {
+    "id": "t178",
+    "source": "OAS2_cell",
+    "target": "OAS2_rna",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "OAS2_cell_active",
+    "target": "OAS2_cell",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "OAS3_cell",
+    "target": "OAS3_rna",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "OAS3_cell_active",
+    "target": "OAS3_cell",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "IRF3_phosphorylated",
+    "target": "Orf8_complex",
+    "sign": false
+   },
+   {
+    "id": "t183",
+    "source": "MAVS",
+    "target": "Orf9b",
+    "sign": false
+   },
+   {
+    "id": "t184",
+    "source": "ITCH",
+    "target": "Orf9b",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "DDX58_ubiquitinated",
+    "target": "TRIM25",
+    "sign": true
+   },
+   {
+    "id": "t186",
+    "source": "DDX58_ubiquitinated",
+    "target": "RNF135",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "Viral_dsRNA_rna_cell",
+    "target": "Viral_replication_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "ISG15",
+    "target": "ISG15_rna",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/JNK_pathway.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/JNK_pathway.json
@@ -1,0 +1,304 @@
+{
+ "header": {
+  "name": "JNK_pathway",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on JNK_pathway",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "JNK_complex_cell",
+    "name": "JNK_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "AP-1_complex",
+    "name": "AP-1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCL2_phosphorylated",
+    "name": "BCL2_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATF2_phosphorylated",
+    "name": "ATF2_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TP53_phosphorylated",
+    "name": "TP53_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP2K4_phosphorylated",
+    "name": "MAP2K4_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP2K7_phosphorylated",
+    "name": "MAP2K7_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "7a",
+    "name": "7a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "3a",
+    "name": "3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S",
+    "name": "S",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MLK1/2/3_complex",
+    "name": "MLK1/2/3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS-CoV-1_proteins_complex",
+    "name": "SARS-CoV-1_proteins_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MEKK1/4_complex",
+    "name": "MEKK1/4_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Innate_Immunity_phenotype",
+    "name": "Innate_Immunity_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "3b",
+    "name": "3b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Apoptosis_phenotype",
+    "name": "Apoptosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Autophagy_phenotype",
+    "name": "Autophagy_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TP53_signalling_phenotype",
+    "name": "TP53_signalling_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "AP-1_complex",
+    "target": "JNK_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "BCL2_phosphorylated",
+    "target": "JNK_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "ATF2_phosphorylated",
+    "target": "JNK_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "TP53_phosphorylated",
+    "target": "JNK_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "JNK_complex_cell",
+    "target": "MAP2K4_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "JNK_complex_cell",
+    "target": "MAP2K7_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "JNK_complex_cell",
+    "target": "7a",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "JNK_complex_cell",
+    "target": "3a",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "JNK_complex_cell",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "MAP2K7_phosphorylated",
+    "target": "MLK1/2/3_complex",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "MLK1/2/3_complex",
+    "target": "SARS-CoV-1_proteins_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "MEKK1/4_complex",
+    "target": "SARS-CoV-1_proteins_complex",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "MAP2K4_phosphorylated",
+    "target": "SARS-CoV-1_proteins_complex",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "MAP2K7_phosphorylated",
+    "target": "SARS-CoV-1_proteins_complex",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "Innate_Immunity_phenotype",
+    "target": "AP-1_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "AP-1_complex",
+    "target": "3b",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "MAP2K4_phosphorylated",
+    "target": "MEKK1/4_complex",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "Apoptosis_phenotype",
+    "target": "BCL2_phosphorylated",
+    "sign": false
+   },
+   {
+    "id": "t20",
+    "source": "Autophagy_phenotype",
+    "target": "BCL2_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "TP53_signalling_phenotype",
+    "target": "TP53_phosphorylated",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Kynurenine_pathway.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Kynurenine_pathway.json
@@ -1,0 +1,3050 @@
+{
+ "header": {
+  "name": "Kynurenine_pathway",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Kynurenine_pathway",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "AHR/L-KYN_complex",
+    "name": "AHR/L-KYN_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Regulatory_T-cell_generation_phenotype",
+    "name": "Regulatory_T-cell_generation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Kynurenine_simple_molecule",
+    "name": "L-Kynurenine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_cell",
+    "name": "H2O_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP-DOBu_simple_molecule",
+    "name": "AP-DOBu_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADP+_simple_molecule_cell",
+    "name": "NADP+_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Ala_simple_molecule",
+    "name": "L-Ala_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "3HKYN_simple_molecule",
+    "name": "3HKYN_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "T-cell_apoptosis_phenotype",
+    "name": "T-cell_apoptosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AHR",
+    "name": "AHR",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nf-KB_Complex_complex",
+    "name": "Nf-KB_Complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "iNOS_rna",
+    "name": "iNOS_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CO_simple_molecule",
+    "name": "CO_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IDO1_complex",
+    "name": "IDO1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFK_simple_molecule",
+    "name": "NFK_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Heme_simple_molecule",
+    "name": "Heme_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe2+_ion",
+    "name": "Fe2+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Biliverdin_simple_molecule",
+    "name": "Biliverdin_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "apo-IDO1",
+    "name": "apo-IDO1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Tryptophan_simple_molecule_cell",
+    "name": "L-Tryptophan_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Tryptophan_simple_molecule_human_host",
+    "name": "L-Tryptophan_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Effector_T-cell_apoptosis_phenotype",
+    "name": "Effector_T-cell_apoptosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC36A4",
+    "name": "SLC36A4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IDO1_rna",
+    "name": "IDO1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HCOOH_simple_molecule",
+    "name": "HCOOH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_cell",
+    "name": "H+_ion_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "3HAA_simple_molecule",
+    "name": "3HAA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADH_simple_molecule_cell",
+    "name": "NADH_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAD+_simple_molecule_cell",
+    "name": "NAD+_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "2AM_simple_molecule",
+    "name": "2AM_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPi_simple_molecule",
+    "name": "PPi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Glu_simple_molecule",
+    "name": "L-Glu_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AMP_simple_molecule_cell",
+    "name": "AMP_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADPH_simple_molecule_cell",
+    "name": "NADPH_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NO_simple_molecule",
+    "name": "NO_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Citrulline_simple_molecule",
+    "name": "Citrulline_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CO2_simple_molecule",
+    "name": "CO2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAMN_simple_molecule_cell",
+    "name": "NAMN_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2_simple_molecule",
+    "name": "O2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACS_simple_molecule",
+    "name": "ACS_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "KMO",
+    "name": "KMO",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "KYNA_simple_molecule",
+    "name": "KYNA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "QUIN_simple_molecule",
+    "name": "QUIN_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "2AMA_simple_molecule",
+    "name": "2AMA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRPP_simple_molecule",
+    "name": "PRPP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "QPRT",
+    "name": "QPRT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMOX1_cell",
+    "name": "HMOX1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IDO2",
+    "name": "IDO2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Epacadostat_drug",
+    "name": "Epacadostat_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PYR_simple_molecule",
+    "name": "PYR_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PXLP-KYAT1_complex",
+    "name": "PXLP-KYAT1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "I3PROPA",
+    "name": "I3PROPA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Phe_simple_molecule",
+    "name": "L-Phe_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "I3LACT",
+    "name": "I3LACT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AFMID",
+    "name": "AFMID",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP_simple_molecule_cell",
+    "name": "ADP_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAM_simple_molecule_cell",
+    "name": "NAM_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(ADP-D-ribosyl)(n+1)-acceptor_simple_molecule",
+    "name": "(ADP-D-ribosyl)(n+1)-acceptor_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule_cell",
+    "name": "ATP_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPi(3-)_simple_molecule_cell",
+    "name": "PPi(3-)_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMN_simple_molecule_cell",
+    "name": "NMN_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADK:Zn2+_tetramer_complex",
+    "name": "NADK:Zn2+_tetramer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Arginine_simple_molecule",
+    "name": "L-Arginine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "iNOS",
+    "name": "iNOS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAR_simple_molecule",
+    "name": "NAR_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMRK1",
+    "name": "NMRK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMRK2",
+    "name": "NMRK2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NR_simple_molecule",
+    "name": "NR_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CCBL2",
+    "name": "CCBL2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Dendritic_cell_maturation_phenotype",
+    "name": "Dendritic_cell_maturation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "KYNU",
+    "name": "KYNU",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMOX1_rna",
+    "name": "HMOX1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CA_simple_molecule",
+    "name": "CA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Th1_cell_cytokine_production_phenotype",
+    "name": "Th1_cell_cytokine_production_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HAAO",
+    "name": "HAAO",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACMSD",
+    "name": "ACMSD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAAD_simple_molecule_cell",
+    "name": "NAAD_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Gln_simple_molecule",
+    "name": "L-Gln_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADSYN1_hexamer",
+    "name": "NADSYN1_hexamer",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMNAT2:Mg2+_complex",
+    "name": "NMNAT2:Mg2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFN-G",
+    "name": "IFN-G",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAMN_simple_molecule_mitochondrial_matrix",
+    "name": "NAMN_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPi_(3-)_simple_molecule",
+    "name": "PPi_(3-)_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAAD_simple_molecule_mitochondrial_matrix",
+    "name": "NAAD_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule_mitochondrial_matrix",
+    "name": "ATP_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_mitochondrial_matrix",
+    "name": "H+_ion_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP_simple_molecule_mitochondrial_matrix",
+    "name": "ADP_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADPH_simple_molecule_mitochondrial_matrix",
+    "name": "NADPH_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADP+_simple_molecule_mitochondrial_matrix",
+    "name": "NADP+_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pi_simple_molecule",
+    "name": "Pi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMNAT3:Mg2+_complex",
+    "name": "NMNAT3:Mg2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S-NADPHX_simple_molecule",
+    "name": "S-NADPHX_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CARKD",
+    "name": "CARKD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAD+_simple_molecule_mitochondrial_matrix",
+    "name": "NAD+_simple_molecule_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADK2",
+    "name": "NADK2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "R-NADPHX_simple_molecule",
+    "name": "R-NADPHX_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "APOA1BP",
+    "name": "APOA1BP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NCA_simple_molecule",
+    "name": "NCA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC22A13",
+    "name": "SLC22A13",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAPRT1",
+    "name": "NAPRT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mg2+_ion",
+    "name": "Mg2+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MNA_simple_molecule",
+    "name": "MNA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AdoHcy_simple_molecule",
+    "name": "AdoHcy_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAMPT",
+    "name": "NAMPT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PGH2_simple_molecule",
+    "name": "PGH2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_endoplasmic_reticulum",
+    "name": "H2O_simple_molecule_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AdoMet_simple_molecule",
+    "name": "AdoMet_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NNMT",
+    "name": "NNMT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(ADP-D-ribosyl)(n)-acceptor_simple_molecule",
+    "name": "(ADP-D-ribosyl)(n)-acceptor_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PARPs",
+    "name": "PARPs",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_human_host",
+    "name": "H+_ion_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O2_simple_molecule",
+    "name": "H2O2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAD+_simple_molecule_human_host",
+    "name": "NAD+_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAM_simple_molecule_human_host",
+    "name": "NAM_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP-ribose_simple_molecule",
+    "name": "ADP-ribose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pi_ion",
+    "name": "Pi_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMN_simple_molecule_human_host",
+    "name": "NMN_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_human_host",
+    "name": "H2O_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NRNAM_simple_molecule",
+    "name": "NRNAM_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BST1",
+    "name": "BST1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CD38",
+    "name": "CD38",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dh-beta-NAD_simple_molecule",
+    "name": "dh-beta-NAD_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2_ion",
+    "name": "O2_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RNLS:FAD_complex",
+    "name": "RNLS:FAD_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NT5E:Zn2+_complex",
+    "name": "NT5E:Zn2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADH_simple_molecule_peroxisome",
+    "name": "NADH_simple_molecule_peroxisome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMNH_simple_molecule",
+    "name": "NMNH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_peroxisome",
+    "name": "H+_ion_peroxisome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AMP_simple_molecule_peroxisome",
+    "name": "AMP_simple_molecule_peroxisome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_peroxisome",
+    "name": "H2O_simple_molecule_peroxisome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUDT12",
+    "name": "NUDT12",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAMN_simple_molecule_nucleus",
+    "name": "NAMN_simple_molecule_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAAD_simple_molecule_nucleus",
+    "name": "NAAD_simple_molecule_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPi(3-)_simple_molecule_nucleus",
+    "name": "PPi(3-)_simple_molecule_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule_nucleus",
+    "name": "ATP_simple_molecule_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMNAT1:Zn2+_complex",
+    "name": "NMNAT1:Zn2+_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PGI2_simple_molecule",
+    "name": "PGI2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PTGIS",
+    "name": "PTGIS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PGG2_simple_molecule",
+    "name": "PGG2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "e-_ion",
+    "name": "e-_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion_endoplasmic_reticulum",
+    "name": "H+_ion_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PTGS2",
+    "name": "PTGS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PTCS2:celecoxib_complex",
+    "name": "PTCS2:celecoxib_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "monocarboxylates_transported_by_SLC5A8_simple_molecule_human_host",
+    "name": "monocarboxylates_transported_by_SLC5A8_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "monocarboxylates_transported_by_SLC5A8_simple_molecule_cell",
+    "name": "monocarboxylates_transported_by_SLC5A8_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Na+_ion_cell",
+    "name": "Na+_ion_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Na+_ion_human_host",
+    "name": "Na+_ion_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC5A8",
+    "name": "SLC5A8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a",
+    "name": "Orf3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Regulatory_T-cell_generation_phenotype",
+    "target": "AHR/L-KYN_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "AHR/L-KYN_complex",
+    "target": "L-Kynurenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "H2O_simple_molecule_cell",
+    "target": "L-Kynurenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "AP-DOBu_simple_molecule",
+    "target": "L-Kynurenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "L-Kynurenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "L-Ala_simple_molecule",
+    "target": "L-Kynurenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "3HKYN_simple_molecule",
+    "target": "L-Kynurenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "T-cell_apoptosis_phenotype",
+    "target": "L-Kynurenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "AHR/L-KYN_complex",
+    "target": "AHR",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "iNOS_rna",
+    "target": "Nf-KB_Complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "Nf-KB_Complex_complex",
+    "target": "CO_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t12",
+    "source": "iNOS_rna",
+    "target": "CO_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t13",
+    "source": "NFK_simple_molecule",
+    "target": "IDO1_complex",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "IDO1_complex",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "H2O_simple_molecule_cell",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "Fe2+_ion",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "Biliverdin_simple_molecule",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "CO_simple_molecule",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "IDO1_complex",
+    "target": "apo-IDO1",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "NFK_simple_molecule",
+    "target": "L-Tryptophan_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "L-Tryptophan_simple_molecule_cell",
+    "target": "L-Tryptophan_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "Effector_T-cell_apoptosis_phenotype",
+    "target": "L-Tryptophan_simple_molecule_human_host",
+    "sign": false
+   },
+   {
+    "id": "t24",
+    "source": "L-Tryptophan_simple_molecule_cell",
+    "target": "SLC36A4",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "apo-IDO1",
+    "target": "IDO1_rna",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "HCOOH_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "L-Kynurenine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "H+_ion_cell",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "L-Ala_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "3HAA_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "NADH_simple_molecule_cell",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "NAD+_simple_molecule_cell",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "2AM_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "PPi_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "L-Glu_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "AMP_simple_molecule_cell",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "H2O_simple_molecule_cell",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "H+_ion_cell",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "3HKYN_simple_molecule",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "NO_simple_molecule",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "Fe2+_ion",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "Biliverdin_simple_molecule",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "CO_simple_molecule",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "Citrulline_simple_molecule",
+    "target": "NADPH_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "H2O_simple_molecule_cell",
+    "target": "H+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "H+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "3HKYN_simple_molecule",
+    "target": "H+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "CO2_simple_molecule",
+    "target": "H+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "PPi_simple_molecule",
+    "target": "H+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "H+_ion_cell",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "H2O_simple_molecule_cell",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "NFK_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "H+_ion_cell",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "3HKYN_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "ACS_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "NO_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "Fe2+_ion",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "Biliverdin_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "CO_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "Citrulline_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "H2O_simple_molecule_cell",
+    "target": "KMO",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "KMO",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "3HKYN_simple_molecule",
+    "target": "KMO",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "H2O_simple_molecule_cell",
+    "target": "AP-DOBu_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "KYNA_simple_molecule",
+    "target": "AP-DOBu_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "H2O_simple_molecule_cell",
+    "target": "ACS_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "CO2_simple_molecule",
+    "target": "ACS_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "QUIN_simple_molecule",
+    "target": "ACS_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "2AMA_simple_molecule",
+    "target": "ACS_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "H2O_simple_molecule_cell",
+    "target": "QUIN_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "CO2_simple_molecule",
+    "target": "QUIN_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "QUIN_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "H2O_simple_molecule_cell",
+    "target": "PRPP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "CO2_simple_molecule",
+    "target": "PRPP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "PPi_simple_molecule",
+    "target": "PRPP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "PRPP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "H2O_simple_molecule_cell",
+    "target": "QPRT",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "CO2_simple_molecule",
+    "target": "QPRT",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "QPRT",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "H2O_simple_molecule_cell",
+    "target": "HMOX1_cell",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "HMOX1_cell",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "Fe2+_ion",
+    "target": "HMOX1_cell",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "Biliverdin_simple_molecule",
+    "target": "HMOX1_cell",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "CO_simple_molecule",
+    "target": "HMOX1_cell",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "HCOOH_simple_molecule",
+    "target": "NFK_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "L-Kynurenine_simple_molecule",
+    "target": "NFK_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "NFK_simple_molecule",
+    "target": "IDO2",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "NFK_simple_molecule",
+    "target": "Epacadostat_drug",
+    "sign": false
+   },
+   {
+    "id": "t91",
+    "source": "AP-DOBu_simple_molecule",
+    "target": "PYR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "L-Ala_simple_molecule",
+    "target": "PYR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "AP-DOBu_simple_molecule",
+    "target": "PXLP-KYAT1_complex",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "L-Ala_simple_molecule",
+    "target": "PXLP-KYAT1_complex",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "AP-DOBu_simple_molecule",
+    "target": "I3PROPA",
+    "sign": false
+   },
+   {
+    "id": "t96",
+    "source": "L-Ala_simple_molecule",
+    "target": "I3PROPA",
+    "sign": false
+   },
+   {
+    "id": "t97",
+    "source": "AP-DOBu_simple_molecule",
+    "target": "L-Phe_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t98",
+    "source": "L-Ala_simple_molecule",
+    "target": "L-Phe_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t99",
+    "source": "AP-DOBu_simple_molecule",
+    "target": "I3LACT",
+    "sign": false
+   },
+   {
+    "id": "t100",
+    "source": "L-Ala_simple_molecule",
+    "target": "I3LACT",
+    "sign": false
+   },
+   {
+    "id": "t101",
+    "source": "HCOOH_simple_molecule",
+    "target": "AFMID",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "L-Kynurenine_simple_molecule",
+    "target": "AFMID",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "NAD+_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "H+_ion_cell",
+    "target": "NAD+_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "NADH_simple_molecule_cell",
+    "target": "NAD+_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "2AM_simple_molecule",
+    "target": "NAD+_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "ADP_simple_molecule_cell",
+    "target": "NAD+_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t108",
+    "source": "NAM_simple_molecule_cell",
+    "target": "NAD+_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "(ADP-D-ribosyl)(n+1)-acceptor_simple_molecule",
+    "target": "NAD+_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "H+_ion_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "NAD+_simple_molecule_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "PPi_simple_molecule",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "PPi(3-)_simple_molecule_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "L-Glu_simple_molecule",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t117",
+    "source": "AMP_simple_molecule_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "ADP_simple_molecule_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "NMN_simple_molecule_cell",
+    "target": "ATP_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "NADK:Zn2+_tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "ADP_simple_molecule_cell",
+    "target": "NADK:Zn2+_tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "L-Arginine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "H+_ion_cell",
+    "target": "L-Arginine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "NO_simple_molecule",
+    "target": "L-Arginine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "Citrulline_simple_molecule",
+    "target": "L-Arginine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "NADP+_simple_molecule_cell",
+    "target": "iNOS",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "H+_ion_cell",
+    "target": "iNOS",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "NO_simple_molecule",
+    "target": "iNOS",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "Citrulline_simple_molecule",
+    "target": "iNOS",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "H+_ion_cell",
+    "target": "2AMA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "NADH_simple_molecule_cell",
+    "target": "2AMA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "2AM_simple_molecule",
+    "target": "2AMA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "H+_ion_cell",
+    "target": "NAR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "NAR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "ADP_simple_molecule_cell",
+    "target": "NAR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "H+_ion_cell",
+    "target": "NMRK1",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "NMRK1",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "ADP_simple_molecule_cell",
+    "target": "NMRK1",
+    "sign": true
+   },
+   {
+    "id": "t139",
+    "source": "NMN_simple_molecule_cell",
+    "target": "NMRK1",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "H+_ion_cell",
+    "target": "NMRK2",
+    "sign": true
+   },
+   {
+    "id": "t141",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "NMRK2",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "ADP_simple_molecule_cell",
+    "target": "NMRK2",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "NMN_simple_molecule_cell",
+    "target": "NMRK2",
+    "sign": true
+   },
+   {
+    "id": "t144",
+    "source": "H+_ion_cell",
+    "target": "NR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "ADP_simple_molecule_cell",
+    "target": "NR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "NMN_simple_molecule_cell",
+    "target": "NR_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "L-Ala_simple_molecule",
+    "target": "CCBL2",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "L-Ala_simple_molecule",
+    "target": "3HKYN_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "3HAA_simple_molecule",
+    "target": "3HKYN_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "T-cell_apoptosis_phenotype",
+    "target": "3HKYN_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "Dendritic_cell_maturation_phenotype",
+    "target": "3HKYN_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "L-Ala_simple_molecule",
+    "target": "KYNU",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "3HAA_simple_molecule",
+    "target": "KYNU",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "Regulatory_T-cell_generation_phenotype",
+    "target": "3HAA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "ACS_simple_molecule",
+    "target": "3HAA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t156",
+    "source": "HMOX1_rna",
+    "target": "3HAA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "CA_simple_molecule",
+    "target": "3HAA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t158",
+    "source": "Th1_cell_cytokine_production_phenotype",
+    "target": "3HAA_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t159",
+    "source": "T-cell_apoptosis_phenotype",
+    "target": "3HAA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "Dendritic_cell_maturation_phenotype",
+    "target": "3HAA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "ACS_simple_molecule",
+    "target": "HAAO",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "CO2_simple_molecule",
+    "target": "ACMSD",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "2AMA_simple_molecule",
+    "target": "ACMSD",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "NAD+_simple_molecule_cell",
+    "target": "NAAD_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t165",
+    "source": "PPi_simple_molecule",
+    "target": "NAAD_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t166",
+    "source": "L-Glu_simple_molecule",
+    "target": "NAAD_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t167",
+    "source": "AMP_simple_molecule_cell",
+    "target": "NAAD_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t168",
+    "source": "NAD+_simple_molecule_cell",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t169",
+    "source": "PPi_simple_molecule",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t170",
+    "source": "L-Glu_simple_molecule",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t171",
+    "source": "AMP_simple_molecule_cell",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t172",
+    "source": "NAD+_simple_molecule_cell",
+    "target": "NADSYN1_hexamer",
+    "sign": true
+   },
+   {
+    "id": "t173",
+    "source": "PPi_simple_molecule",
+    "target": "NADSYN1_hexamer",
+    "sign": true
+   },
+   {
+    "id": "t174",
+    "source": "L-Glu_simple_molecule",
+    "target": "NADSYN1_hexamer",
+    "sign": true
+   },
+   {
+    "id": "t175",
+    "source": "AMP_simple_molecule_cell",
+    "target": "NADSYN1_hexamer",
+    "sign": true
+   },
+   {
+    "id": "t176",
+    "source": "NAD+_simple_molecule_cell",
+    "target": "NMN_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t177",
+    "source": "PPi(3-)_simple_molecule_cell",
+    "target": "NMN_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t178",
+    "source": "NAD+_simple_molecule_cell",
+    "target": "NMNAT2:Mg2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "NAAD_simple_molecule_cell",
+    "target": "NMNAT2:Mg2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "PPi(3-)_simple_molecule_cell",
+    "target": "NMNAT2:Mg2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "iNOS",
+    "target": "iNOS_rna",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "iNOS_rna",
+    "target": "IFN-G",
+    "sign": true
+   },
+   {
+    "id": "t183",
+    "source": "IDO1_rna",
+    "target": "IFN-G",
+    "sign": true
+   },
+   {
+    "id": "t184",
+    "source": "HMOX1_rna",
+    "target": "IFN-G",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "IDO1_rna",
+    "target": "NO_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t186",
+    "source": "HMOX1_rna",
+    "target": "NO_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "PPi_(3-)_simple_molecule",
+    "target": "NAMN_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "NAAD_simple_molecule_mitochondrial_matrix",
+    "target": "NAMN_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t189",
+    "source": "PPi_(3-)_simple_molecule",
+    "target": "ATP_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t190",
+    "source": "NAAD_simple_molecule_mitochondrial_matrix",
+    "target": "ATP_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t191",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "ATP_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t192",
+    "source": "ADP_simple_molecule_mitochondrial_matrix",
+    "target": "ATP_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t193",
+    "source": "NADPH_simple_molecule_mitochondrial_matrix",
+    "target": "ATP_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t194",
+    "source": "NADP+_simple_molecule_mitochondrial_matrix",
+    "target": "ATP_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t195",
+    "source": "Pi_simple_molecule",
+    "target": "ATP_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t196",
+    "source": "PPi_(3-)_simple_molecule",
+    "target": "NMNAT3:Mg2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t197",
+    "source": "NAAD_simple_molecule_mitochondrial_matrix",
+    "target": "NMNAT3:Mg2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t198",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "S-NADPHX_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t199",
+    "source": "ADP_simple_molecule_mitochondrial_matrix",
+    "target": "S-NADPHX_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t200",
+    "source": "NADPH_simple_molecule_mitochondrial_matrix",
+    "target": "S-NADPHX_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t201",
+    "source": "Pi_simple_molecule",
+    "target": "S-NADPHX_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t202",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "CARKD",
+    "sign": true
+   },
+   {
+    "id": "t203",
+    "source": "ADP_simple_molecule_mitochondrial_matrix",
+    "target": "CARKD",
+    "sign": true
+   },
+   {
+    "id": "t204",
+    "source": "NADPH_simple_molecule_mitochondrial_matrix",
+    "target": "CARKD",
+    "sign": true
+   },
+   {
+    "id": "t205",
+    "source": "Pi_simple_molecule",
+    "target": "CARKD",
+    "sign": true
+   },
+   {
+    "id": "t206",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "NAD+_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t207",
+    "source": "ADP_simple_molecule_mitochondrial_matrix",
+    "target": "NAD+_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t208",
+    "source": "NADP+_simple_molecule_mitochondrial_matrix",
+    "target": "NAD+_simple_molecule_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t209",
+    "source": "H+_ion_mitochondrial_matrix",
+    "target": "NADK2",
+    "sign": true
+   },
+   {
+    "id": "t210",
+    "source": "ADP_simple_molecule_mitochondrial_matrix",
+    "target": "NADK2",
+    "sign": true
+   },
+   {
+    "id": "t211",
+    "source": "NADP+_simple_molecule_mitochondrial_matrix",
+    "target": "NADK2",
+    "sign": true
+   },
+   {
+    "id": "t212",
+    "source": "S-NADPHX_simple_molecule",
+    "target": "R-NADPHX_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t213",
+    "source": "S-NADPHX_simple_molecule",
+    "target": "APOA1BP",
+    "sign": true
+   },
+   {
+    "id": "t214",
+    "source": "PPi_simple_molecule",
+    "target": "NCA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t215",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "NCA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t216",
+    "source": "NCA_simple_molecule",
+    "target": "SLC22A13",
+    "sign": true
+   },
+   {
+    "id": "t217",
+    "source": "PPi_simple_molecule",
+    "target": "NAPRT1",
+    "sign": true
+   },
+   {
+    "id": "t218",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "NAPRT1",
+    "sign": true
+   },
+   {
+    "id": "t219",
+    "source": "PPi_simple_molecule",
+    "target": "Mg2+_ion",
+    "sign": true
+   },
+   {
+    "id": "t220",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "Mg2+_ion",
+    "sign": true
+   },
+   {
+    "id": "t221",
+    "source": "PPi_simple_molecule",
+    "target": "NAM_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t222",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "NAM_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t223",
+    "source": "MNA_simple_molecule",
+    "target": "NAM_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t224",
+    "source": "AdoHcy_simple_molecule",
+    "target": "NAM_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t225",
+    "source": "PPi_simple_molecule",
+    "target": "NAMPT",
+    "sign": true
+   },
+   {
+    "id": "t226",
+    "source": "NAMN_simple_molecule_cell",
+    "target": "NAMPT",
+    "sign": true
+   },
+   {
+    "id": "t227",
+    "source": "NAAD_simple_molecule_cell",
+    "target": "NAMN_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t228",
+    "source": "PPi(3-)_simple_molecule_cell",
+    "target": "NAMN_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t229",
+    "source": "PGH2_simple_molecule",
+    "target": "MNA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t230",
+    "source": "H2O_simple_molecule_endoplasmic_reticulum",
+    "target": "MNA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t231",
+    "source": "MNA_simple_molecule",
+    "target": "AdoMet_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t232",
+    "source": "AdoHcy_simple_molecule",
+    "target": "AdoMet_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t233",
+    "source": "MNA_simple_molecule",
+    "target": "NNMT",
+    "sign": true
+   },
+   {
+    "id": "t234",
+    "source": "AdoHcy_simple_molecule",
+    "target": "NNMT",
+    "sign": true
+   },
+   {
+    "id": "t235",
+    "source": "NAM_simple_molecule_cell",
+    "target": "(ADP-D-ribosyl)(n)-acceptor_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t236",
+    "source": "(ADP-D-ribosyl)(n+1)-acceptor_simple_molecule",
+    "target": "(ADP-D-ribosyl)(n)-acceptor_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t237",
+    "source": "NAM_simple_molecule_cell",
+    "target": "PARPs",
+    "sign": true
+   },
+   {
+    "id": "t238",
+    "source": "(ADP-D-ribosyl)(n+1)-acceptor_simple_molecule",
+    "target": "PARPs",
+    "sign": true
+   },
+   {
+    "id": "t239",
+    "source": "H2O2_simple_molecule",
+    "target": "H+_ion_human_host",
+    "sign": true
+   },
+   {
+    "id": "t240",
+    "source": "NAD+_simple_molecule_human_host",
+    "target": "H+_ion_human_host",
+    "sign": true
+   },
+   {
+    "id": "t241",
+    "source": "H+_ion_human_host",
+    "target": "NAD+_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t242",
+    "source": "NAM_simple_molecule_human_host",
+    "target": "NAD+_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t243",
+    "source": "ADP-ribose_simple_molecule",
+    "target": "NAD+_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t244",
+    "source": "Pi_ion",
+    "target": "NAD+_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t245",
+    "source": "NMN_simple_molecule_human_host",
+    "target": "NAD+_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t246",
+    "source": "H+_ion_human_host",
+    "target": "H2O_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t247",
+    "source": "NAM_simple_molecule_human_host",
+    "target": "H2O_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t248",
+    "source": "ADP-ribose_simple_molecule",
+    "target": "H2O_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t249",
+    "source": "Pi_ion",
+    "target": "H2O_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t250",
+    "source": "NMN_simple_molecule_human_host",
+    "target": "H2O_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t251",
+    "source": "NRNAM_simple_molecule",
+    "target": "H2O_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t252",
+    "source": "H+_ion_human_host",
+    "target": "BST1",
+    "sign": true
+   },
+   {
+    "id": "t253",
+    "source": "NAM_simple_molecule_human_host",
+    "target": "BST1",
+    "sign": true
+   },
+   {
+    "id": "t254",
+    "source": "ADP-ribose_simple_molecule",
+    "target": "BST1",
+    "sign": true
+   },
+   {
+    "id": "t255",
+    "source": "H+_ion_human_host",
+    "target": "CD38",
+    "sign": true
+   },
+   {
+    "id": "t256",
+    "source": "NAM_simple_molecule_human_host",
+    "target": "CD38",
+    "sign": true
+   },
+   {
+    "id": "t257",
+    "source": "ADP-ribose_simple_molecule",
+    "target": "CD38",
+    "sign": true
+   },
+   {
+    "id": "t258",
+    "source": "H2O2_simple_molecule",
+    "target": "dh-beta-NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t259",
+    "source": "NAD+_simple_molecule_human_host",
+    "target": "dh-beta-NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t260",
+    "source": "H2O2_simple_molecule",
+    "target": "O2_ion",
+    "sign": true
+   },
+   {
+    "id": "t261",
+    "source": "NAD+_simple_molecule_human_host",
+    "target": "O2_ion",
+    "sign": true
+   },
+   {
+    "id": "t262",
+    "source": "H2O2_simple_molecule",
+    "target": "RNLS:FAD_complex",
+    "sign": true
+   },
+   {
+    "id": "t263",
+    "source": "NAD+_simple_molecule_human_host",
+    "target": "RNLS:FAD_complex",
+    "sign": true
+   },
+   {
+    "id": "t264",
+    "source": "Pi_ion",
+    "target": "NT5E:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t265",
+    "source": "NMN_simple_molecule_human_host",
+    "target": "NT5E:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t266",
+    "source": "NRNAM_simple_molecule",
+    "target": "NT5E:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t267",
+    "source": "Pi_ion",
+    "target": "NMN_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t268",
+    "source": "NRNAM_simple_molecule",
+    "target": "NMN_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t269",
+    "source": "NMNH_simple_molecule",
+    "target": "NADH_simple_molecule_peroxisome",
+    "sign": true
+   },
+   {
+    "id": "t270",
+    "source": "H+_ion_peroxisome",
+    "target": "NADH_simple_molecule_peroxisome",
+    "sign": true
+   },
+   {
+    "id": "t271",
+    "source": "NMNH_simple_molecule",
+    "target": "AMP_simple_molecule_peroxisome",
+    "sign": true
+   },
+   {
+    "id": "t272",
+    "source": "H+_ion_peroxisome",
+    "target": "AMP_simple_molecule_peroxisome",
+    "sign": true
+   },
+   {
+    "id": "t273",
+    "source": "NMNH_simple_molecule",
+    "target": "H2O_simple_molecule_peroxisome",
+    "sign": true
+   },
+   {
+    "id": "t274",
+    "source": "H+_ion_peroxisome",
+    "target": "H2O_simple_molecule_peroxisome",
+    "sign": true
+   },
+   {
+    "id": "t275",
+    "source": "NMNH_simple_molecule",
+    "target": "NUDT12",
+    "sign": true
+   },
+   {
+    "id": "t276",
+    "source": "H+_ion_peroxisome",
+    "target": "NUDT12",
+    "sign": true
+   },
+   {
+    "id": "t277",
+    "source": "NAAD_simple_molecule_nucleus",
+    "target": "NAMN_simple_molecule_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t278",
+    "source": "PPi(3-)_simple_molecule_nucleus",
+    "target": "NAMN_simple_molecule_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t279",
+    "source": "NAAD_simple_molecule_nucleus",
+    "target": "ATP_simple_molecule_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t280",
+    "source": "PPi(3-)_simple_molecule_nucleus",
+    "target": "ATP_simple_molecule_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t281",
+    "source": "NAAD_simple_molecule_nucleus",
+    "target": "NMNAT1:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t282",
+    "source": "PPi(3-)_simple_molecule_nucleus",
+    "target": "NMNAT1:Zn2+_complex",
+    "sign": true
+   },
+   {
+    "id": "t283",
+    "source": "PGI2_simple_molecule",
+    "target": "PGH2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t284",
+    "source": "PGI2_simple_molecule",
+    "target": "PTGIS",
+    "sign": true
+   },
+   {
+    "id": "t285",
+    "source": "PGH2_simple_molecule",
+    "target": "PGG2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t286",
+    "source": "H2O_simple_molecule_endoplasmic_reticulum",
+    "target": "PGG2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t287",
+    "source": "PGH2_simple_molecule",
+    "target": "e-_ion",
+    "sign": true
+   },
+   {
+    "id": "t288",
+    "source": "H2O_simple_molecule_endoplasmic_reticulum",
+    "target": "e-_ion",
+    "sign": true
+   },
+   {
+    "id": "t289",
+    "source": "PGH2_simple_molecule",
+    "target": "H+_ion_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t290",
+    "source": "H2O_simple_molecule_endoplasmic_reticulum",
+    "target": "H+_ion_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t291",
+    "source": "PGH2_simple_molecule",
+    "target": "PTGS2",
+    "sign": true
+   },
+   {
+    "id": "t292",
+    "source": "H2O_simple_molecule_endoplasmic_reticulum",
+    "target": "PTGS2",
+    "sign": true
+   },
+   {
+    "id": "t293",
+    "source": "PGH2_simple_molecule",
+    "target": "PTCS2:celecoxib_complex",
+    "sign": false
+   },
+   {
+    "id": "t294",
+    "source": "H2O_simple_molecule_endoplasmic_reticulum",
+    "target": "PTCS2:celecoxib_complex",
+    "sign": false
+   },
+   {
+    "id": "t295",
+    "source": "monocarboxylates_transported_by_SLC5A8_simple_molecule_cell",
+    "target": "monocarboxylates_transported_by_SLC5A8_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t296",
+    "source": "Na+_ion_cell",
+    "target": "monocarboxylates_transported_by_SLC5A8_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t297",
+    "source": "monocarboxylates_transported_by_SLC5A8_simple_molecule_cell",
+    "target": "Na+_ion_human_host",
+    "sign": true
+   },
+   {
+    "id": "t298",
+    "source": "Na+_ion_cell",
+    "target": "Na+_ion_human_host",
+    "sign": true
+   },
+   {
+    "id": "t299",
+    "source": "monocarboxylates_transported_by_SLC5A8_simple_molecule_cell",
+    "target": "SLC5A8",
+    "sign": true
+   },
+   {
+    "id": "t300",
+    "source": "Na+_ion_cell",
+    "target": "SLC5A8",
+    "sign": true
+   },
+   {
+    "id": "t301",
+    "source": "HMOX1_cell",
+    "target": "HMOX1_rna",
+    "sign": true
+   },
+   {
+    "id": "t303",
+    "source": "HMOX1_cell",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t304",
+    "source": "T-cell_apoptosis_phenotype",
+    "target": "CA_simple_molecule",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/NLRP3_Activation.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/NLRP3_Activation.json
@@ -1,0 +1,995 @@
+{
+ "header": {
+  "name": "NLRP3_Activation",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on NLRP3_Activation",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "ASC:MAVS:TRAF3_complex_cell",
+    "name": "ASC:MAVS:TRAF3_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "ASC:MAVS_complex",
+    "name": "ASC:MAVS_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3",
+    "name": "TRAF3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3:SARS_Orf3a_complex_cell",
+    "name": "TRAF3:SARS_Orf3a_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3:SUGT1:HSP90_complex",
+    "name": "NLRP3:SUGT1:HSP90_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SUGT1:HSP90AB1_complex",
+    "name": "SUGT1:HSP90AB1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_cell",
+    "name": "NLRP3_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXNIP:NLRP3_complex",
+    "name": "TXNIP:NLRP3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "p105_ubiquitinated",
+    "name": "p105_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_oligomer:ASC:proCaspase1_complex",
+    "name": "NLRP3_oligomer:ASC:proCaspase1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_oligomer:ASC_complex",
+    "name": "NLRP3_oligomer:ASC_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP1_cell",
+    "name": "CASP1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTSG",
+    "name": "CTSG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ASC_ubiquitinated",
+    "name": "ASC_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Caspase-1_Tetramer_complex",
+    "name": "Caspase-1_Tetramer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL-18_cell",
+    "name": "IL-18_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL-1B_cell",
+    "name": "IL-1B_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "proIL-18_cell",
+    "name": "proIL-18_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "proIL-1B_cell",
+    "name": "proIL-1B_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "CASP1(120-197):CASP1(317-404)_complex",
+    "name": "CASP1(120-197):CASP1(317-404)_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXNIP",
+    "name": "TXNIP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thioredoxin:TXNIP_complex",
+    "name": "Thioredoxin:TXNIP_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAVS",
+    "name": "MAVS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nf-KB_Complex_complex_nucleus",
+    "name": "Nf-KB_Complex_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NF-KB_COMPLEX:IKBA_complex",
+    "name": "NF-KB_COMPLEX:IKBA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKBA_phosphorylated_phosphorylated",
+    "name": "IKBA_phosphorylated_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nf-KB_Complex_complex_cell",
+    "name": "Nf-KB_Complex_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "p50",
+    "name": "p50",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "p65",
+    "name": "p65",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "proIL-18_rna",
+    "name": "proIL-18_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "proIL-1B_rna",
+    "name": "proIL-1B_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TXN_cell",
+    "name": "TXN_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "ASC",
+    "name": "ASC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a",
+    "name": "Orf3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DAMPs_phenotype",
+    "name": "DAMPs_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PAMPs_phenotype",
+    "name": "PAMPs_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_Elicitor_Small_Molecules_simple_molecule",
+    "name": "NLRP3_Elicitor_Small_Molecules_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLRP3_Elicitor_Proteins",
+    "name": "NLRP3_Elicitor_Proteins",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Reactive_Oxygen_Species_simple_molecule",
+    "name": "Reactive_Oxygen_Species_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca2+_ion",
+    "name": "Ca2+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CO_simple_molecule",
+    "name": "CO_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL-18_default_compartment",
+    "name": "IL-18_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IL-1B_default_compartment",
+    "name": "IL-1B_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_Golgi_apparatus",
+    "name": "E_Golgi_apparatus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_endoplasmic_reticulum-Golgi_intermediate_compartment",
+    "name": "E_endoplasmic_reticulum-Golgi_intermediate_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Heme_simple_molecule",
+    "name": "Heme_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADP+_simple_molecule",
+    "name": "NADP+_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Biliverdin_simple_molecule",
+    "name": "Biliverdin_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule",
+    "name": "H2O_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fe2+_ion",
+    "name": "Fe2+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O2_simple_molecule",
+    "name": "O2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADPH_simple_molecule",
+    "name": "NADPH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HMOX1",
+    "name": "HMOX1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t2",
+    "source": "ASC:MAVS:TRAF3_complex_cell",
+    "target": "ASC:MAVS_complex",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "ASC:MAVS:TRAF3_complex_cell",
+    "target": "TRAF3",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "TRAF3:SARS_Orf3a_complex_cell",
+    "target": "TRAF3",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "NLRP3:SUGT1:HSP90_complex",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "NLRP3_cell",
+    "target": "NLRP3:SUGT1:HSP90_complex",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "NLRP3:SUGT1:HSP90_complex",
+    "target": "NLRP3_cell",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "TXNIP:NLRP3_complex",
+    "target": "NLRP3_cell",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "NLRP3:SUGT1:HSP90_complex",
+    "target": "SUGT1:HSP90AB1_complex",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "p105_ubiquitinated",
+    "target": "TRAF3:SARS_Orf3a_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "NLRP3_oligomer:ASC:proCaspase1_complex",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "CASP1_cell",
+    "target": "NLRP3_oligomer:ASC:proCaspase1_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "NLRP3_oligomer:ASC:proCaspase1_complex",
+    "target": "CASP1_cell",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "NLRP3_oligomer:ASC:proCaspase1_complex",
+    "target": "NLRP3_oligomer:ASC_complex",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "CTSG",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "CASP1_cell",
+    "target": "CTSG",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "ASC_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "NLRP3_oligomer:ASC_complex",
+    "target": "NLRP3_cell",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "IL-18_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "IL-1B_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "proIL-18_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "proIL-1B_cell",
+    "target": "Caspase-1_Tetramer_complex",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "Caspase-1_Tetramer_complex",
+    "target": "CASP1(120-197):CASP1(317-404)_complex",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "TXNIP:NLRP3_complex",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "NLRP3_cell",
+    "target": "TXNIP:NLRP3_complex",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "TXNIP:NLRP3_complex",
+    "target": "TXNIP",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "Thioredoxin:TXNIP_complex",
+    "target": "TXNIP",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "CASP1(120-197):CASP1(317-404)_complex",
+    "target": "CASP1_cell",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "TRAF3",
+    "target": "ASC:MAVS:TRAF3_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "MAVS",
+    "target": "ASC:MAVS:TRAF3_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "ASC_ubiquitinated",
+    "target": "ASC:MAVS:TRAF3_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "ASC:MAVS:TRAF3_complex_cell",
+    "target": "TRAF3:SARS_Orf3a_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "Nf-KB_Complex_complex_nucleus",
+    "target": "NF-KB_COMPLEX:IKBA_complex",
+    "sign": false
+   },
+   {
+    "id": "t34",
+    "source": "NF-KB_COMPLEX:IKBA_complex",
+    "target": "IKBA_phosphorylated_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "NF-KB_COMPLEX:IKBA_complex",
+    "target": "Nf-KB_Complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "Nf-KB_Complex_complex_nucleus",
+    "target": "Nf-KB_Complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "Nf-KB_Complex_complex_cell",
+    "target": "p50",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "Nf-KB_Complex_complex_cell",
+    "target": "p65",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "proIL-18_rna",
+    "target": "Nf-KB_Complex_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "proIL-1B_rna",
+    "target": "Nf-KB_Complex_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "TXNIP",
+    "target": "Thioredoxin:TXNIP_complex",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "TXN_cell",
+    "target": "Thioredoxin:TXNIP_complex",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "Thioredoxin:TXNIP_complex",
+    "target": "TXN_cell",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "ASC:MAVS_complex",
+    "target": "ASC",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "ASC:MAVS_complex",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "TRAF3:SARS_Orf3a_complex_cell",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "DAMPs_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "NLRP3_cell",
+    "target": "DAMPs_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "PAMPs_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "NLRP3_cell",
+    "target": "PAMPs_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "NLRP3_Elicitor_Small_Molecules_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "NLRP3_cell",
+    "target": "NLRP3_Elicitor_Small_Molecules_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "NLRP3_Elicitor_Proteins",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "NLRP3_cell",
+    "target": "NLRP3_Elicitor_Proteins",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "Reactive_Oxygen_Species_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "NLRP3_cell",
+    "target": "Reactive_Oxygen_Species_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "TXN_cell",
+    "target": "Reactive_Oxygen_Species_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "SUGT1:HSP90AB1_complex",
+    "target": "Ca2+_ion",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "NLRP3_cell",
+    "target": "Ca2+_ion",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "Reactive_Oxygen_Species_simple_molecule",
+    "target": "CO_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t62",
+    "source": "IL-18_cell",
+    "target": "proIL-18_cell",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "proIL-18_cell",
+    "target": "proIL-18_rna",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "IL-1B_cell",
+    "target": "proIL-1B_cell",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "proIL-1B_cell",
+    "target": "proIL-1B_rna",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "IL-18_default_compartment",
+    "target": "IL-18_cell",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "IL-1B_default_compartment",
+    "target": "IL-1B_cell",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "p50",
+    "target": "p105_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "Ca2+_ion",
+    "target": "E_Golgi_apparatus",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "Ca2+_ion",
+    "target": "E_endoplasmic_reticulum-Golgi_intermediate_compartment",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "NADP+_simple_molecule",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "Biliverdin_simple_molecule",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "H2O_simple_molecule",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "CO_simple_molecule",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "Fe2+_ion",
+    "target": "Heme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "NADP+_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "Biliverdin_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "H2O_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "CO_simple_molecule",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "Fe2+_ion",
+    "target": "O2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "NADP+_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "Biliverdin_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "H2O_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "CO_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "Fe2+_ion",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "NADP+_simple_molecule",
+    "target": "HMOX1",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "Biliverdin_simple_molecule",
+    "target": "HMOX1",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "H2O_simple_molecule",
+    "target": "HMOX1",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "CO_simple_molecule",
+    "target": "HMOX1",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "Fe2+_ion",
+    "target": "HMOX1",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Nsp14.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Nsp14.json
@@ -1,0 +1,4697 @@
+{
+ "header": {
+  "name": "Nsp14",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Nsp14",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "SIRT5:Nsp14_complex",
+    "name": "SIRT5:Nsp14_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nicotinamide_simple_molecule",
+    "name": "Nicotinamide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Histone-L-lysine_simple_molecule",
+    "name": "Histone-L-lysine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "O-Acetyl-ADP-ribose_simple_molecule",
+    "name": "O-Acetyl-ADP-ribose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIRT5",
+    "name": "SIRT5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Urea_cycle_phenotype",
+    "name": "Urea_cycle_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp14_mitochondrion",
+    "name": "Nsp14_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GLA:Nsp14_complex",
+    "name": "GLA:Nsp14_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "D-Galactose_simple_molecule",
+    "name": "D-Galactose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "_alpha_-D-Glucose_simple_molecule",
+    "name": "_alpha_-D-Glucose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Raffinose_simple_molecule",
+    "name": "Raffinose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Sucrose_simple_molecule",
+    "name": "Sucrose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GLA",
+    "name": "GLA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp14_cell",
+    "name": "Nsp14_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IMPDH2:Nsp14_complex",
+    "name": "IMPDH2:Nsp14_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H_simple_molecule",
+    "name": "H_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADH_simple_molecule",
+    "name": "NADH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "XMP_simple_molecule",
+    "name": "XMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IMPDH2",
+    "name": "IMPDH2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Guanine_nucleotide_synthesis_phenotype",
+    "name": "Guanine_nucleotide_synthesis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "_alpha_-D-Galactose_simple_molecule",
+    "name": "_alpha_-D-Galactose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Lactose_simple_molecule",
+    "name": "Lactose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_cell",
+    "name": "H2O_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP_simple_molecule",
+    "name": "ADP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPi_simple_molecule",
+    "name": "PPi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N-Ribosyl-nicotinamide_simple_molecule",
+    "name": "N-Ribosyl-nicotinamide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "name": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAD_simple_molecule",
+    "name": "NAD_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "name": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Glutamate_simple_molecule",
+    "name": "L-Glutamate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AMP_simple_molecule",
+    "name": "AMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pi_simple_molecule",
+    "name": "Pi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP-D-ribose_simple_molecule",
+    "name": "ADP-D-ribose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "name": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "name": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IMP_simple_molecule",
+    "name": "IMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GMP_simple_molecule",
+    "name": "GMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GDP_simple_molecule",
+    "name": "GDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dGMP_simple_molecule",
+    "name": "dGMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Guanosine_simple_molecule",
+    "name": "Guanosine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ammonium_simple_molecule",
+    "name": "Ammonium_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Xanthosine_simple_molecule",
+    "name": "Xanthosine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Xanthine_simple_molecule",
+    "name": "Xanthine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Inosine_simple_molecule",
+    "name": "Inosine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Adenosine_simple_molecule",
+    "name": "Adenosine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Deoxyinosine_simple_molecule",
+    "name": "Deoxyinosine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GLB1",
+    "name": "GLB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LCT",
+    "name": "LCT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Galacitol_simple_molecule",
+    "name": "Galacitol_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADPH_simple_molecule",
+    "name": "NADPH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADP_simple_molecule",
+    "name": "NADP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nicotinate-adenine_dinucleotide_phosphate_simple_molecule",
+    "name": "nicotinate-adenine_dinucleotide_phosphate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AKR1B1",
+    "name": "AKR1B1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Melibiose_simple_molecule",
+    "name": "Melibiose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Migalastat_drug",
+    "name": "Migalastat_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Stachyose_simple_molecule",
+    "name": "Stachyose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "_alpha_-D-Galactose-1P_simple_molecule",
+    "name": "_alpha_-D-Galactose-1P_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GALM",
+    "name": "GALM",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "name": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "_alpha_-D-Glucose-1-P_simple_molecule",
+    "name": "_alpha_-D-Glucose-1-P_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule",
+    "name": "ATP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Deamino-NAD_simple_molecule",
+    "name": "Deamino-NAD_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "name": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "name": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Aminoimidazole_ribotide_simple_molecule",
+    "name": "Aminoimidazole_ribotide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "name": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GTP_simple_molecule",
+    "name": "GTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dGDP_simple_molecule",
+    "name": "dGDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dGTP_simple_molecule",
+    "name": "dGTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dAMP_simple_molecule",
+    "name": "dAMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dADP_simple_molecule",
+    "name": "dADP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dATP_simple_molecule",
+    "name": "dATP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GALK1",
+    "name": "GALK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thioredoxin_disulfide_simple_molecule",
+    "name": "Thioredoxin_disulfide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADK",
+    "name": "NADK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Glutamine_simple_molecule",
+    "name": "L-Glutamine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADSYN1",
+    "name": "NADSYN1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "name": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NRK1",
+    "name": "NRK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nicotinate_simple_molecule",
+    "name": "Nicotinate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CO2_simple_molecule",
+    "name": "CO2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAPRT1",
+    "name": "NAPRT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Glycine_simple_molecule",
+    "name": "Glycine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GART",
+    "name": "GART",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "name": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Tetrahydrofolate_simple_molecule",
+    "name": "Tetrahydrofolate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PFAS",
+    "name": "PFAS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "name": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Aspartate_simple_molecule",
+    "name": "L-Aspartate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PAICS",
+    "name": "PAICS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GUK1",
+    "name": "GUK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NME3",
+    "name": "NME3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nucleoside_diphosphate_kinase_complex_cell",
+    "name": "Nucleoside_diphosphate_kinase_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NME5",
+    "name": "NME5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NME6",
+    "name": "NME6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NME7",
+    "name": "NME7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Deoxyguanosine_simple_molecule",
+    "name": "Deoxyguanosine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Guanine_simple_molecule",
+    "name": "Guanine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "2-deoxy-_alpha_-D-ribose_1-phosphate_simple_molecule",
+    "name": "2-deoxy-_alpha_-D-ribose_1-phosphate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DCK",
+    "name": "DCK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Adenine_simple_molecule",
+    "name": "Adenine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADK",
+    "name": "ADK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AK7",
+    "name": "AK7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AK1",
+    "name": "AK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AK8",
+    "name": "AK8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AK5",
+    "name": "AK5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Deoxyadenosine_simple_molecule",
+    "name": "Deoxyadenosine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UDP_simple_molecule",
+    "name": "UDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UDP-_alpha_-D-Glucose_simple_molecule",
+    "name": "UDP-_alpha_-D-Glucose_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UTP_simple_molecule",
+    "name": "UTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GALT",
+    "name": "GALT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GALE",
+    "name": "GALE",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UGP2",
+    "name": "UGP2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMNAT2",
+    "name": "NMNAT2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMNAT1",
+    "name": "NMNAT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NMNAT3",
+    "name": "NMNAT3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAMPT",
+    "name": "NAMPT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Quinolinate_simple_molecule",
+    "name": "Quinolinate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "QPRT",
+    "name": "QPRT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPAT",
+    "name": "PPAT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GMPS",
+    "name": "GMPS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ITPA",
+    "name": "ITPA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENPP1",
+    "name": "ENPP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENPP3",
+    "name": "ENPP3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HPRT1",
+    "name": "HPRT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Hypoxanthine_simple_molecule",
+    "name": "Hypoxanthine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "APRT",
+    "name": "APRT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "lactose_synthetase_complex",
+    "name": "lactose_synthetase_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "1-(5'-Phosphoribosyl)-5-formamido-4-imidazolecarboxamide_simple_molecule",
+    "name": "1-(5'-Phosphoribosyl)-5-formamido-4-imidazolecarboxamide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATIC",
+    "name": "ATIC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Thioredoxin_simple_molecule",
+    "name": "Thioredoxin_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ribonucleoside_reductase_complex_cell",
+    "name": "ribonucleoside_reductase_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NNT",
+    "name": "NNT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GMPR",
+    "name": "GMPR",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GMPR2",
+    "name": "GMPR2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CD38",
+    "name": "CD38",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "10-Formyltetrahydrofolate_simple_molecule",
+    "name": "10-Formyltetrahydrofolate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IMPDH1",
+    "name": "IMPDH1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mycophenolic_acid_drug",
+    "name": "Mycophenolic_acid_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Merimepodib_drug",
+    "name": "Merimepodib_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ribavirin_drug",
+    "name": "Ribavirin_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENTPD2",
+    "name": "ENTPD2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NTPCR",
+    "name": "NTPCR",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENTPD4",
+    "name": "ENTPD4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENTPD5",
+    "name": "ENTPD5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENTPD6",
+    "name": "ENTPD6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CANT1",
+    "name": "CANT1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "XDH",
+    "name": "XDH",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PNP",
+    "name": "PNP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Histone_N6-acetyl-L-lysine_simple_molecule",
+    "name": "Histone_N6-acetyl-L-lysine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule_mitochondrion",
+    "name": "H2O_simple_molecule_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NT5E",
+    "name": "NT5E",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "D-Ribose_5P_simple_molecule",
+    "name": "D-Ribose_5P_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRPS1",
+    "name": "PRPS1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRPS2",
+    "name": "PRPS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRPS1L1",
+    "name": "PRPS1L1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "_alpha_D-Ribose_1P_simple_molecule",
+    "name": "_alpha_D-Ribose_1P_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PGM2",
+    "name": "PGM2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "1-(5'-Phosphoribosyl)-5-amino-4-imidazolecarboxamide_simple_molecule",
+    "name": "1-(5'-Phosphoribosyl)-5-amino-4-imidazolecarboxamide_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fumarate_simple_molecule",
+    "name": "Fumarate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADSL",
+    "name": "ADSL",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AMDP2",
+    "name": "AMDP2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AMPD1",
+    "name": "AMPD1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AMPD3",
+    "name": "AMPD3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GDA",
+    "name": "GDA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADA",
+    "name": "ADA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "SIRT5:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "Histone-L-lysine_simple_molecule",
+    "target": "SIRT5:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "O-Acetyl-ADP-ribose_simple_molecule",
+    "target": "SIRT5:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "SIRT5:Nsp14_complex",
+    "target": "SIRT5",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "SIRT5",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "Histone-L-lysine_simple_molecule",
+    "target": "SIRT5",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "O-Acetyl-ADP-ribose_simple_molecule",
+    "target": "SIRT5",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "Urea_cycle_phenotype",
+    "target": "SIRT5",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "SIRT5:Nsp14_complex",
+    "target": "Nsp14_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "D-Galactose_simple_molecule",
+    "target": "GLA:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "GLA:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "Raffinose_simple_molecule",
+    "target": "GLA:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "Sucrose_simple_molecule",
+    "target": "GLA:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "GLA:Nsp14_complex",
+    "target": "GLA",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "D-Galactose_simple_molecule",
+    "target": "GLA",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "GLA",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "Raffinose_simple_molecule",
+    "target": "GLA",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "Sucrose_simple_molecule",
+    "target": "GLA",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "GLA:Nsp14_complex",
+    "target": "Nsp14_cell",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "IMPDH2:Nsp14_complex",
+    "target": "Nsp14_cell",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "H_simple_molecule",
+    "target": "IMPDH2:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "NADH_simple_molecule",
+    "target": "IMPDH2:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "XMP_simple_molecule",
+    "target": "IMPDH2:Nsp14_complex",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "IMPDH2:Nsp14_complex",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "H_simple_molecule",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "NADH_simple_molecule",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "XMP_simple_molecule",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "Guanine_nucleotide_synthesis_phenotype",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "_alpha_-D-Galactose_simple_molecule",
+    "target": "D-Galactose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "D-Galactose_simple_molecule",
+    "target": "Lactose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "Lactose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "D-Galactose_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "ADP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "PPi_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "H_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "Raffinose_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "Sucrose_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "N-Ribosyl-nicotinamide_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "NAD_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "NADH_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "AMP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "Pi_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "ADP-D-ribose_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "IMP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "XMP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "GMP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "GDP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "dGMP_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "Guanosine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "Ammonium_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "Xanthosine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "Xanthine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "Inosine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "Adenosine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "Deoxyinosine_simple_molecule",
+    "target": "H2O_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "D-Galactose_simple_molecule",
+    "target": "GLB1",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "GLB1",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "D-Galactose_simple_molecule",
+    "target": "LCT",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "LCT",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "D-Galactose_simple_molecule",
+    "target": "Galacitol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "NADPH_simple_molecule",
+    "target": "Galacitol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "H_simple_molecule",
+    "target": "Galacitol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "D-Galactose_simple_molecule",
+    "target": "NADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "NADPH_simple_molecule",
+    "target": "NADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "H_simple_molecule",
+    "target": "NADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "NADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "nicotinate-adenine_dinucleotide_phosphate_simple_molecule",
+    "target": "NADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "GMP_simple_molecule",
+    "target": "NADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "D-Galactose_simple_molecule",
+    "target": "AKR1B1",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "NADPH_simple_molecule",
+    "target": "AKR1B1",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "H_simple_molecule",
+    "target": "AKR1B1",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "D-Galactose_simple_molecule",
+    "target": "Melibiose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "Melibiose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "D-Galactose_simple_molecule",
+    "target": "Migalastat_drug",
+    "sign": false
+   },
+   {
+    "id": "t82",
+    "source": "_alpha_-D-Glucose_simple_molecule",
+    "target": "Migalastat_drug",
+    "sign": false
+   },
+   {
+    "id": "t83",
+    "source": "Raffinose_simple_molecule",
+    "target": "Migalastat_drug",
+    "sign": false
+   },
+   {
+    "id": "t84",
+    "source": "Sucrose_simple_molecule",
+    "target": "Migalastat_drug",
+    "sign": false
+   },
+   {
+    "id": "t85",
+    "source": "D-Galactose_simple_molecule",
+    "target": "Raffinose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "Sucrose_simple_molecule",
+    "target": "Raffinose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "D-Galactose_simple_molecule",
+    "target": "Stachyose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "Raffinose_simple_molecule",
+    "target": "Stachyose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "_alpha_-D-Galactose-1P_simple_molecule",
+    "target": "_alpha_-D-Galactose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "ADP_simple_molecule",
+    "target": "_alpha_-D-Galactose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "_alpha_-D-Galactose_simple_molecule",
+    "target": "GALM",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "target": "_alpha_-D-Galactose-1P_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "_alpha_-D-Glucose-1-P_simple_molecule",
+    "target": "_alpha_-D-Galactose-1P_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "_alpha_-D-Galactose-1P_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "ADP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "PPi_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "NADP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "H_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "NAD_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "Deamino-NAD_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "AMP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "Pi_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t108",
+    "source": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "Aminoimidazole_ribotide_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "GMP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "GDP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "GTP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "dGDP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "dGTP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "dGMP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t117",
+    "source": "dAMP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "dADP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "dATP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "_alpha_-D-Galactose-1P_simple_molecule",
+    "target": "GALK1",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "ADP_simple_molecule",
+    "target": "GALK1",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "H2O_simple_molecule_cell",
+    "target": "ADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "Thioredoxin_disulfide_simple_molecule",
+    "target": "ADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "dADP_simple_molecule",
+    "target": "ADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "ADP_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "NADP_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "H_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "NADH_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "AMP_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "Histone-L-lysine_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "O-Acetyl-ADP-ribose_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "ADP-D-ribose_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "XMP_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "Xanthine_simple_molecule",
+    "target": "NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "ADP_simple_molecule",
+    "target": "NADK",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "NADP_simple_molecule",
+    "target": "NADK",
+    "sign": true
+   },
+   {
+    "id": "t139",
+    "source": "H_simple_molecule",
+    "target": "NADK",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "ADP_simple_molecule",
+    "target": "Deamino-NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t141",
+    "source": "H_simple_molecule",
+    "target": "Deamino-NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "NAD_simple_molecule",
+    "target": "Deamino-NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "Deamino-NAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t144",
+    "source": "ADP_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "PPi_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "H_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "NAD_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "AMP_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "Pi_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "GMP_simple_molecule",
+    "target": "L-Glutamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "ADP_simple_molecule",
+    "target": "NADSYN1",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "H_simple_molecule",
+    "target": "NADSYN1",
+    "sign": true
+   },
+   {
+    "id": "t156",
+    "source": "NAD_simple_molecule",
+    "target": "NADSYN1",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "NADSYN1",
+    "sign": true
+   },
+   {
+    "id": "t158",
+    "source": "ADP_simple_molecule",
+    "target": "N-Ribosyl-nicotinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "H_simple_molecule",
+    "target": "N-Ribosyl-nicotinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "N-Ribosyl-nicotinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "N-Ribosyl-nicotinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "target": "N-Ribosyl-nicotinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "ADP_simple_molecule",
+    "target": "NRK1",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "H_simple_molecule",
+    "target": "NRK1",
+    "sign": true
+   },
+   {
+    "id": "t165",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "NRK1",
+    "sign": true
+   },
+   {
+    "id": "t166",
+    "source": "ADP_simple_molecule",
+    "target": "Nicotinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t167",
+    "source": "PPi_simple_molecule",
+    "target": "Nicotinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t168",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "Nicotinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t169",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "Nicotinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t170",
+    "source": "Pi_simple_molecule",
+    "target": "Nicotinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t171",
+    "source": "nicotinate-adenine_dinucleotide_phosphate_simple_molecule",
+    "target": "Nicotinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t172",
+    "source": "ADP_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t173",
+    "source": "PPi_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t174",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t175",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t176",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t177",
+    "source": "AMP_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t178",
+    "source": "Pi_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "CO2_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "IMP_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "GMP_simple_molecule",
+    "target": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t183",
+    "source": "ADP_simple_molecule",
+    "target": "NAPRT1",
+    "sign": true
+   },
+   {
+    "id": "t184",
+    "source": "PPi_simple_molecule",
+    "target": "NAPRT1",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "NAPRT1",
+    "sign": true
+   },
+   {
+    "id": "t186",
+    "source": "Pi_simple_molecule",
+    "target": "NAPRT1",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "ADP_simple_molecule",
+    "target": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "H_simple_molecule",
+    "target": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t189",
+    "source": "Pi_simple_molecule",
+    "target": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t190",
+    "source": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "target": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t191",
+    "source": "ADP_simple_molecule",
+    "target": "Glycine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t192",
+    "source": "H_simple_molecule",
+    "target": "Glycine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t193",
+    "source": "Pi_simple_molecule",
+    "target": "Glycine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t194",
+    "source": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "target": "Glycine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t195",
+    "source": "ADP_simple_molecule",
+    "target": "GART",
+    "sign": true
+   },
+   {
+    "id": "t196",
+    "source": "H_simple_molecule",
+    "target": "GART",
+    "sign": true
+   },
+   {
+    "id": "t197",
+    "source": "Pi_simple_molecule",
+    "target": "GART",
+    "sign": true
+   },
+   {
+    "id": "t198",
+    "source": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "target": "GART",
+    "sign": true
+   },
+   {
+    "id": "t199",
+    "source": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "target": "GART",
+    "sign": true
+   },
+   {
+    "id": "t200",
+    "source": "Tetrahydrofolate_simple_molecule",
+    "target": "GART",
+    "sign": true
+   },
+   {
+    "id": "t201",
+    "source": "Aminoimidazole_ribotide_simple_molecule",
+    "target": "GART",
+    "sign": true
+   },
+   {
+    "id": "t202",
+    "source": "ADP_simple_molecule",
+    "target": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t203",
+    "source": "H_simple_molecule",
+    "target": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t204",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t205",
+    "source": "Pi_simple_molecule",
+    "target": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t206",
+    "source": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "target": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t207",
+    "source": "ADP_simple_molecule",
+    "target": "PFAS",
+    "sign": true
+   },
+   {
+    "id": "t208",
+    "source": "H_simple_molecule",
+    "target": "PFAS",
+    "sign": true
+   },
+   {
+    "id": "t209",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "PFAS",
+    "sign": true
+   },
+   {
+    "id": "t210",
+    "source": "Pi_simple_molecule",
+    "target": "PFAS",
+    "sign": true
+   },
+   {
+    "id": "t211",
+    "source": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "target": "PFAS",
+    "sign": true
+   },
+   {
+    "id": "t212",
+    "source": "ADP_simple_molecule",
+    "target": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t213",
+    "source": "H_simple_molecule",
+    "target": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t214",
+    "source": "Pi_simple_molecule",
+    "target": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t215",
+    "source": "Aminoimidazole_ribotide_simple_molecule",
+    "target": "2-(Formamido)-N1-(5'-phosphoribosyl)acetamidine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t216",
+    "source": "ADP_simple_molecule",
+    "target": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t217",
+    "source": "H_simple_molecule",
+    "target": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t218",
+    "source": "Pi_simple_molecule",
+    "target": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t219",
+    "source": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "target": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t220",
+    "source": "ADP_simple_molecule",
+    "target": "L-Aspartate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t221",
+    "source": "H_simple_molecule",
+    "target": "L-Aspartate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t222",
+    "source": "Pi_simple_molecule",
+    "target": "L-Aspartate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t223",
+    "source": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "target": "L-Aspartate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t224",
+    "source": "ADP_simple_molecule",
+    "target": "PAICS",
+    "sign": true
+   },
+   {
+    "id": "t225",
+    "source": "H_simple_molecule",
+    "target": "PAICS",
+    "sign": true
+   },
+   {
+    "id": "t226",
+    "source": "Pi_simple_molecule",
+    "target": "PAICS",
+    "sign": true
+   },
+   {
+    "id": "t227",
+    "source": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "target": "PAICS",
+    "sign": true
+   },
+   {
+    "id": "t228",
+    "source": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "target": "PAICS",
+    "sign": true
+   },
+   {
+    "id": "t229",
+    "source": "ADP_simple_molecule",
+    "target": "GMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t230",
+    "source": "Pi_simple_molecule",
+    "target": "GMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t231",
+    "source": "GDP_simple_molecule",
+    "target": "GMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t232",
+    "source": "Guanosine_simple_molecule",
+    "target": "GMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t233",
+    "source": "ADP_simple_molecule",
+    "target": "GUK1",
+    "sign": true
+   },
+   {
+    "id": "t234",
+    "source": "GDP_simple_molecule",
+    "target": "GUK1",
+    "sign": true
+   },
+   {
+    "id": "t235",
+    "source": "dGDP_simple_molecule",
+    "target": "GUK1",
+    "sign": true
+   },
+   {
+    "id": "t236",
+    "source": "ADP_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t237",
+    "source": "H2O_simple_molecule_cell",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t238",
+    "source": "H_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t239",
+    "source": "Pi_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t240",
+    "source": "GMP_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t241",
+    "source": "GTP_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t242",
+    "source": "dGDP_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t243",
+    "source": "Thioredoxin_disulfide_simple_molecule",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t244",
+    "source": "ADP_simple_molecule",
+    "target": "NME3",
+    "sign": true
+   },
+   {
+    "id": "t245",
+    "source": "GTP_simple_molecule",
+    "target": "NME3",
+    "sign": true
+   },
+   {
+    "id": "t246",
+    "source": "dGTP_simple_molecule",
+    "target": "NME3",
+    "sign": true
+   },
+   {
+    "id": "t247",
+    "source": "dATP_simple_molecule",
+    "target": "NME3",
+    "sign": true
+   },
+   {
+    "id": "t248",
+    "source": "ADP_simple_molecule",
+    "target": "Nucleoside_diphosphate_kinase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t249",
+    "source": "GTP_simple_molecule",
+    "target": "Nucleoside_diphosphate_kinase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t250",
+    "source": "dGTP_simple_molecule",
+    "target": "Nucleoside_diphosphate_kinase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t251",
+    "source": "ADP_simple_molecule",
+    "target": "NME5",
+    "sign": true
+   },
+   {
+    "id": "t252",
+    "source": "GTP_simple_molecule",
+    "target": "NME5",
+    "sign": true
+   },
+   {
+    "id": "t253",
+    "source": "dGTP_simple_molecule",
+    "target": "NME5",
+    "sign": true
+   },
+   {
+    "id": "t254",
+    "source": "dATP_simple_molecule",
+    "target": "NME5",
+    "sign": true
+   },
+   {
+    "id": "t255",
+    "source": "ADP_simple_molecule",
+    "target": "NME6",
+    "sign": true
+   },
+   {
+    "id": "t256",
+    "source": "GTP_simple_molecule",
+    "target": "NME6",
+    "sign": true
+   },
+   {
+    "id": "t257",
+    "source": "dGTP_simple_molecule",
+    "target": "NME6",
+    "sign": true
+   },
+   {
+    "id": "t258",
+    "source": "dATP_simple_molecule",
+    "target": "NME6",
+    "sign": true
+   },
+   {
+    "id": "t259",
+    "source": "ADP_simple_molecule",
+    "target": "NME7",
+    "sign": true
+   },
+   {
+    "id": "t260",
+    "source": "GTP_simple_molecule",
+    "target": "NME7",
+    "sign": true
+   },
+   {
+    "id": "t261",
+    "source": "dGTP_simple_molecule",
+    "target": "NME7",
+    "sign": true
+   },
+   {
+    "id": "t262",
+    "source": "dATP_simple_molecule",
+    "target": "NME7",
+    "sign": true
+   },
+   {
+    "id": "t263",
+    "source": "ADP_simple_molecule",
+    "target": "dGDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t264",
+    "source": "dGTP_simple_molecule",
+    "target": "dGDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t265",
+    "source": "ADP_simple_molecule",
+    "target": "dGMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t266",
+    "source": "dGDP_simple_molecule",
+    "target": "dGMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t267",
+    "source": "ADP_simple_molecule",
+    "target": "Deoxyguanosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t268",
+    "source": "H_simple_molecule",
+    "target": "Deoxyguanosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t269",
+    "source": "dGMP_simple_molecule",
+    "target": "Deoxyguanosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t270",
+    "source": "Guanine_simple_molecule",
+    "target": "Deoxyguanosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t271",
+    "source": "2-deoxy-_alpha_-D-ribose_1-phosphate_simple_molecule",
+    "target": "Deoxyguanosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t272",
+    "source": "ADP_simple_molecule",
+    "target": "DCK",
+    "sign": true
+   },
+   {
+    "id": "t273",
+    "source": "H_simple_molecule",
+    "target": "DCK",
+    "sign": true
+   },
+   {
+    "id": "t274",
+    "source": "dGMP_simple_molecule",
+    "target": "DCK",
+    "sign": true
+   },
+   {
+    "id": "t275",
+    "source": "dAMP_simple_molecule",
+    "target": "DCK",
+    "sign": true
+   },
+   {
+    "id": "t276",
+    "source": "ADP_simple_molecule",
+    "target": "Adenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t277",
+    "source": "H_simple_molecule",
+    "target": "Adenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t278",
+    "source": "AMP_simple_molecule",
+    "target": "Adenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t279",
+    "source": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "target": "Adenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t280",
+    "source": "Ammonium_simple_molecule",
+    "target": "Adenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t281",
+    "source": "Inosine_simple_molecule",
+    "target": "Adenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t282",
+    "source": "Adenine_simple_molecule",
+    "target": "Adenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t283",
+    "source": "ADP_simple_molecule",
+    "target": "ADK",
+    "sign": true
+   },
+   {
+    "id": "t284",
+    "source": "H_simple_molecule",
+    "target": "ADK",
+    "sign": true
+   },
+   {
+    "id": "t285",
+    "source": "AMP_simple_molecule",
+    "target": "ADK",
+    "sign": true
+   },
+   {
+    "id": "t286",
+    "source": "ADP_simple_molecule",
+    "target": "AMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t287",
+    "source": "Pi_simple_molecule",
+    "target": "AMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t288",
+    "source": "IMP_simple_molecule",
+    "target": "AMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t289",
+    "source": "Ammonium_simple_molecule",
+    "target": "AMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t290",
+    "source": "Adenosine_simple_molecule",
+    "target": "AMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t291",
+    "source": "ADP_simple_molecule",
+    "target": "AK7",
+    "sign": true
+   },
+   {
+    "id": "t292",
+    "source": "ADP_simple_molecule",
+    "target": "AK1",
+    "sign": true
+   },
+   {
+    "id": "t293",
+    "source": "ADP_simple_molecule",
+    "target": "AK8",
+    "sign": true
+   },
+   {
+    "id": "t294",
+    "source": "ADP_simple_molecule",
+    "target": "AK5",
+    "sign": true
+   },
+   {
+    "id": "t295",
+    "source": "dADP_simple_molecule",
+    "target": "AK5",
+    "sign": true
+   },
+   {
+    "id": "t296",
+    "source": "ADP_simple_molecule",
+    "target": "Deoxyadenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t297",
+    "source": "H_simple_molecule",
+    "target": "Deoxyadenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t298",
+    "source": "Ammonium_simple_molecule",
+    "target": "Deoxyadenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t299",
+    "source": "Deoxyinosine_simple_molecule",
+    "target": "Deoxyadenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t300",
+    "source": "dAMP_simple_molecule",
+    "target": "Deoxyadenosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t301",
+    "source": "ADP_simple_molecule",
+    "target": "dAMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t302",
+    "source": "dADP_simple_molecule",
+    "target": "dAMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t303",
+    "source": "ADP_simple_molecule",
+    "target": "dADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t304",
+    "source": "dATP_simple_molecule",
+    "target": "dADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t305",
+    "source": "dATP_simple_molecule",
+    "target": "Nucleoside_diphosphate_kinase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t306",
+    "source": "Lactose_simple_molecule",
+    "target": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t307",
+    "source": "UDP_simple_molecule",
+    "target": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t308",
+    "source": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "target": "UDP-_alpha_-D-Glucose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t309",
+    "source": "_alpha_-D-Glucose-1-P_simple_molecule",
+    "target": "UDP-_alpha_-D-Glucose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t310",
+    "source": "UTP_simple_molecule",
+    "target": "UDP-_alpha_-D-Glucose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t311",
+    "source": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "target": "GALT",
+    "sign": true
+   },
+   {
+    "id": "t312",
+    "source": "_alpha_-D-Glucose-1-P_simple_molecule",
+    "target": "GALT",
+    "sign": true
+   },
+   {
+    "id": "t313",
+    "source": "UDP-_alpha_-D-Galactose_simple_molecule",
+    "target": "GALE",
+    "sign": true
+   },
+   {
+    "id": "t314",
+    "source": "_alpha_-D-Glucose-1-P_simple_molecule",
+    "target": "PPi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t315",
+    "source": "UTP_simple_molecule",
+    "target": "PPi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t316",
+    "source": "_alpha_-D-Glucose-1-P_simple_molecule",
+    "target": "UGP2",
+    "sign": true
+   },
+   {
+    "id": "t317",
+    "source": "UTP_simple_molecule",
+    "target": "UGP2",
+    "sign": true
+   },
+   {
+    "id": "t318",
+    "source": "PPi_simple_molecule",
+    "target": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t319",
+    "source": "N-Ribosyl-nicotinamide_simple_molecule",
+    "target": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t320",
+    "source": "NAD_simple_molecule",
+    "target": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t321",
+    "source": "Pi_simple_molecule",
+    "target": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t322",
+    "source": "PPi_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t323",
+    "source": "NAD_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t324",
+    "source": "Deamino-NAD_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t325",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t326",
+    "source": "CO2_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t327",
+    "source": "IMP_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t328",
+    "source": "Ammonium_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t329",
+    "source": "Xanthine_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t330",
+    "source": "Inosine_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t331",
+    "source": "Deoxyinosine_simple_molecule",
+    "target": "H_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t332",
+    "source": "PPi_simple_molecule",
+    "target": "NMNAT2",
+    "sign": true
+   },
+   {
+    "id": "t333",
+    "source": "NAD_simple_molecule",
+    "target": "NMNAT2",
+    "sign": true
+   },
+   {
+    "id": "t334",
+    "source": "Deamino-NAD_simple_molecule",
+    "target": "NMNAT2",
+    "sign": true
+   },
+   {
+    "id": "t335",
+    "source": "PPi_simple_molecule",
+    "target": "NMNAT1",
+    "sign": true
+   },
+   {
+    "id": "t336",
+    "source": "NAD_simple_molecule",
+    "target": "NMNAT1",
+    "sign": true
+   },
+   {
+    "id": "t337",
+    "source": "Deamino-NAD_simple_molecule",
+    "target": "NMNAT1",
+    "sign": true
+   },
+   {
+    "id": "t338",
+    "source": "PPi_simple_molecule",
+    "target": "NMNAT3",
+    "sign": true
+   },
+   {
+    "id": "t339",
+    "source": "NAD_simple_molecule",
+    "target": "NMNAT3",
+    "sign": true
+   },
+   {
+    "id": "t340",
+    "source": "Deamino-NAD_simple_molecule",
+    "target": "NMNAT3",
+    "sign": true
+   },
+   {
+    "id": "t341",
+    "source": "PPi_simple_molecule",
+    "target": "Nicotinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t342",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "Nicotinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t343",
+    "source": "PPi_simple_molecule",
+    "target": "NAMPT",
+    "sign": true
+   },
+   {
+    "id": "t344",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "NAMPT",
+    "sign": true
+   },
+   {
+    "id": "t345",
+    "source": "PPi_simple_molecule",
+    "target": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t346",
+    "source": "Deamino-NAD_simple_molecule",
+    "target": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t347",
+    "source": "PPi_simple_molecule",
+    "target": "Quinolinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t348",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "Quinolinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t349",
+    "source": "CO2_simple_molecule",
+    "target": "Quinolinate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t350",
+    "source": "PPi_simple_molecule",
+    "target": "QPRT",
+    "sign": true
+   },
+   {
+    "id": "t351",
+    "source": "Nicotinate_D-ribonucleotide_simple_molecule",
+    "target": "QPRT",
+    "sign": true
+   },
+   {
+    "id": "t352",
+    "source": "CO2_simple_molecule",
+    "target": "QPRT",
+    "sign": true
+   },
+   {
+    "id": "t353",
+    "source": "PPi_simple_molecule",
+    "target": "PPAT",
+    "sign": true
+   },
+   {
+    "id": "t354",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "PPAT",
+    "sign": true
+   },
+   {
+    "id": "t355",
+    "source": "5-phospho-beta-D-ribosylamine_simple_molecule",
+    "target": "PPAT",
+    "sign": true
+   },
+   {
+    "id": "t356",
+    "source": "PPi_simple_molecule",
+    "target": "XMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t357",
+    "source": "H_simple_molecule",
+    "target": "XMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t358",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "XMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t359",
+    "source": "AMP_simple_molecule",
+    "target": "XMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t360",
+    "source": "Pi_simple_molecule",
+    "target": "XMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t361",
+    "source": "GMP_simple_molecule",
+    "target": "XMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t362",
+    "source": "Xanthosine_simple_molecule",
+    "target": "XMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t363",
+    "source": "PPi_simple_molecule",
+    "target": "GMPS",
+    "sign": true
+   },
+   {
+    "id": "t364",
+    "source": "H_simple_molecule",
+    "target": "GMPS",
+    "sign": true
+   },
+   {
+    "id": "t365",
+    "source": "L-Glutamate_simple_molecule",
+    "target": "GMPS",
+    "sign": true
+   },
+   {
+    "id": "t366",
+    "source": "AMP_simple_molecule",
+    "target": "GMPS",
+    "sign": true
+   },
+   {
+    "id": "t367",
+    "source": "GMP_simple_molecule",
+    "target": "GMPS",
+    "sign": true
+   },
+   {
+    "id": "t368",
+    "source": "PPi_simple_molecule",
+    "target": "dGTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t369",
+    "source": "H_simple_molecule",
+    "target": "dGTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t370",
+    "source": "dGMP_simple_molecule",
+    "target": "dGTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t371",
+    "source": "PPi_simple_molecule",
+    "target": "ITPA",
+    "sign": true
+   },
+   {
+    "id": "t372",
+    "source": "H_simple_molecule",
+    "target": "ITPA",
+    "sign": true
+   },
+   {
+    "id": "t373",
+    "source": "dGMP_simple_molecule",
+    "target": "ITPA",
+    "sign": true
+   },
+   {
+    "id": "t374",
+    "source": "PPi_simple_molecule",
+    "target": "ENPP1",
+    "sign": true
+   },
+   {
+    "id": "t375",
+    "source": "H_simple_molecule",
+    "target": "ENPP1",
+    "sign": true
+   },
+   {
+    "id": "t376",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "ENPP1",
+    "sign": true
+   },
+   {
+    "id": "t377",
+    "source": "AMP_simple_molecule",
+    "target": "ENPP1",
+    "sign": true
+   },
+   {
+    "id": "t378",
+    "source": "dGMP_simple_molecule",
+    "target": "ENPP1",
+    "sign": true
+   },
+   {
+    "id": "t379",
+    "source": "PPi_simple_molecule",
+    "target": "ENPP3",
+    "sign": true
+   },
+   {
+    "id": "t380",
+    "source": "H_simple_molecule",
+    "target": "ENPP3",
+    "sign": true
+   },
+   {
+    "id": "t381",
+    "source": "Nicotinamide_D-ribonucleotide_simple_molecule",
+    "target": "ENPP3",
+    "sign": true
+   },
+   {
+    "id": "t382",
+    "source": "AMP_simple_molecule",
+    "target": "ENPP3",
+    "sign": true
+   },
+   {
+    "id": "t383",
+    "source": "dGMP_simple_molecule",
+    "target": "ENPP3",
+    "sign": true
+   },
+   {
+    "id": "t384",
+    "source": "PPi_simple_molecule",
+    "target": "Guanine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t385",
+    "source": "GMP_simple_molecule",
+    "target": "Guanine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t386",
+    "source": "Ammonium_simple_molecule",
+    "target": "Guanine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t387",
+    "source": "Xanthine_simple_molecule",
+    "target": "Guanine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t388",
+    "source": "PPi_simple_molecule",
+    "target": "HPRT1",
+    "sign": true
+   },
+   {
+    "id": "t389",
+    "source": "IMP_simple_molecule",
+    "target": "HPRT1",
+    "sign": true
+   },
+   {
+    "id": "t390",
+    "source": "GMP_simple_molecule",
+    "target": "HPRT1",
+    "sign": true
+   },
+   {
+    "id": "t391",
+    "source": "PPi_simple_molecule",
+    "target": "Hypoxanthine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t392",
+    "source": "H_simple_molecule",
+    "target": "Hypoxanthine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t393",
+    "source": "NADH_simple_molecule",
+    "target": "Hypoxanthine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t394",
+    "source": "Pi_simple_molecule",
+    "target": "Hypoxanthine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t395",
+    "source": "IMP_simple_molecule",
+    "target": "Hypoxanthine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t396",
+    "source": "Xanthine_simple_molecule",
+    "target": "Hypoxanthine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t397",
+    "source": "Deoxyinosine_simple_molecule",
+    "target": "Hypoxanthine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t398",
+    "source": "PPi_simple_molecule",
+    "target": "Adenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t399",
+    "source": "AMP_simple_molecule",
+    "target": "Adenine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t400",
+    "source": "PPi_simple_molecule",
+    "target": "APRT",
+    "sign": true
+   },
+   {
+    "id": "t401",
+    "source": "AMP_simple_molecule",
+    "target": "APRT",
+    "sign": true
+   },
+   {
+    "id": "t402",
+    "source": "Lactose_simple_molecule",
+    "target": "_alpha_-D-Glucose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t403",
+    "source": "UDP_simple_molecule",
+    "target": "_alpha_-D-Glucose_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t404",
+    "source": "Lactose_simple_molecule",
+    "target": "lactose_synthetase_complex",
+    "sign": true
+   },
+   {
+    "id": "t405",
+    "source": "UDP_simple_molecule",
+    "target": "lactose_synthetase_complex",
+    "sign": true
+   },
+   {
+    "id": "t406",
+    "source": "H2O_simple_molecule_cell",
+    "target": "1-(5'-Phosphoribosyl)-5-formamido-4-imidazolecarboxamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t407",
+    "source": "IMP_simple_molecule",
+    "target": "1-(5'-Phosphoribosyl)-5-formamido-4-imidazolecarboxamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t408",
+    "source": "H2O_simple_molecule_cell",
+    "target": "ATIC",
+    "sign": true
+   },
+   {
+    "id": "t409",
+    "source": "Tetrahydrofolate_simple_molecule",
+    "target": "ATIC",
+    "sign": true
+   },
+   {
+    "id": "t410",
+    "source": "1-(5'-Phosphoribosyl)-5-formamido-4-imidazolecarboxamide_simple_molecule",
+    "target": "ATIC",
+    "sign": true
+   },
+   {
+    "id": "t411",
+    "source": "IMP_simple_molecule",
+    "target": "ATIC",
+    "sign": true
+   },
+   {
+    "id": "t412",
+    "source": "H2O_simple_molecule_cell",
+    "target": "Thioredoxin_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t413",
+    "source": "dGDP_simple_molecule",
+    "target": "Thioredoxin_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t414",
+    "source": "Thioredoxin_disulfide_simple_molecule",
+    "target": "Thioredoxin_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t415",
+    "source": "dADP_simple_molecule",
+    "target": "Thioredoxin_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t416",
+    "source": "H2O_simple_molecule_cell",
+    "target": "ribonucleoside_reductase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t417",
+    "source": "dGDP_simple_molecule",
+    "target": "ribonucleoside_reductase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t418",
+    "source": "Thioredoxin_disulfide_simple_molecule",
+    "target": "ribonucleoside_reductase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t419",
+    "source": "dADP_simple_molecule",
+    "target": "ribonucleoside_reductase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t420",
+    "source": "NADP_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t421",
+    "source": "NADH_simple_molecule",
+    "target": "NADPH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t422",
+    "source": "NADP_simple_molecule",
+    "target": "NNT",
+    "sign": true
+   },
+   {
+    "id": "t423",
+    "source": "NADH_simple_molecule",
+    "target": "NNT",
+    "sign": true
+   },
+   {
+    "id": "t424",
+    "source": "NADPH_simple_molecule",
+    "target": "IMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t425",
+    "source": "H_simple_molecule",
+    "target": "IMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t426",
+    "source": "NADH_simple_molecule",
+    "target": "IMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t427",
+    "source": "Pi_simple_molecule",
+    "target": "IMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t428",
+    "source": "XMP_simple_molecule",
+    "target": "IMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t429",
+    "source": "GMP_simple_molecule",
+    "target": "IMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t430",
+    "source": "Inosine_simple_molecule",
+    "target": "IMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t431",
+    "source": "NADPH_simple_molecule",
+    "target": "Ammonium_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t432",
+    "source": "H_simple_molecule",
+    "target": "Ammonium_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t433",
+    "source": "GMP_simple_molecule",
+    "target": "Ammonium_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t434",
+    "source": "NADPH_simple_molecule",
+    "target": "GMPR",
+    "sign": true
+   },
+   {
+    "id": "t435",
+    "source": "H_simple_molecule",
+    "target": "GMPR",
+    "sign": true
+   },
+   {
+    "id": "t436",
+    "source": "GMP_simple_molecule",
+    "target": "GMPR",
+    "sign": true
+   },
+   {
+    "id": "t437",
+    "source": "NADPH_simple_molecule",
+    "target": "GMPR2",
+    "sign": true
+   },
+   {
+    "id": "t438",
+    "source": "H_simple_molecule",
+    "target": "GMPR2",
+    "sign": true
+   },
+   {
+    "id": "t439",
+    "source": "GMP_simple_molecule",
+    "target": "GMPR2",
+    "sign": true
+   },
+   {
+    "id": "t440",
+    "source": "H_simple_molecule",
+    "target": "CD38",
+    "sign": true
+   },
+   {
+    "id": "t441",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "CD38",
+    "sign": true
+   },
+   {
+    "id": "t442",
+    "source": "nicotinate-adenine_dinucleotide_phosphate_simple_molecule",
+    "target": "CD38",
+    "sign": true
+   },
+   {
+    "id": "t443",
+    "source": "ADP-D-ribose_simple_molecule",
+    "target": "CD38",
+    "sign": true
+   },
+   {
+    "id": "t444",
+    "source": "H_simple_molecule",
+    "target": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t445",
+    "source": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "target": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t446",
+    "source": "Tetrahydrofolate_simple_molecule",
+    "target": "5-phospho-beta-D-ribosylglycinamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t447",
+    "source": "H_simple_molecule",
+    "target": "10-Formyltetrahydrofolate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t448",
+    "source": "5-phosphoribosyl-N-formylglycinamide_simple_molecule",
+    "target": "10-Formyltetrahydrofolate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t449",
+    "source": "Tetrahydrofolate_simple_molecule",
+    "target": "10-Formyltetrahydrofolate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t450",
+    "source": "1-(5'-Phosphoribosyl)-5-formamido-4-imidazolecarboxamide_simple_molecule",
+    "target": "10-Formyltetrahydrofolate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t451",
+    "source": "H_simple_molecule",
+    "target": "Aminoimidazole_ribotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t452",
+    "source": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "target": "Aminoimidazole_ribotide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t453",
+    "source": "H_simple_molecule",
+    "target": "CO2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t454",
+    "source": "1-(5-Phospho-D-ribosyl)-5-amino-4-imidazolecarboxylate_simple_molecule",
+    "target": "CO2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t455",
+    "source": "H_simple_molecule",
+    "target": "IMPDH1",
+    "sign": true
+   },
+   {
+    "id": "t456",
+    "source": "NADH_simple_molecule",
+    "target": "IMPDH1",
+    "sign": true
+   },
+   {
+    "id": "t457",
+    "source": "XMP_simple_molecule",
+    "target": "IMPDH1",
+    "sign": true
+   },
+   {
+    "id": "t458",
+    "source": "H_simple_molecule",
+    "target": "Mycophenolic_acid_drug",
+    "sign": false
+   },
+   {
+    "id": "t459",
+    "source": "NADH_simple_molecule",
+    "target": "Mycophenolic_acid_drug",
+    "sign": false
+   },
+   {
+    "id": "t460",
+    "source": "XMP_simple_molecule",
+    "target": "Mycophenolic_acid_drug",
+    "sign": false
+   },
+   {
+    "id": "t461",
+    "source": "H_simple_molecule",
+    "target": "Merimepodib_drug",
+    "sign": false
+   },
+   {
+    "id": "t462",
+    "source": "NADH_simple_molecule",
+    "target": "Merimepodib_drug",
+    "sign": false
+   },
+   {
+    "id": "t463",
+    "source": "XMP_simple_molecule",
+    "target": "Merimepodib_drug",
+    "sign": false
+   },
+   {
+    "id": "t464",
+    "source": "H_simple_molecule",
+    "target": "Ribavirin_drug",
+    "sign": false
+   },
+   {
+    "id": "t465",
+    "source": "NADH_simple_molecule",
+    "target": "Ribavirin_drug",
+    "sign": false
+   },
+   {
+    "id": "t466",
+    "source": "XMP_simple_molecule",
+    "target": "Ribavirin_drug",
+    "sign": false
+   },
+   {
+    "id": "t467",
+    "source": "H_simple_molecule",
+    "target": "GTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t468",
+    "source": "Pi_simple_molecule",
+    "target": "GTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t469",
+    "source": "GMP_simple_molecule",
+    "target": "GTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t470",
+    "source": "GDP_simple_molecule",
+    "target": "GTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t471",
+    "source": "H_simple_molecule",
+    "target": "ENTPD2",
+    "sign": true
+   },
+   {
+    "id": "t472",
+    "source": "Pi_simple_molecule",
+    "target": "ENTPD2",
+    "sign": true
+   },
+   {
+    "id": "t473",
+    "source": "GMP_simple_molecule",
+    "target": "ENTPD2",
+    "sign": true
+   },
+   {
+    "id": "t474",
+    "source": "GDP_simple_molecule",
+    "target": "ENTPD2",
+    "sign": true
+   },
+   {
+    "id": "t475",
+    "source": "H_simple_molecule",
+    "target": "NTPCR",
+    "sign": true
+   },
+   {
+    "id": "t476",
+    "source": "Pi_simple_molecule",
+    "target": "NTPCR",
+    "sign": true
+   },
+   {
+    "id": "t477",
+    "source": "GDP_simple_molecule",
+    "target": "NTPCR",
+    "sign": true
+   },
+   {
+    "id": "t478",
+    "source": "H_simple_molecule",
+    "target": "ENTPD4",
+    "sign": true
+   },
+   {
+    "id": "t479",
+    "source": "Pi_simple_molecule",
+    "target": "ENTPD4",
+    "sign": true
+   },
+   {
+    "id": "t480",
+    "source": "GMP_simple_molecule",
+    "target": "ENTPD4",
+    "sign": true
+   },
+   {
+    "id": "t481",
+    "source": "H_simple_molecule",
+    "target": "ENTPD5",
+    "sign": true
+   },
+   {
+    "id": "t482",
+    "source": "Pi_simple_molecule",
+    "target": "ENTPD5",
+    "sign": true
+   },
+   {
+    "id": "t483",
+    "source": "GMP_simple_molecule",
+    "target": "ENTPD5",
+    "sign": true
+   },
+   {
+    "id": "t484",
+    "source": "H_simple_molecule",
+    "target": "ENTPD6",
+    "sign": true
+   },
+   {
+    "id": "t485",
+    "source": "Pi_simple_molecule",
+    "target": "ENTPD6",
+    "sign": true
+   },
+   {
+    "id": "t486",
+    "source": "GMP_simple_molecule",
+    "target": "ENTPD6",
+    "sign": true
+   },
+   {
+    "id": "t487",
+    "source": "H_simple_molecule",
+    "target": "CANT1",
+    "sign": true
+   },
+   {
+    "id": "t488",
+    "source": "Pi_simple_molecule",
+    "target": "CANT1",
+    "sign": true
+   },
+   {
+    "id": "t489",
+    "source": "GMP_simple_molecule",
+    "target": "CANT1",
+    "sign": true
+   },
+   {
+    "id": "t490",
+    "source": "H_simple_molecule",
+    "target": "XDH",
+    "sign": true
+   },
+   {
+    "id": "t491",
+    "source": "NADH_simple_molecule",
+    "target": "XDH",
+    "sign": true
+   },
+   {
+    "id": "t492",
+    "source": "Xanthine_simple_molecule",
+    "target": "XDH",
+    "sign": true
+   },
+   {
+    "id": "t493",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t494",
+    "source": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t495",
+    "source": "Guanine_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t496",
+    "source": "2-deoxy-_alpha_-D-ribose_1-phosphate_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t497",
+    "source": "Xanthine_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t498",
+    "source": "Hypoxanthine_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t499",
+    "source": "Adenine_simple_molecule",
+    "target": "Pi_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t500",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t501",
+    "source": "Pi_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t502",
+    "source": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t503",
+    "source": "Guanine_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t504",
+    "source": "2-deoxy-_alpha_-D-ribose_1-phosphate_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t505",
+    "source": "Xanthine_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t506",
+    "source": "Hypoxanthine_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t507",
+    "source": "Adenine_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t508",
+    "source": "Deoxyinosine_simple_molecule",
+    "target": "PNP",
+    "sign": true
+   },
+   {
+    "id": "t509",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "Histone_N6-acetyl-L-lysine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t510",
+    "source": "Histone-L-lysine_simple_molecule",
+    "target": "Histone_N6-acetyl-L-lysine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t511",
+    "source": "O-Acetyl-ADP-ribose_simple_molecule",
+    "target": "Histone_N6-acetyl-L-lysine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t512",
+    "source": "Nicotinamide_simple_molecule",
+    "target": "H2O_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t513",
+    "source": "Histone-L-lysine_simple_molecule",
+    "target": "H2O_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t514",
+    "source": "O-Acetyl-ADP-ribose_simple_molecule",
+    "target": "H2O_simple_molecule_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t515",
+    "source": "N-Ribosyl-nicotinamide_simple_molecule",
+    "target": "NT5E",
+    "sign": true
+   },
+   {
+    "id": "t516",
+    "source": "Pi_simple_molecule",
+    "target": "NT5E",
+    "sign": true
+   },
+   {
+    "id": "t517",
+    "source": "Guanosine_simple_molecule",
+    "target": "NT5E",
+    "sign": true
+   },
+   {
+    "id": "t518",
+    "source": "Xanthosine_simple_molecule",
+    "target": "NT5E",
+    "sign": true
+   },
+   {
+    "id": "t519",
+    "source": "Inosine_simple_molecule",
+    "target": "NT5E",
+    "sign": true
+   },
+   {
+    "id": "t520",
+    "source": "Adenosine_simple_molecule",
+    "target": "NT5E",
+    "sign": true
+   },
+   {
+    "id": "t521",
+    "source": "AMP_simple_molecule",
+    "target": "D-Ribose_5P_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t522",
+    "source": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "target": "D-Ribose_5P_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t523",
+    "source": "AMP_simple_molecule",
+    "target": "PRPS1",
+    "sign": true
+   },
+   {
+    "id": "t524",
+    "source": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "target": "PRPS1",
+    "sign": true
+   },
+   {
+    "id": "t525",
+    "source": "AMP_simple_molecule",
+    "target": "PRPS2",
+    "sign": true
+   },
+   {
+    "id": "t526",
+    "source": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "target": "PRPS2",
+    "sign": true
+   },
+   {
+    "id": "t527",
+    "source": "AMP_simple_molecule",
+    "target": "PRPS1L1",
+    "sign": true
+   },
+   {
+    "id": "t528",
+    "source": "5-phospho-_alpha_-D-ribose_1-diphosphate_simple_molecule",
+    "target": "PRPS1L1",
+    "sign": true
+   },
+   {
+    "id": "t529",
+    "source": "Pi_simple_molecule",
+    "target": "2-deoxy-_alpha_-D-ribose_1-phosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t530",
+    "source": "Deoxyinosine_simple_molecule",
+    "target": "2-deoxy-_alpha_-D-ribose_1-phosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t531",
+    "source": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "target": "Guanosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t532",
+    "source": "Guanine_simple_molecule",
+    "target": "Guanosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t533",
+    "source": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "target": "Xanthosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t534",
+    "source": "Xanthine_simple_molecule",
+    "target": "Xanthosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t535",
+    "source": "_alpha_-D-Ribose_1-phosphate_simple_molecule",
+    "target": "Inosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t536",
+    "source": "Hypoxanthine_simple_molecule",
+    "target": "Inosine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t537",
+    "source": "D-Ribose_5P_simple_molecule",
+    "target": "_alpha_D-Ribose_1P_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t538",
+    "source": "D-Ribose_5P_simple_molecule",
+    "target": "PGM2",
+    "sign": true
+   },
+   {
+    "id": "t539",
+    "source": "Tetrahydrofolate_simple_molecule",
+    "target": "1-(5'-Phosphoribosyl)-5-amino-4-imidazolecarboxamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t540",
+    "source": "1-(5'-Phosphoribosyl)-5-formamido-4-imidazolecarboxamide_simple_molecule",
+    "target": "1-(5'-Phosphoribosyl)-5-amino-4-imidazolecarboxamide_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t541",
+    "source": "1-(5'-Phosphoribosyl)-5-amino-4-imidazolecarboxamide_simple_molecule",
+    "target": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t542",
+    "source": "Fumarate_simple_molecule",
+    "target": "1-(5'-Phosphoribosyl)-5-amino-4-(N-succinocarboxamide)-imidazole_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t543",
+    "source": "1-(5'-Phosphoribosyl)-5-amino-4-imidazolecarboxamide_simple_molecule",
+    "target": "ADSL",
+    "sign": true
+   },
+   {
+    "id": "t544",
+    "source": "Fumarate_simple_molecule",
+    "target": "ADSL",
+    "sign": true
+   },
+   {
+    "id": "t545",
+    "source": "IMP_simple_molecule",
+    "target": "AMDP2",
+    "sign": true
+   },
+   {
+    "id": "t546",
+    "source": "Ammonium_simple_molecule",
+    "target": "AMDP2",
+    "sign": true
+   },
+   {
+    "id": "t547",
+    "source": "IMP_simple_molecule",
+    "target": "AMPD1",
+    "sign": true
+   },
+   {
+    "id": "t548",
+    "source": "Ammonium_simple_molecule",
+    "target": "AMPD1",
+    "sign": true
+   },
+   {
+    "id": "t549",
+    "source": "IMP_simple_molecule",
+    "target": "AMPD3",
+    "sign": true
+   },
+   {
+    "id": "t550",
+    "source": "Ammonium_simple_molecule",
+    "target": "AMPD3",
+    "sign": true
+   },
+   {
+    "id": "t551",
+    "source": "Ammonium_simple_molecule",
+    "target": "GDA",
+    "sign": true
+   },
+   {
+    "id": "t552",
+    "source": "Xanthine_simple_molecule",
+    "target": "GDA",
+    "sign": true
+   },
+   {
+    "id": "t553",
+    "source": "Ammonium_simple_molecule",
+    "target": "ADA",
+    "sign": true
+   },
+   {
+    "id": "t554",
+    "source": "Inosine_simple_molecule",
+    "target": "ADA",
+    "sign": true
+   },
+   {
+    "id": "t555",
+    "source": "Deoxyinosine_simple_molecule",
+    "target": "ADA",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Nsp4_Nsp6.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Nsp4_Nsp6.json
@@ -1,0 +1,897 @@
+{
+ "header": {
+  "name": "Nsp4_Nsp6",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Nsp4_Nsp6",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "Nsp3:Nsp4:Nsp6_complex",
+    "name": "Nsp3:Nsp4:Nsp6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Plasma_membrane_organization_phenotype",
+    "name": "Plasma_membrane_organization_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp3",
+    "name": "Nsp3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6",
+    "name": "Nsp6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F-ATPase:Nsp6_complex",
+    "name": "F-ATPase:Nsp6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "name": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "P-ATPase:Nsp6_complex",
+    "name": "P-ATPase:Nsp6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC6A15:Nsp6_complex",
+    "name": "SLC6A15:Nsp6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "name": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_cell",
+    "name": "Nsp4_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "name": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp4:DNAJC11_complex",
+    "name": "Nsp4:DNAJC11_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "name": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4:IDE_complex_cell",
+    "name": "Nsp4:IDE_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp4_mitochondrion",
+    "name": "Nsp4_mitochondrion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ALG11_endoplasmic_reticulum",
+    "name": "ALG11_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp4_IDE_complex",
+    "name": "Nsp4_IDE_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNAJC11",
+    "name": "DNAJC11",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "F-ATPase_complex_mitochondrial_matrix",
+    "name": "F-ATPase_complex_mitochondrial_matrix",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp4:NUP210_complex_nucleus",
+    "name": "Nsp4:NUP210_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP210_endoplasmic_reticulum",
+    "name": "NUP210_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP210:Selinexor_complex",
+    "name": "NUP210:Selinexor_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP210_nucleus",
+    "name": "NUP210_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Several_drugs_drug",
+    "name": "Several_drugs_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1:Drugs_complex",
+    "name": "SIGMAR1:Drugs_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_endoplasmic_reticulum",
+    "name": "SIGMAR1_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_nucleus",
+    "name": "SIGMAR1_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_cell",
+    "name": "SIGMAR1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6:SIGMAR1_complex_nucleus",
+    "name": "Nsp6:SIGMAR1_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6:SIGMAR1_complex_cell",
+    "name": "Nsp6:SIGMAR1_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase:Nsp6_complex_endosome",
+    "name": "V-ATPase:Nsp6_complex_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TIM_complex:Nsp4_complex",
+    "name": "TIM_complex:Nsp4_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TIM_complex_complex",
+    "name": "TIM_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase_complex_endoplasmic_reticulum",
+    "name": "V-ATPase_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase_complex_endosome",
+    "name": "V-ATPase_complex_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP5MG",
+    "name": "ATP5MG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-type_space_proton_space_ATPase_complex",
+    "name": "V-type_space_proton_space_ATPase_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion",
+    "name": "H+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP6AP1",
+    "name": "ATP6AP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP6AP1:Bafilomycin_A1_complex",
+    "name": "ATP6AP1:Bafilomycin_A1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Selinexor_drug",
+    "name": "Selinexor_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "P-ATPase_complex_cell",
+    "name": "P-ATPase_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "ATP13A3",
+    "name": "ATP13A3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC6A15",
+    "name": "SLC6A15",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC6A15:Orf9c_complex",
+    "name": "SLC6A15:Orf9c_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC6A15:M_complex",
+    "name": "SLC6A15:M_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SLC6A15:Loratadine_complex",
+    "name": "SLC6A15:Loratadine_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9c",
+    "name": "Orf9c",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M",
+    "name": "M",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Loratadine_drug",
+    "name": "Loratadine_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Bafilomycin_A1_drug",
+    "name": "Bafilomycin_A1_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IDE_cell",
+    "name": "IDE_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IDE_human_host",
+    "name": "IDE_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_(+)_rna",
+    "name": "Nsp4_(+)_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_(-)_rna",
+    "name": "Nsp4_(-)_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6_(+)_rna",
+    "name": "Nsp6_(+)_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6_(-)_rna",
+    "name": "Nsp6_(-)_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp3_(+)_rna",
+    "name": "Nsp3_(+)_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp3_(-)_rna",
+    "name": "Nsp3_(-)_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TOM_complex_complex",
+    "name": "TOM_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Plasma_membrane_organization_phenotype",
+    "target": "Nsp3:Nsp4:Nsp6_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "Nsp3:Nsp4:Nsp6_complex",
+    "target": "Nsp3",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "Nsp3:Nsp4:Nsp6_complex",
+    "target": "Nsp6",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "F-ATPase:Nsp6_complex",
+    "target": "Nsp6",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "target": "Nsp6",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "P-ATPase:Nsp6_complex",
+    "target": "Nsp6",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "SLC6A15:Nsp6_complex",
+    "target": "Nsp6",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "target": "Nsp6",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "Nsp3:Nsp4:Nsp6_complex",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "Nsp4:DNAJC11_complex",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "Nsp4:IDE_complex_cell",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "Nsp4_mitochondrion",
+    "target": "Nsp4_cell",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "target": "ALG11_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "Nsp4_IDE_complex",
+    "target": "Nsp4:IDE_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "Nsp4:DNAJC11_complex",
+    "target": "DNAJC11",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "F-ATPase:Nsp6_complex",
+    "target": "F-ATPase_complex_mitochondrial_matrix",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "Nsp4:NUP210_complex_nucleus",
+    "target": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "target": "NUP210_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "NUP210:Selinexor_complex",
+    "target": "NUP210_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "NUP210_nucleus",
+    "target": "NUP210_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "SIGMAR1:Drugs_complex",
+    "target": "Several_drugs_drug",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "SIGMAR1:Drugs_complex",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "SIGMAR1_nucleus",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "SIGMAR1_cell",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "Nsp6:SIGMAR1_complex_nucleus",
+    "target": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "Nsp6:SIGMAR1_complex_cell",
+    "target": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "V-ATPase:Nsp6_complex_endosome",
+    "target": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "TIM_complex:Nsp4_complex",
+    "target": "Nsp4_mitochondrion",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "TIM_complex:Nsp4_complex",
+    "target": "TIM_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "target": "V-ATPase_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "V-ATPase_complex_endosome",
+    "target": "V-ATPase_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "F-ATPase_complex_mitochondrial_matrix",
+    "target": "ATP5MG",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "V-ATPase_complex_endoplasmic_reticulum",
+    "target": "V-type_space_proton_space_ATPase_complex",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "H+_ion",
+    "target": "V-type_space_proton_space_ATPase_complex",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "V-ATPase_complex_endoplasmic_reticulum",
+    "target": "ATP6AP1",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "ATP6AP1:Bafilomycin_A1_complex",
+    "target": "ATP6AP1",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "NUP210:Selinexor_complex",
+    "target": "Selinexor_drug",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "P-ATPase:Nsp6_complex",
+    "target": "P-ATPase_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "P-ATPase_complex_cell",
+    "target": "ATP13A3",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "SLC6A15:Nsp6_complex",
+    "target": "SLC6A15",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "SLC6A15:Orf9c_complex",
+    "target": "SLC6A15",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "SLC6A15:M_complex",
+    "target": "SLC6A15",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "SLC6A15:Loratadine_complex",
+    "target": "SLC6A15",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "SLC6A15:Orf9c_complex",
+    "target": "Orf9c",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "SLC6A15:M_complex",
+    "target": "M",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "SLC6A15:Loratadine_complex",
+    "target": "Loratadine_drug",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "ATP6AP1:Bafilomycin_A1_complex",
+    "target": "Bafilomycin_A1_drug",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "Nsp4:IDE_complex_cell",
+    "target": "IDE_cell",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "IDE_human_host",
+    "target": "IDE_cell",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "Nsp4_cell",
+    "target": "Nsp4_(+)_rna",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "Nsp4_(-)_rna",
+    "target": "Nsp4_(+)_rna",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "Nsp4_(+)_rna",
+    "target": "Nsp4_(-)_rna",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "Nsp6",
+    "target": "Nsp6_(+)_rna",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "Nsp6_(-)_rna",
+    "target": "Nsp6_(+)_rna",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "Nsp6_(+)_rna",
+    "target": "Nsp6_(-)_rna",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "Nsp3",
+    "target": "Nsp3_(+)_rna",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "Nsp3_(-)_rna",
+    "target": "Nsp3_(+)_rna",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "Nsp3_(+)_rna",
+    "target": "Nsp3_(-)_rna",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "Nsp4_mitochondrion",
+    "target": "TOM_complex_complex",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Nsp9_protein.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Nsp9_protein.json
@@ -1,0 +1,3484 @@
+{
+ "header": {
+  "name": "Nsp9_protein",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Nsp9_protein",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "Nsp9_cell",
+    "name": "Nsp9_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fibrillincomp_complex",
+    "name": "Fibrillincomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nuclear_Pore_comp_complex",
+    "name": "Nuclear_Pore_comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mibcomp_complex",
+    "name": "mibcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pathogen_complex",
+    "name": "pathogen_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "spartcomp_complex",
+    "name": "spartcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "mat2bcomp_complex",
+    "name": "mat2bcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NspComp_complex",
+    "name": "NspComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "homodimer_complex",
+    "name": "homodimer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Fibrillin_complex_human_host",
+    "name": "Fibrillin_complex_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "FBLN5",
+    "name": "FBLN5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LOXcomp_complex",
+    "name": "LOXcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PLG",
+    "name": "PLG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nuclear_Pore_complex",
+    "name": "Nuclear_Pore_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MIB1",
+    "name": "MIB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MIBcomp_complex",
+    "name": "MIBcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DLL1",
+    "name": "DLL1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Vpr",
+    "name": "Vpr",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPS_complex_nucleus",
+    "name": "COPS_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "SCARB1",
+    "name": "SCARB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "lipidcomp_complex",
+    "name": "lipidcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SCARB1_complex",
+    "name": "SCARB1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Phosphatidyl_serine_simple_molecule",
+    "name": "Phosphatidyl_serine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAT1A",
+    "name": "MAT1A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SAdComp_complex",
+    "name": "SAdComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAT_complex",
+    "name": "MAT_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S-Adenosylmethionine_drug",
+    "name": "S-Adenosylmethionine_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SAdComp2_complex",
+    "name": "SAdComp2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nup2_complex",
+    "name": "nup2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nup1_complex",
+    "name": "nup1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EXOSC2",
+    "name": "EXOSC2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EXOCcomp_complex",
+    "name": "EXOCcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp8",
+    "name": "Nsp8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp7812_complex_cell",
+    "name": "Nsp7812_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "FOCADcomp_complex",
+    "name": "FOCADcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SRP54comp_complex",
+    "name": "SRP54comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MPHOSPHcomp_complex",
+    "name": "MPHOSPHcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRPScomp_complex",
+    "name": "MRPScomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SEPSECScomp_complex",
+    "name": "SEPSECScomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NOL10comp_complex",
+    "name": "NOL10comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AATFcomp_complex",
+    "name": "AATFcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDX10comp_complex",
+    "name": "DDX10comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NGDNcomp_complex",
+    "name": "NGDNcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CCDCcomp_complex",
+    "name": "CCDCcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MEPCEcomp_complex",
+    "name": "MEPCEcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NARS2comp_complex",
+    "name": "NARS2comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EXOSC3",
+    "name": "EXOSC3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EXOSC5",
+    "name": "EXOSC5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EXOSC8",
+    "name": "EXOSC8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp9_nucleus",
+    "name": "Nsp9_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "gtf2f2comp_complex",
+    "name": "gtf2f2comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "znfcomp_complex",
+    "name": "znfcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "eifcomp_complex",
+    "name": "eifcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dcafcomp_complex",
+    "name": "dcafcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nek9comp_complex",
+    "name": "nek9comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GTF2F2",
+    "name": "GTF2F2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "gtfrnapoly_complex",
+    "name": "gtfrnapoly_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAT-HIV_complex",
+    "name": "TAT-HIV_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDN1-homo_complex_human_host",
+    "name": "EDN1-homo_complex_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDN1-homo_complex_cell",
+    "name": "EDN1-homo_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDNRA",
+    "name": "EDNRA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDNRASitaComp_complex",
+    "name": "EDNRASitaComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDNRAmbComp_complex",
+    "name": "EDNRAmbComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDNRAcetComp_complex",
+    "name": "EDNRAcetComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDNRMacComp_complex",
+    "name": "EDNRMacComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDN1-homo_complex_nucleus",
+    "name": "EDN1-homo_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "EDN1-homo_complex_endoplasmic_reticulum",
+    "name": "EDN1-homo_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZNF503",
+    "name": "ZNF503",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dcafznf_complex",
+    "name": "dcafznf_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp7",
+    "name": "Nsp7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RHOA7comp_complex",
+    "name": "RHOA7comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CA12comp_complex",
+    "name": "CA12comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CYB5R3comp_complex",
+    "name": "CYB5R3comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COMT_complex",
+    "name": "COMT_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RALAcomp_complex",
+    "name": "RALAcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RAB7comp_complex",
+    "name": "RAB7comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACSLcomp_complex",
+    "name": "ACSLcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SRP72comp_complex",
+    "name": "SRP72comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp12",
+    "name": "Nsp12",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MYCBPcomp_complex",
+    "name": "MYCBPcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SBNOcomp_complex",
+    "name": "SBNOcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "s389_complex",
+    "name": "s389_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RBMcomp_complex",
+    "name": "RBMcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZNFcomp_complex",
+    "name": "ZNFcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LARPcomp_complex",
+    "name": "LARPcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZC3H7Acomp_complex",
+    "name": "ZC3H7Acomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TCFcomp_complex",
+    "name": "TCFcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "virus_replication_phenotype",
+    "name": "virus_replication_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RdRpassembled_rna",
+    "name": "RdRpassembled_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "remdesivir__drug",
+    "name": "remdesivir__drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "favipiravir_drug",
+    "name": "favipiravir_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP54",
+    "name": "NUP54",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP58",
+    "name": "NUP58",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP62",
+    "name": "NUP62",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP214",
+    "name": "NUP214",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP88",
+    "name": "NUP88",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAG6",
+    "name": "BAG6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEK9",
+    "name": "NEK9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEKs_complex",
+    "name": "NEKs_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEK7",
+    "name": "NEK7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEK6",
+    "name": "NEK6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GTF2B",
+    "name": "GTF2B",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "POLR2A",
+    "name": "POLR2A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "POLR2B",
+    "name": "POLR2B",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "POLR2E",
+    "name": "POLR2E",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "POLR2G",
+    "name": "POLR2G",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDN1",
+    "name": "EDN1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF4H",
+    "name": "EIF4H",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPS2",
+    "name": "COPS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPS4",
+    "name": "COPS4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPS5",
+    "name": "COPS5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPS6",
+    "name": "COPS6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPS7A",
+    "name": "COPS7A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COPS8",
+    "name": "COPS8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UBQLN4",
+    "name": "UBQLN4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TAT",
+    "name": "TAT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DCAF7",
+    "name": "DCAF7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EDN1_rna",
+    "name": "EDN1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SPART",
+    "name": "SPART",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SPARTcomp_complex",
+    "name": "SPARTcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AIFM1",
+    "name": "AIFM1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AIFMFlaComp_complex",
+    "name": "AIFMFlaComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Neutrophil_activation_phenotype",
+    "name": "Neutrophil_activation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp10_cell",
+    "name": "Nsp10_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP2A2comp_complex",
+    "name": "AP2A2comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GFERcomp_complex",
+    "name": "GFERcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP2M1comp_complex",
+    "name": "AP2M1comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp16",
+    "name": "Nsp16",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEMF",
+    "name": "NEMF",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp14_cell",
+    "name": "Nsp14_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIRT5comp_complex",
+    "name": "SIRT5comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PEG10comp_complex",
+    "name": "PEG10comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CA12",
+    "name": "CA12",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HCTcomp_complex",
+    "name": "HCTcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZonisamideComp_complex",
+    "name": "ZonisamideComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EAcomp_complex",
+    "name": "EAcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HFTcomp_complex",
+    "name": "HFTcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BZcomp_complex",
+    "name": "BZcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Hydrochlorothiazide_drug",
+    "name": "Hydrochlorothiazide_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FOCAD",
+    "name": "FOCAD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RNArecognition_complex",
+    "name": "RNArecognition_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ssRNAoligo_rna",
+    "name": "ssRNAoligo_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAT2B",
+    "name": "MAT2B",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEC1_complex",
+    "name": "NEC1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAT2A",
+    "name": "MAT2A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PTGS2",
+    "name": "PTGS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PTGScomp_complex",
+    "name": "PTGScomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Rofecoxib_drug",
+    "name": "Rofecoxib_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RofecoxibComp_complex",
+    "name": "RofecoxibComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RHOA",
+    "name": "RHOA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RGcomp_complex_cell",
+    "name": "RGcomp_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PCSK1",
+    "name": "PCSK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NECINsComp_complex",
+    "name": "NECINsComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NECENVComp_complex",
+    "name": "NECENVComp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Flavin_adenine_dinucleotide_drug",
+    "name": "Flavin_adenine_dinucleotide_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Sitaxentan_drug",
+    "name": "Sitaxentan_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ambrisentan_drug",
+    "name": "Ambrisentan_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Acetylsalicylic_acid_drug",
+    "name": "Acetylsalicylic_acid_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Macitentan_drug",
+    "name": "Macitentan_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SEPSECS",
+    "name": "SEPSECS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SPcomp_complex",
+    "name": "SPcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pyridoxal_phosphate_simple_molecule",
+    "name": "Pyridoxal_phosphate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MYCBP2",
+    "name": "MYCBP2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SBNO1",
+    "name": "SBNO1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BCKDK",
+    "name": "BCKDK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADPcomp_complex",
+    "name": "ADPcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP_simple_molecule",
+    "name": "ADP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RBM41",
+    "name": "RBM41",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZNF318",
+    "name": "ZNF318",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LARP4B_",
+    "name": "LARP4B_",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SRP54",
+    "name": "SRP54",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SRP19",
+    "name": "SRP19",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZC3H7A_",
+    "name": "ZC3H7A_",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Insulin",
+    "name": "Insulin",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Zonisamide_drug",
+    "name": "Zonisamide_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ellagic_Acid_drug",
+    "name": "Ellagic_Acid_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Hydroflumethiazide_drug",
+    "name": "Hydroflumethiazide_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Benzthiazide_drug",
+    "name": "Benzthiazide_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP2A2",
+    "name": "AP2A2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ELN",
+    "name": "ELN",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENV",
+    "name": "ENV",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CYB5R3",
+    "name": "CYB5R3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADHcomp_complex",
+    "name": "NADHcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FADcomp_complex",
+    "name": "FADcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NADH_simple_molecule",
+    "name": "NADH_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FAD_simple_molecule",
+    "name": "FAD_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FGCOMP_complex",
+    "name": "FGCOMP_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "COMT",
+    "name": "COMT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TCcomp_complex",
+    "name": "TCcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NCcomp_complex",
+    "name": "NCcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DCcomp_complex",
+    "name": "DCcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACcomp_complex",
+    "name": "ACcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNCcomp_complex",
+    "name": "DNCcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MCcomp_complex",
+    "name": "MCcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RALA",
+    "name": "RALA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GDPcomp_complex",
+    "name": "GDPcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GDP_simple_molecule",
+    "name": "GDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Tolcapone_drug",
+    "name": "Tolcapone_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Entacapone_drug",
+    "name": "Entacapone_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "3,5-Dinitrocatechol_drug",
+    "name": "3,5-Dinitrocatechol_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ademetionine_drug",
+    "name": "Ademetionine_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(3,4-DIHYDROXY-2-NITROPHENYL)(PHENYL)METHANONE_drug",
+    "name": "(3,4-DIHYDROXY-2-NITROPHENYL)(PHENYL)METHANONE_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "2-Methoxyestradiol_drug",
+    "name": "2-Methoxyestradiol_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RAB7A",
+    "name": "RAB7A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIRT5",
+    "name": "SIRT5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SScomp_complex",
+    "name": "SScomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Suramin_drug",
+    "name": "Suramin_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MPHOSPH10",
+    "name": "MPHOSPH10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACSL3",
+    "name": "ACSL3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IMPDH2",
+    "name": "IMPDH2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IMercomp_complex",
+    "name": "IMercomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRcomp_complex",
+    "name": "IRcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "INPDH2comp_complex",
+    "name": "INPDH2comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IMcomp_complex",
+    "name": "IMcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mercaptopurine_drug",
+    "name": "Mercaptopurine_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRPS5",
+    "name": "MRPS5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRPS2",
+    "name": "MRPS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ribavirin_drug",
+    "name": "Ribavirin_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LOXL1",
+    "name": "LOXL1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NOL10",
+    "name": "NOL10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SRP72",
+    "name": "SRP72",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NARS2",
+    "name": "NARS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NLcomp_complex",
+    "name": "NLcomp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Asparagine_simple_molecule",
+    "name": "L-Asparagine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AATF",
+    "name": "AATF",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp14_nucleus",
+    "name": "Nsp14_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZNF250comp_complex",
+    "name": "ZNF250comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDX10",
+    "name": "DDX10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TCF12",
+    "name": "TCF12",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp10_nucleus",
+    "name": "Nsp10_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERGIC1comp_complex",
+    "name": "ERGIC1comp_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ERGIC1",
+    "name": "ERGIC1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GFER",
+    "name": "GFER",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP2M1",
+    "name": "AP2M1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mycophenolic_acid_drug",
+    "name": "Mycophenolic_acid_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NGDN",
+    "name": "NGDN",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CCDC86",
+    "name": "CCDC86",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MEPCE",
+    "name": "MEPCE",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LARP7",
+    "name": "LARP7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZNF250",
+    "name": "ZNF250",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PEG10",
+    "name": "PEG10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Mycophenolate_mofetil_drug",
+    "name": "Mycophenolate_mofetil_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PLAT",
+    "name": "PLAT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nafamostat_drug",
+    "name": "Nafamostat_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Fibrillincomp_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "Nuclear_Pore_comp_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "mibcomp_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "pathogen_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "spartcomp_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "mat2bcomp_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "NspComp_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "homodimer_complex",
+    "target": "Nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "Fibrillincomp_complex",
+    "target": "Fibrillin_complex_human_host",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "Fibrillincomp_complex",
+    "target": "FBLN5",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "LOXcomp_complex",
+    "target": "FBLN5",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "Fibrillincomp_complex",
+    "target": "PLG",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "Fibrillin_complex_human_host",
+    "target": "PLG",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "LOXcomp_complex",
+    "target": "PLG",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "Nuclear_Pore_comp_complex",
+    "target": "Nuclear_Pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "MIBcomp_complex",
+    "target": "MIB1",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "mibcomp_complex",
+    "target": "MIB1",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "MIBcomp_complex",
+    "target": "DLL1",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "COPS_complex_nucleus",
+    "target": "Vpr",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "lipidcomp_complex",
+    "target": "SCARB1",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "SCARB1_complex",
+    "target": "SCARB1",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "lipidcomp_complex",
+    "target": "Phosphatidyl_serine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "SAdComp_complex",
+    "target": "MAT1A",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "MAT_complex",
+    "target": "MAT1A",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "SAdComp_complex",
+    "target": "S-Adenosylmethionine_drug",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "SAdComp2_complex",
+    "target": "S-Adenosylmethionine_drug",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "Nuclear_Pore_complex",
+    "target": "nup2_complex",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "Nuclear_Pore_complex",
+    "target": "nup1_complex",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "EXOCcomp_complex",
+    "target": "EXOSC2",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "EXOCcomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "Nsp7812_complex_cell",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "FOCADcomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "SRP54comp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "NspComp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "MPHOSPHcomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "MRPScomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "SEPSECScomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "NOL10comp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "AATFcomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "DDX10comp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "NGDNcomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "CCDCcomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "MEPCEcomp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "NARS2comp_complex",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "EXOCcomp_complex",
+    "target": "EXOSC3",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "EXOCcomp_complex",
+    "target": "EXOSC5",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "EXOCcomp_complex",
+    "target": "EXOSC8",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "gtf2f2comp_complex",
+    "target": "Nsp9_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "znfcomp_complex",
+    "target": "Nsp9_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "eifcomp_complex",
+    "target": "Nsp9_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "dcafcomp_complex",
+    "target": "Nsp9_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "nek9comp_complex",
+    "target": "Nsp9_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "gtf2f2comp_complex",
+    "target": "GTF2F2",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "gtfrnapoly_complex",
+    "target": "GTF2F2",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "TAT-HIV_complex",
+    "target": "GTF2F2",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "EDN1-homo_complex_cell",
+    "target": "EDN1-homo_complex_human_host",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "EDN1-homo_complex_cell",
+    "target": "EDNRA",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "EDNRASitaComp_complex",
+    "target": "EDNRA",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "EDNRAmbComp_complex",
+    "target": "EDNRA",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "EDNRAcetComp_complex",
+    "target": "EDNRA",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "EDNRMacComp_complex",
+    "target": "EDNRA",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "EDN1-homo_complex_human_host",
+    "target": "EDN1-homo_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "EDN1-homo_complex_endoplasmic_reticulum",
+    "target": "EDN1-homo_complex_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "znfcomp_complex",
+    "target": "ZNF503",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "dcafznf_complex",
+    "target": "ZNF503",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "Nsp7812_complex_cell",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "FOCADcomp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "RHOA7comp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "SCARB1_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "CA12comp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "CYB5R3comp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "COMT_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "RALAcomp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "RAB7comp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "ACSLcomp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "SRP72comp_complex",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "Nsp7812_complex_cell",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "MYCBPcomp_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "SBNOcomp_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "s389_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "RBMcomp_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "ZNFcomp_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "LARPcomp_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "ZC3H7Acomp_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "TCFcomp_complex",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "virus_replication_phenotype",
+    "target": "Nsp7812_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "Nsp7812_complex_cell",
+    "target": "RdRpassembled_rna",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "Nsp7812_complex_cell",
+    "target": "remdesivir__drug",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "Nsp7812_complex_cell",
+    "target": "favipiravir_drug",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "nup1_complex",
+    "target": "NUP54",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "nup1_complex",
+    "target": "NUP58",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "nup1_complex",
+    "target": "NUP62",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "nup2_complex",
+    "target": "NUP214",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "nup2_complex",
+    "target": "NUP88",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "EDN1-homo_complex_nucleus",
+    "target": "BAG6",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "NEKs_complex",
+    "target": "NEK9",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "nek9comp_complex",
+    "target": "NEK9",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "NEKs_complex",
+    "target": "NEK7",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "NEKs_complex",
+    "target": "NEK6",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "gtfrnapoly_complex",
+    "target": "GTF2B",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "gtfrnapoly_complex",
+    "target": "POLR2A",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "gtfrnapoly_complex",
+    "target": "POLR2B",
+    "sign": true
+   },
+   {
+    "id": "t108",
+    "source": "gtfrnapoly_complex",
+    "target": "POLR2E",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "gtfrnapoly_complex",
+    "target": "POLR2G",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "EDN1-homo_complex_nucleus",
+    "target": "EDN1",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "eifcomp_complex",
+    "target": "EIF4H",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "COPS_complex_nucleus",
+    "target": "COPS2",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "COPS_complex_nucleus",
+    "target": "COPS4",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "COPS_complex_nucleus",
+    "target": "COPS5",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "COPS_complex_nucleus",
+    "target": "COPS6",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "EDN1-homo_complex_nucleus",
+    "target": "COPS6",
+    "sign": true
+   },
+   {
+    "id": "t117",
+    "source": "COPS_complex_nucleus",
+    "target": "COPS7A",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "COPS_complex_nucleus",
+    "target": "COPS8",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "EDN1-homo_complex_nucleus",
+    "target": "UBQLN4",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "TAT-HIV_complex",
+    "target": "TAT",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "dcafcomp_complex",
+    "target": "DCAF7",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "dcafznf_complex",
+    "target": "DCAF7",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "EDN1_rna",
+    "target": "DCAF7",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "SPARTcomp_complex",
+    "target": "SPART",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "spartcomp_complex",
+    "target": "SPART",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "SPARTcomp_complex",
+    "target": "AIFM1",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "AIFMFlaComp_complex",
+    "target": "AIFM1",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "Neutrophil_activation_phenotype",
+    "target": "pathogen_complex",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "pathogen_complex",
+    "target": "Nsp10_cell",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "AP2A2comp_complex",
+    "target": "Nsp10_cell",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "GFERcomp_complex",
+    "target": "Nsp10_cell",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "AP2M1comp_complex",
+    "target": "Nsp10_cell",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "pathogen_complex",
+    "target": "Nsp16",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "pathogen_complex",
+    "target": "NEMF",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "pathogen_complex",
+    "target": "Nsp14_cell",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "SIRT5comp_complex",
+    "target": "Nsp14_cell",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "PEG10comp_complex",
+    "target": "Nsp14_cell",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "HCTcomp_complex",
+    "target": "CA12",
+    "sign": true
+   },
+   {
+    "id": "t139",
+    "source": "CA12comp_complex",
+    "target": "CA12",
+    "sign": true
+   },
+   {
+    "id": "t140",
+    "source": "ZonisamideComp_complex",
+    "target": "CA12",
+    "sign": true
+   },
+   {
+    "id": "t141",
+    "source": "EAcomp_complex",
+    "target": "CA12",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "HFTcomp_complex",
+    "target": "CA12",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "BZcomp_complex",
+    "target": "CA12",
+    "sign": true
+   },
+   {
+    "id": "t144",
+    "source": "HCTcomp_complex",
+    "target": "Hydrochlorothiazide_drug",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "FOCADcomp_complex",
+    "target": "FOCAD",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "RNArecognition_complex",
+    "target": "homodimer_complex",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "RNArecognition_complex",
+    "target": "ssRNAoligo_rna",
+    "sign": true
+   },
+   {
+    "id": "t148",
+    "source": "mat2bcomp_complex",
+    "target": "MAT2B",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "MAT_complex",
+    "target": "MAT2B",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "NEC1_complex",
+    "target": "MAT2B",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "SAdComp2_complex",
+    "target": "MAT2A",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "MAT_complex",
+    "target": "MAT2A",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "PTGScomp_complex",
+    "target": "PTGS2",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "PTGScomp_complex",
+    "target": "Rofecoxib_drug",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "RofecoxibComp_complex",
+    "target": "Rofecoxib_drug",
+    "sign": true
+   },
+   {
+    "id": "t156",
+    "source": "RHOA7comp_complex",
+    "target": "RHOA",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "RGcomp_complex_cell",
+    "target": "RHOA",
+    "sign": true
+   },
+   {
+    "id": "t158",
+    "source": "NEC1_complex",
+    "target": "PCSK1",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "NECINsComp_complex",
+    "target": "PCSK1",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "NECENVComp_complex",
+    "target": "PCSK1",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "AIFMFlaComp_complex",
+    "target": "Flavin_adenine_dinucleotide_drug",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "EDNRASitaComp_complex",
+    "target": "Sitaxentan_drug",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "EDNRAmbComp_complex",
+    "target": "Ambrisentan_drug",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "EDNRAcetComp_complex",
+    "target": "Acetylsalicylic_acid_drug",
+    "sign": true
+   },
+   {
+    "id": "t165",
+    "source": "EDNRMacComp_complex",
+    "target": "Macitentan_drug",
+    "sign": true
+   },
+   {
+    "id": "t166",
+    "source": "SPcomp_complex",
+    "target": "SEPSECS",
+    "sign": true
+   },
+   {
+    "id": "t167",
+    "source": "SEPSECScomp_complex",
+    "target": "SEPSECS",
+    "sign": true
+   },
+   {
+    "id": "t168",
+    "source": "SPcomp_complex",
+    "target": "Pyridoxal_phosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t169",
+    "source": "MYCBPcomp_complex",
+    "target": "MYCBP2",
+    "sign": true
+   },
+   {
+    "id": "t170",
+    "source": "SBNOcomp_complex",
+    "target": "SBNO1",
+    "sign": true
+   },
+   {
+    "id": "t171",
+    "source": "s389_complex",
+    "target": "BCKDK",
+    "sign": true
+   },
+   {
+    "id": "t172",
+    "source": "ADPcomp_complex",
+    "target": "BCKDK",
+    "sign": true
+   },
+   {
+    "id": "t173",
+    "source": "ADPcomp_complex",
+    "target": "ADP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t174",
+    "source": "RBMcomp_complex",
+    "target": "RBM41",
+    "sign": true
+   },
+   {
+    "id": "t175",
+    "source": "ZNFcomp_complex",
+    "target": "ZNF318",
+    "sign": true
+   },
+   {
+    "id": "t176",
+    "source": "LARPcomp_complex",
+    "target": "LARP4B_",
+    "sign": true
+   },
+   {
+    "id": "t177",
+    "source": "SRP54comp_complex",
+    "target": "SRP54",
+    "sign": true
+   },
+   {
+    "id": "t178",
+    "source": "SRP54comp_complex",
+    "target": "SRP19",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "ZC3H7Acomp_complex",
+    "target": "ZC3H7A_",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "NECINsComp_complex",
+    "target": "Insulin",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "ZonisamideComp_complex",
+    "target": "Zonisamide_drug",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "EAcomp_complex",
+    "target": "Ellagic_Acid_drug",
+    "sign": true
+   },
+   {
+    "id": "t183",
+    "source": "HFTcomp_complex",
+    "target": "Hydroflumethiazide_drug",
+    "sign": true
+   },
+   {
+    "id": "t184",
+    "source": "BZcomp_complex",
+    "target": "Benzthiazide_drug",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "AP2A2comp_complex",
+    "target": "AP2A2",
+    "sign": true
+   },
+   {
+    "id": "t186",
+    "source": "Fibrillin_complex_human_host",
+    "target": "ELN",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "RofecoxibComp_complex",
+    "target": "ELN",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "NECENVComp_complex",
+    "target": "ENV",
+    "sign": true
+   },
+   {
+    "id": "t189",
+    "source": "NADHcomp_complex",
+    "target": "CYB5R3",
+    "sign": true
+   },
+   {
+    "id": "t190",
+    "source": "CYB5R3comp_complex",
+    "target": "CYB5R3",
+    "sign": true
+   },
+   {
+    "id": "t191",
+    "source": "FADcomp_complex",
+    "target": "CYB5R3",
+    "sign": true
+   },
+   {
+    "id": "t192",
+    "source": "NADHcomp_complex",
+    "target": "NADH_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t193",
+    "source": "FADcomp_complex",
+    "target": "FAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t194",
+    "source": "FGCOMP_complex",
+    "target": "FAD_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t195",
+    "source": "COMT_complex",
+    "target": "COMT",
+    "sign": true
+   },
+   {
+    "id": "t196",
+    "source": "TCcomp_complex",
+    "target": "COMT",
+    "sign": true
+   },
+   {
+    "id": "t197",
+    "source": "NCcomp_complex",
+    "target": "COMT",
+    "sign": true
+   },
+   {
+    "id": "t198",
+    "source": "DCcomp_complex",
+    "target": "COMT",
+    "sign": true
+   },
+   {
+    "id": "t199",
+    "source": "ACcomp_complex",
+    "target": "COMT",
+    "sign": true
+   },
+   {
+    "id": "t200",
+    "source": "DNCcomp_complex",
+    "target": "COMT",
+    "sign": true
+   },
+   {
+    "id": "t201",
+    "source": "MCcomp_complex",
+    "target": "COMT",
+    "sign": true
+   },
+   {
+    "id": "t202",
+    "source": "GDPcomp_complex",
+    "target": "RALA",
+    "sign": true
+   },
+   {
+    "id": "t203",
+    "source": "RALAcomp_complex",
+    "target": "RALA",
+    "sign": true
+   },
+   {
+    "id": "t204",
+    "source": "GDPcomp_complex",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t205",
+    "source": "RGcomp_complex_cell",
+    "target": "GDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t206",
+    "source": "TCcomp_complex",
+    "target": "Tolcapone_drug",
+    "sign": true
+   },
+   {
+    "id": "t207",
+    "source": "NCcomp_complex",
+    "target": "Entacapone_drug",
+    "sign": true
+   },
+   {
+    "id": "t208",
+    "source": "DCcomp_complex",
+    "target": "3,5-Dinitrocatechol_drug",
+    "sign": true
+   },
+   {
+    "id": "t209",
+    "source": "ACcomp_complex",
+    "target": "Ademetionine_drug",
+    "sign": true
+   },
+   {
+    "id": "t210",
+    "source": "DNCcomp_complex",
+    "target": "(3,4-DIHYDROXY-2-NITROPHENYL)(PHENYL)METHANONE_drug",
+    "sign": true
+   },
+   {
+    "id": "t211",
+    "source": "MCcomp_complex",
+    "target": "2-Methoxyestradiol_drug",
+    "sign": true
+   },
+   {
+    "id": "t212",
+    "source": "RAB7comp_complex",
+    "target": "RAB7A",
+    "sign": true
+   },
+   {
+    "id": "t213",
+    "source": "RGcomp_complex_cell",
+    "target": "RAB7A",
+    "sign": true
+   },
+   {
+    "id": "t214",
+    "source": "SScomp_complex",
+    "target": "SIRT5",
+    "sign": true
+   },
+   {
+    "id": "t215",
+    "source": "SIRT5comp_complex",
+    "target": "SIRT5",
+    "sign": true
+   },
+   {
+    "id": "t216",
+    "source": "SScomp_complex",
+    "target": "Suramin_drug",
+    "sign": true
+   },
+   {
+    "id": "t217",
+    "source": "MPHOSPHcomp_complex",
+    "target": "MPHOSPH10",
+    "sign": true
+   },
+   {
+    "id": "t218",
+    "source": "ACSLcomp_complex",
+    "target": "ACSL3",
+    "sign": true
+   },
+   {
+    "id": "t219",
+    "source": "IMercomp_complex",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t220",
+    "source": "IRcomp_complex",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t221",
+    "source": "INPDH2comp_complex",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t222",
+    "source": "IMcomp_complex",
+    "target": "IMPDH2",
+    "sign": true
+   },
+   {
+    "id": "t223",
+    "source": "IMercomp_complex",
+    "target": "Mercaptopurine_drug",
+    "sign": true
+   },
+   {
+    "id": "t224",
+    "source": "MRPScomp_complex",
+    "target": "MRPS5",
+    "sign": true
+   },
+   {
+    "id": "t225",
+    "source": "MRPScomp_complex",
+    "target": "MRPS2",
+    "sign": true
+   },
+   {
+    "id": "t226",
+    "source": "IRcomp_complex",
+    "target": "Ribavirin_drug",
+    "sign": true
+   },
+   {
+    "id": "t227",
+    "source": "LOXcomp_complex",
+    "target": "LOXL1",
+    "sign": true
+   },
+   {
+    "id": "t228",
+    "source": "NOL10comp_complex",
+    "target": "NOL10",
+    "sign": true
+   },
+   {
+    "id": "t229",
+    "source": "SRP72comp_complex",
+    "target": "SRP72",
+    "sign": true
+   },
+   {
+    "id": "t230",
+    "source": "NLcomp_complex",
+    "target": "NARS2",
+    "sign": true
+   },
+   {
+    "id": "t231",
+    "source": "NARS2comp_complex",
+    "target": "NARS2",
+    "sign": true
+   },
+   {
+    "id": "t232",
+    "source": "NLcomp_complex",
+    "target": "L-Asparagine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t233",
+    "source": "AATFcomp_complex",
+    "target": "AATF",
+    "sign": true
+   },
+   {
+    "id": "t234",
+    "source": "INPDH2comp_complex",
+    "target": "Nsp14_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t235",
+    "source": "ZNF250comp_complex",
+    "target": "Nsp14_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t236",
+    "source": "DDX10comp_complex",
+    "target": "DDX10",
+    "sign": true
+   },
+   {
+    "id": "t237",
+    "source": "TCFcomp_complex",
+    "target": "TCF12",
+    "sign": true
+   },
+   {
+    "id": "t238",
+    "source": "ERGIC1comp_complex",
+    "target": "Nsp10_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t239",
+    "source": "ERGIC1comp_complex",
+    "target": "ERGIC1",
+    "sign": true
+   },
+   {
+    "id": "t240",
+    "source": "GFERcomp_complex",
+    "target": "GFER",
+    "sign": true
+   },
+   {
+    "id": "t241",
+    "source": "FGCOMP_complex",
+    "target": "GFER",
+    "sign": true
+   },
+   {
+    "id": "t242",
+    "source": "AP2M1comp_complex",
+    "target": "AP2M1",
+    "sign": true
+   },
+   {
+    "id": "t243",
+    "source": "IMcomp_complex",
+    "target": "Mycophenolic_acid_drug",
+    "sign": true
+   },
+   {
+    "id": "t244",
+    "source": "NGDNcomp_complex",
+    "target": "NGDN",
+    "sign": true
+   },
+   {
+    "id": "t245",
+    "source": "CCDCcomp_complex",
+    "target": "CCDC86",
+    "sign": true
+   },
+   {
+    "id": "t246",
+    "source": "MEPCEcomp_complex",
+    "target": "MEPCE",
+    "sign": true
+   },
+   {
+    "id": "t247",
+    "source": "MEPCEcomp_complex",
+    "target": "LARP7",
+    "sign": true
+   },
+   {
+    "id": "t248",
+    "source": "ZNF250comp_complex",
+    "target": "ZNF250",
+    "sign": true
+   },
+   {
+    "id": "t249",
+    "source": "PEG10comp_complex",
+    "target": "PEG10",
+    "sign": true
+   },
+   {
+    "id": "t250",
+    "source": "EDN1",
+    "target": "EDN1_rna",
+    "sign": true
+   },
+   {
+    "id": "t251",
+    "source": "Mycophenolic_acid_drug",
+    "target": "Mycophenolate_mofetil_drug",
+    "sign": true
+   },
+   {
+    "id": "t252",
+    "source": "PLG",
+    "target": "PLAT",
+    "sign": true
+   },
+   {
+    "id": "t253",
+    "source": "PLG",
+    "target": "Nafamostat_drug",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Orf10_Cul2_pathway.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Orf10_Cul2_pathway.json
@@ -1,0 +1,1116 @@
+{
+ "header": {
+  "name": "Orf10_Cul2_pathway",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Orf10_Cul2_pathway",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "Cul2_ubiquitin_ligase_complex",
+    "name": "Cul2_ubiquitin_ligase_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Zyg11B:EloBC_complex",
+    "name": "Zyg11B:EloBC_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "name": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "name": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Rbx1:Cul2_complex",
+    "name": "Rbx1:Cul2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UBE2M",
+    "name": "UBE2M",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ubit_traget",
+    "name": "ubit_traget",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "name": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf10",
+    "name": "Orf10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8_complex",
+    "name": "Cul2_ubiquitin_ligase:N8_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CSN5_complex",
+    "name": "CSN5_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ELOB:ELOC_complex",
+    "name": "ELOB:ELOC_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZYG11B",
+    "name": "ZYG11B",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RBX1",
+    "name": "RBX1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CUL2",
+    "name": "CUL2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ELOB",
+    "name": "ELOB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ELOC",
+    "name": "ELOC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:Orf10_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:Orf10_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAE:Pevonedistat_complex",
+    "name": "NAE:Pevonedistat_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAE_complex",
+    "name": "NAE_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pevonedistat_drug",
+    "name": "Pevonedistat_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAE:NEDD8_complex",
+    "name": "NAE:NEDD8_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAE1",
+    "name": "NAE1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UBA3",
+    "name": "UBA3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UBE2M:NEDD8_complex",
+    "name": "UBE2M:NEDD8_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEDD8",
+    "name": "NEDD8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:Orf10:E2-Ub:substrate_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:Orf10:E2-Ub:substrate_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:Orf10:E2:substrate-Ub_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:Orf10:E2:substrate-Ub_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E2_ubiquitinated",
+    "name": "E2_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:E2-Ub:substrate_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:E2-Ub:substrate_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:E2:substrate_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:E2:substrate_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E2",
+    "name": "E2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:E2:substrate-Ub_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:E2:substrate-Ub_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:substrate-Ub_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:substrate-Ub_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ubit_traget_ubiquitinated",
+    "name": "ubit_traget_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:Orf10:0E2:substrate_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:Orf10:0E2:substrate_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E1",
+    "name": "E1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Cul2_ubiquitin_ligase:N8:Orf10:substrate-Ub_complex",
+    "name": "Cul2_ubiquitin_ligase:N8:Orf10:substrate-Ub_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ELOB_rna",
+    "name": "ELOB_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ELOC_rna",
+    "name": "ELOC_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ZYG11B_rna",
+    "name": "ZYG11B_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RBX1_rna",
+    "name": "RBX1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CUL2_rna",
+    "name": "CUL2_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E1_rna",
+    "name": "E1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E2_rna",
+    "name": "E2_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DUB_rna",
+    "name": "DUB_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DUB",
+    "name": "DUB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E1_ubiquitinated",
+    "name": "E1_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AMP_simple_molecule",
+    "name": "AMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPi_simple_molecule",
+    "name": "PPi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ub_simple_molecule",
+    "name": "Ub_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule",
+    "name": "ATP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf10_(+)ss_sgmRNA_rna",
+    "name": "Orf10_(+)ss_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UBE2M_rna",
+    "name": "UBE2M_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEDD8_rna",
+    "name": "NEDD8_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NAE1_rna",
+    "name": "NAE1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UBA3_rna",
+    "name": "UBA3_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Zyg11B:EloBC_complex",
+    "target": "Cul2_ubiquitin_ligase_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "target": "Cul2_ubiquitin_ligase_complex",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "target": "Cul2_ubiquitin_ligase_complex",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "Rbx1:Cul2_complex",
+    "target": "Cul2_ubiquitin_ligase_complex",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "Cul2_ubiquitin_ligase_complex",
+    "target": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "UBE2M",
+    "target": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "ubit_traget",
+    "target": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "Cul2_ubiquitin_ligase_complex",
+    "target": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "Orf10",
+    "target": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "Cul2_ubiquitin_ligase_complex",
+    "target": "Cul2_ubiquitin_ligase:N8_complex",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "Cul2_ubiquitin_ligase_complex",
+    "target": "CSN5_complex",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "target": "CSN5_complex",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "Cul2_ubiquitin_ligase_complex",
+    "target": "Zyg11B:EloBC_complex",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "ELOB:ELOC_complex",
+    "target": "Zyg11B:EloBC_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "ZYG11B",
+    "target": "Zyg11B:EloBC_complex",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "Cul2_ubiquitin_ligase_complex",
+    "target": "Rbx1:Cul2_complex",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "RBX1",
+    "target": "Rbx1:Cul2_complex",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "CUL2",
+    "target": "Rbx1:Cul2_complex",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "Zyg11B:EloBC_complex",
+    "target": "ELOB:ELOC_complex",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "ELOB",
+    "target": "ELOB:ELOC_complex",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "ELOC",
+    "target": "ELOB:ELOC_complex",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "Zyg11B:EloBC_complex",
+    "target": "ZYG11B",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "target": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "UBE2M",
+    "target": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "ubit_traget",
+    "target": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10_complex",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "Cul2_ubiquitin_ligase:Orf10_complex",
+    "target": "Orf10",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "target": "ubit_traget",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "Cul2_ubiquitin_ligase:Orf10:substrate_complex",
+    "target": "ubit_traget",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "ELOB:ELOC_complex",
+    "target": "ELOB",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "ELOB:ELOC_complex",
+    "target": "ELOC",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "NAE_complex",
+    "target": "NAE:Pevonedistat_complex",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "Pevonedistat_drug",
+    "target": "NAE:Pevonedistat_complex",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "NAE:Pevonedistat_complex",
+    "target": "NAE_complex",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "NAE:NEDD8_complex",
+    "target": "NAE_complex",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "NAE1",
+    "target": "NAE_complex",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "UBA3",
+    "target": "NAE_complex",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "NAE:Pevonedistat_complex",
+    "target": "Pevonedistat_drug",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "UBE2M:NEDD8_complex",
+    "target": "NAE:NEDD8_complex",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "NAE:NEDD8_complex",
+    "target": "NEDD8",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "Rbx1:Cul2_complex",
+    "target": "RBX1",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "Rbx1:Cul2_complex",
+    "target": "CUL2",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:E2:substrate-Ub_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:E2-Ub:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:E2-Ub:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "E2_ubiquitinated",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:E2-Ub:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "Cul2_ubiquitin_ligase:N8:E2-Ub:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "Cul2_ubiquitin_ligase:N8:E2:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "target": "Cul2_ubiquitin_ligase:N8:E2:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "E2",
+    "target": "Cul2_ubiquitin_ligase:N8:E2:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "target": "Cul2_ubiquitin_ligase:N8:E2-Ub:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "Cul2_ubiquitin_ligase:N8:E2:substrate-Ub_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:E2-Ub:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "E2_ubiquitinated",
+    "target": "Cul2_ubiquitin_ligase:N8:E2-Ub:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "Cul2_ubiquitin_ligase:substrate_complex_cell",
+    "target": "UBE2M:NEDD8_complex",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "target": "UBE2M:NEDD8_complex",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "UBE2M",
+    "target": "UBE2M:NEDD8_complex",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "Cul2_ubiquitin_ligase:N8:substrate-Ub_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:E2:substrate-Ub_complex",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "E2",
+    "target": "Cul2_ubiquitin_ligase:N8:E2:substrate-Ub_complex",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "Cul2_ubiquitin_ligase:N8:E2-Ub:substrate_complex",
+    "target": "E2_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:E2-Ub:substrate_complex",
+    "target": "E2_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "Cul2_ubiquitin_ligase:N8_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:substrate-Ub_complex",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "ubit_traget_ubiquitinated",
+    "target": "Cul2_ubiquitin_ligase:N8:substrate-Ub_complex",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "Cul2_ubiquitin_ligase:N8:E2:substrate_complex",
+    "target": "E2",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:0E2:substrate_complex",
+    "target": "E2",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "E1",
+    "target": "E2",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "E2_ubiquitinated",
+    "target": "E2",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:substrate-Ub_complex",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "ubit_traget_ubiquitinated",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:substrate-Ub_complex",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:E2-Ub:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:0E2:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "Cul2_ubiquitin_ligase:N8:Orf10:substrate_complex",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:0E2:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "E2",
+    "target": "Cul2_ubiquitin_ligase:N8:Orf10:0E2:substrate_complex",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "UBE2M:NEDD8_complex",
+    "target": "UBE2M",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "NAE_complex",
+    "target": "NAE1",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "NAE_complex",
+    "target": "UBA3",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "ELOB",
+    "target": "ELOB_rna",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "ELOC",
+    "target": "ELOC_rna",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "ZYG11B",
+    "target": "ZYG11B_rna",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "RBX1",
+    "target": "RBX1_rna",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "CUL2",
+    "target": "CUL2_rna",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "E1",
+    "target": "E1_rna",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "E2",
+    "target": "E2_rna",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "DUB",
+    "target": "DUB_rna",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "E1_ubiquitinated",
+    "target": "E1",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "AMP_simple_molecule",
+    "target": "E1",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "PPi_simple_molecule",
+    "target": "E1",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "E1",
+    "target": "E1_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "E2_ubiquitinated",
+    "target": "E1_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "ubit_traget",
+    "target": "DUB",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "E1_ubiquitinated",
+    "target": "Ub_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "AMP_simple_molecule",
+    "target": "Ub_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "PPi_simple_molecule",
+    "target": "Ub_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "E1_ubiquitinated",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "AMP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "PPi_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "Orf10",
+    "target": "Orf10_(+)ss_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "UBE2M",
+    "target": "UBE2M_rna",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "ubit_traget",
+    "target": "ubit_traget_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "NEDD8",
+    "target": "NEDD8_rna",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "NAE1",
+    "target": "NAE1_rna",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "UBA3",
+    "target": "UBA3_rna",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Orf3a.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Orf3a.json
@@ -1,0 +1,662 @@
+{
+ "header": {
+  "name": "Orf3a",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Orf3a",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "Orf3a",
+    "name": "Orf3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Hops_Complex_complex",
+    "name": "Hops_Complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "P65/P015_complex",
+    "name": "P65/P015_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM59",
+    "name": "TRIM59",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "PYCARD_ubiquitinated_ubiquitinated_ubiquitinated",
+    "name": "PYCARD_ubiquitinated_ubiquitinated_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S",
+    "name": "S",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKBKG/IKBKB/CHUK_complex",
+    "name": "IKBKG/IKBKB/CHUK_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LPS/TNF_\u03b1/IL-1_complex",
+    "name": "LPS/TNF_\u03b1/IL-1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LPS/TLR4/MYD88_complex",
+    "name": "LPS/TLR4/MYD88_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF6",
+    "name": "TRAF6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "TLR4",
+    "name": "TLR4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF6",
+    "name": "IRF6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MYD88",
+    "name": "MYD88",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IL1b",
+    "name": "IL1b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "E",
+    "name": "E",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3",
+    "name": "TRAF3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "TAB2/TAB3/TAK1_complex",
+    "name": "TAB2/TAB3/TAK1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NEMO/IKKA/IKKB_complex",
+    "name": "NEMO/IKKA/IKKB_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SERPINF2",
+    "name": "SERPINF2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM30a/TRIM38_complex",
+    "name": "TRIM30a/TRIM38_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR7/8/9_complex",
+    "name": "TLR7/8/9_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ssRNA_rna",
+    "name": "ssRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKBIA_phosphorylated_ubiquitinated_ubiquitinated_ubiquitinated",
+    "name": "NFKBIA_phosphorylated_ubiquitinated_ubiquitinated_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM22",
+    "name": "TRIM22",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM29",
+    "name": "TRIM29",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM14/TRIM23_complex",
+    "name": "TRIM14/TRIM23_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM27/TRIM21_complex",
+    "name": "TRIM27/TRIM21_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKB1",
+    "name": "NFKB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKB1:NFKNIA_complex",
+    "name": "NFKB1:NFKNIA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CACTIN",
+    "name": "CACTIN",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "NLRP3",
+    "name": "NLRP3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP1",
+    "name": "CASP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "ORF8b",
+    "name": "ORF8b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TICAM1",
+    "name": "TICAM1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "TRIM23",
+    "name": "TRIM23",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM38",
+    "name": "TRIM38",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR3",
+    "name": "TLR3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BTRC",
+    "name": "BTRC",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "TRIM9",
+    "name": "TRIM9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM39",
+    "name": "TRIM39",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IFNB1",
+    "name": "IFNB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "double-stranded_RNA_rna",
+    "name": "double-stranded_RNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Hops_Complex_complex",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "P65/P015_complex",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "TRIM59",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "PYCARD_ubiquitinated_ubiquitinated_ubiquitinated",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "S",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "P65/P015_complex",
+    "target": "IKBKG/IKBKB/CHUK_complex",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "IKBKG/IKBKB/CHUK_complex",
+    "target": "LPS/TNF_\u03b1/IL-1_complex",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "TRAF6",
+    "target": "LPS/TLR4/MYD88_complex",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "LPS/TLR4/MYD88_complex",
+    "target": "TLR4",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "LPS/TLR4/MYD88_complex",
+    "target": "IRF6",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "LPS/TLR4/MYD88_complex",
+    "target": "MYD88",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "TRAF6",
+    "target": "MYD88",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "IL1b",
+    "target": "P65/P015_complex",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "P65/P015_complex",
+    "target": "E",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "IL1b",
+    "target": "E",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "P65/P015_complex",
+    "target": "TRAF3",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "PYCARD_ubiquitinated_ubiquitinated_ubiquitinated",
+    "target": "TRAF3",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "NEMO/IKKA/IKKB_complex",
+    "target": "TAB2/TAB3/TAK1_complex",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "SERPINF2",
+    "target": "TAB2/TAB3/TAK1_complex",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "TAB2/TAB3/TAK1_complex",
+    "target": "TRIM30a/TRIM38_complex",
+    "sign": false
+   },
+   {
+    "id": "t23",
+    "source": "TAB2/TAB3/TAK1_complex",
+    "target": "TRAF6",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "MYD88",
+    "target": "TLR7/8/9_complex",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "TLR7/8/9_complex",
+    "target": "ssRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "NFKBIA_phosphorylated_ubiquitinated_ubiquitinated_ubiquitinated",
+    "target": "NEMO/IKKA/IKKB_complex",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "NEMO/IKKA/IKKB_complex",
+    "target": "TRIM22",
+    "sign": false
+   },
+   {
+    "id": "t29",
+    "source": "NEMO/IKKA/IKKB_complex",
+    "target": "TRIM29",
+    "sign": false
+   },
+   {
+    "id": "t30",
+    "source": "NEMO/IKKA/IKKB_complex",
+    "target": "TRIM14/TRIM23_complex",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "NEMO/IKKA/IKKB_complex",
+    "target": "TRIM27/TRIM21_complex",
+    "sign": false
+   },
+   {
+    "id": "t32",
+    "source": "NFKB1:NFKNIA_complex",
+    "target": "NFKB1",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "NFKB1:NFKNIA_complex",
+    "target": "NFKBIA_phosphorylated_ubiquitinated_ubiquitinated_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "NFKB1:NFKNIA_complex",
+    "target": "CACTIN",
+    "sign": false
+   },
+   {
+    "id": "t37",
+    "source": "MYD88",
+    "target": "TRIM59",
+    "sign": false
+   },
+   {
+    "id": "t38",
+    "source": "CASP1",
+    "target": "NLRP3",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "NLRP3",
+    "target": "ORF8b",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "CASP1",
+    "target": "PYCARD_ubiquitinated_ubiquitinated_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "TRAF3",
+    "target": "TICAM1",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "IL1b",
+    "target": "CASP1",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "TRAF6",
+    "target": "TRIM23",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "TRAF6",
+    "target": "TRIM38",
+    "sign": false
+   },
+   {
+    "id": "t47",
+    "source": "TICAM1",
+    "target": "TRIM38",
+    "sign": false
+   },
+   {
+    "id": "t48",
+    "source": "TICAM1",
+    "target": "TLR3",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "NFKBIA_phosphorylated_ubiquitinated_ubiquitinated_ubiquitinated",
+    "target": "BTRC",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "BTRC",
+    "target": "TRIM9",
+    "sign": false
+   },
+   {
+    "id": "t53",
+    "source": "CACTIN",
+    "target": "TRIM39",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "IFNB1",
+    "target": "SERPINF2",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "TLR3",
+    "target": "double-stranded_RNA_rna",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/PAMP_signaling.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/PAMP_signaling.json
@@ -1,0 +1,1201 @@
+{
+ "header": {
+  "name": "PAMP_signaling",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on PAMP_signaling",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "MYD88:IRAK:TRAF_complex",
+    "name": "MYD88:IRAK:TRAF_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF7_phosphorylated",
+    "name": "IRF7_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF6_ubiquitinated",
+    "name": "TRAF6_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MYD88",
+    "name": "MYD88",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRAK1",
+    "name": "IRAK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRAK4",
+    "name": "IRAK4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF6",
+    "name": "TRAF6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAVS:TRAF_complex",
+    "name": "MAVS:TRAF_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TICAM1:TRAF3:TRAF6_complex",
+    "name": "TICAM1:TRAF3:TRAF6_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF2",
+    "name": "TRAF2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF5",
+    "name": "TRAF5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAVS",
+    "name": "MAVS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAVS:TRADD_complex",
+    "name": "MAVS:TRADD_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TANK:TRAF3:IKBKE_complex_cell",
+    "name": "TANK:TRAF3:IKBKE_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "RIPK1:FADD_complex",
+    "name": "RIPK1:FADD_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRADD",
+    "name": "TRADD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP3K7",
+    "name": "MAP3K7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TICAM1_cell",
+    "name": "TICAM1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IKK_Complex_complex_cell",
+    "name": "IKK_Complex_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IKBKG",
+    "name": "IKBKG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CHUK",
+    "name": "CHUK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKBKB",
+    "name": "IKBKB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKB:NFKBIA_complex_cell",
+    "name": "NFKB:NFKBIA_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "NFKBIA",
+    "name": "NFKBIA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RELA",
+    "name": "RELA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKB1",
+    "name": "NFKB1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TBK1_cell",
+    "name": "TBK1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp3",
+    "name": "Nsp3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDX58:dsRNA_complex",
+    "name": "DDX58:dsRNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFIH1:dsRNA_complex",
+    "name": "IFIH1:dsRNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IKBKE_cell",
+    "name": "IKBKE_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IRF3_phosphorylated_cell",
+    "name": "IRF3_phosphorylated_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M",
+    "name": "M",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP10",
+    "name": "CASP10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CASP8",
+    "name": "CASP8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR3:dsRNA_complex",
+    "name": "TLR3:dsRNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dsRNA_rna_endosome",
+    "name": "dsRNA_rna_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRAF3",
+    "name": "TRAF3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TANK",
+    "name": "TANK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR7:ssRNA_complex",
+    "name": "TLR7:ssRNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR7",
+    "name": "TLR7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ssRNA_rna",
+    "name": "ssRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR8:ssRNA_complex",
+    "name": "TLR8:ssRNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TLR8",
+    "name": "TLR8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDX58_ubiquitinated",
+    "name": "DDX58_ubiquitinated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dsRNA_rna_cell",
+    "name": "dsRNA_rna_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK2:dsRNA_complex",
+    "name": "EIF2AK2:dsRNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DDX58",
+    "name": "DDX58",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFIH1",
+    "name": "IFIH1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp15",
+    "name": "Nsp15",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "JNK_complex",
+    "name": "JNK_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AP1_complex",
+    "name": "AP1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP2K7_phosphorylated",
+    "name": "MAP2K7_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP2K4_phosphorylated",
+    "name": "MAP2K4_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKB_complex",
+    "name": "NFKB_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "transcription_of_proinflammatory_proteins_phenotype",
+    "name": "transcription_of_proinflammatory_proteins_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NFKBIA_phosphorylated",
+    "name": "NFKBIA_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N",
+    "name": "N",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP2K6_phosphorylated",
+    "name": "MAP2K6_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "EIF2AK2",
+    "name": "EIF2AK2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK14_phosphorylated",
+    "name": "MAPK14_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF3_phosphorylated_nucleus",
+    "name": "IRF3_phosphorylated_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF3",
+    "name": "IRF3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3b",
+    "name": "Orf3b",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8",
+    "name": "Orf8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RNF135",
+    "name": "RNF135",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TRIM25",
+    "name": "TRIM25",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UBE2N",
+    "name": "UBE2N",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAP2K3_phosphorylated",
+    "name": "MAP2K3_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9",
+    "name": "Orf9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ITCH",
+    "name": "ITCH",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "IRF7_phosphorylated",
+    "target": "MYD88:IRAK:TRAF_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "TRAF6_ubiquitinated",
+    "target": "MYD88:IRAK:TRAF_complex",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "MYD88:IRAK:TRAF_complex",
+    "target": "MYD88",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "MYD88:IRAK:TRAF_complex",
+    "target": "IRAK1",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "MYD88:IRAK:TRAF_complex",
+    "target": "IRAK4",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "MYD88:IRAK:TRAF_complex",
+    "target": "TRAF6",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "MAVS:TRAF_complex",
+    "target": "TRAF6",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "TICAM1:TRAF3:TRAF6_complex",
+    "target": "TRAF6",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "TRAF6_ubiquitinated",
+    "target": "TRAF6",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "TRAF6_ubiquitinated",
+    "target": "MAVS:TRAF_complex",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "MAVS:TRAF_complex",
+    "target": "TRAF2",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "MAVS:TRAF_complex",
+    "target": "TRAF5",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "MAVS:TRAF_complex",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "MAVS:TRADD_complex",
+    "target": "MAVS",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "TANK:TRAF3:IKBKE_complex_cell",
+    "target": "MAVS:TRADD_complex",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "RIPK1:FADD_complex",
+    "target": "MAVS:TRADD_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "MAVS:TRADD_complex",
+    "target": "TRADD",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "TANK:TRAF3:IKBKE_complex_cell",
+    "target": "TICAM1:TRAF3:TRAF6_complex",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "MAP3K7",
+    "target": "TICAM1:TRAF3:TRAF6_complex",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "TICAM1:TRAF3:TRAF6_complex",
+    "target": "TICAM1_cell",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "IKK_Complex_complex_cell",
+    "target": "IKBKG",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "IKK_Complex_complex_cell",
+    "target": "CHUK",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "IKK_Complex_complex_cell",
+    "target": "IKBKB",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "NFKB:NFKBIA_complex_cell",
+    "target": "NFKBIA",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "NFKB:NFKBIA_complex_cell",
+    "target": "RELA",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "NFKB:NFKBIA_complex_cell",
+    "target": "NFKB1",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "TBK1_cell",
+    "target": "TANK:TRAF3:IKBKE_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "TANK:TRAF3:IKBKE_complex_cell",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t32",
+    "source": "DDX58:dsRNA_complex",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t33",
+    "source": "IFIH1:dsRNA_complex",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t34",
+    "source": "IKBKE_cell",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t35",
+    "source": "IRF3_phosphorylated_cell",
+    "target": "Nsp3",
+    "sign": false
+   },
+   {
+    "id": "t36",
+    "source": "TRAF6",
+    "target": "Nsp3",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "TANK:TRAF3:IKBKE_complex_cell",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t38",
+    "source": "DDX58:dsRNA_complex",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t39",
+    "source": "IFIH1:dsRNA_complex",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t40",
+    "source": "IKK_Complex_complex_cell",
+    "target": "M",
+    "sign": false
+   },
+   {
+    "id": "t41",
+    "source": "IKBKE_cell",
+    "target": "TANK:TRAF3:IKBKE_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "CASP10",
+    "target": "RIPK1:FADD_complex",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "CASP8",
+    "target": "RIPK1:FADD_complex",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "TICAM1_cell",
+    "target": "TLR3:dsRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "TLR3:dsRNA_complex",
+    "target": "dsRNA_rna_endosome",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "TANK:TRAF3:IKBKE_complex_cell",
+    "target": "TRAF3",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "TANK:TRAF3:IKBKE_complex_cell",
+    "target": "TANK",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "TANK:TRAF3:IKBKE_complex_cell",
+    "target": "IKBKE_cell",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "MYD88",
+    "target": "TLR7:ssRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "TLR7:ssRNA_complex",
+    "target": "TLR7",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "TLR7:ssRNA_complex",
+    "target": "ssRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "TLR8:ssRNA_complex",
+    "target": "ssRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "MYD88",
+    "target": "TLR8:ssRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "TLR8:ssRNA_complex",
+    "target": "TLR8",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "DDX58_ubiquitinated",
+    "target": "DDX58:dsRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "DDX58:dsRNA_complex",
+    "target": "dsRNA_rna_cell",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "IFIH1:dsRNA_complex",
+    "target": "dsRNA_rna_cell",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "EIF2AK2:dsRNA_complex",
+    "target": "dsRNA_rna_cell",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "DDX58:dsRNA_complex",
+    "target": "DDX58",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "MAVS",
+    "target": "IFIH1:dsRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "IFIH1:dsRNA_complex",
+    "target": "IFIH1",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "IFIH1:dsRNA_complex",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t65",
+    "source": "EIF2AK2:dsRNA_complex",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t66",
+    "source": "AP1_complex",
+    "target": "JNK_complex",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "JNK_complex",
+    "target": "MAP2K7_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "JNK_complex",
+    "target": "MAP2K4_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "transcription_of_proinflammatory_proteins_phenotype",
+    "target": "NFKB_complex",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "NFKB_complex",
+    "target": "NFKB:NFKBIA_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "NFKBIA_phosphorylated",
+    "target": "NFKB:NFKBIA_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "NFKB_complex",
+    "target": "N",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "DDX58_ubiquitinated",
+    "target": "N",
+    "sign": false
+   },
+   {
+    "id": "t74",
+    "source": "NFKBIA_phosphorylated",
+    "target": "N",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "MAP2K6_phosphorylated",
+    "target": "EIF2AK2:dsRNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "EIF2AK2:dsRNA_complex",
+    "target": "EIF2AK2",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "NFKB:NFKBIA_complex_cell",
+    "target": "IKK_Complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "IKK_Complex_complex_cell",
+    "target": "TRAF6_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "TRAF6",
+    "target": "TRAF6_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "MAP3K7",
+    "target": "TRAF6_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "IKK_Complex_complex_cell",
+    "target": "CASP8",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "IKK_Complex_complex_cell",
+    "target": "CASP10",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "transcription_of_proinflammatory_proteins_phenotype",
+    "target": "AP1_complex",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "AP1_complex",
+    "target": "MAPK14_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "IRF3_phosphorylated_cell",
+    "target": "TBK1_cell",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "IRF7_phosphorylated",
+    "target": "IKBKE_cell",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "IRF3_phosphorylated_nucleus",
+    "target": "IRF3_phosphorylated_cell",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "IRF3_phosphorylated_cell",
+    "target": "IRF3",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "IRF3_phosphorylated_cell",
+    "target": "Orf3b",
+    "sign": false
+   },
+   {
+    "id": "t91",
+    "source": "IRF3_phosphorylated_cell",
+    "target": "Orf8",
+    "sign": false
+   },
+   {
+    "id": "t92",
+    "source": "MAVS",
+    "target": "DDX58_ubiquitinated",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "DDX58_ubiquitinated",
+    "target": "RNF135",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "DDX58_ubiquitinated",
+    "target": "TRIM25",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "transcription_of_proinflammatory_proteins_phenotype",
+    "target": "IRF3_phosphorylated_nucleus",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "transcription_of_proinflammatory_proteins_phenotype",
+    "target": "IRF7_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "TRAF6_ubiquitinated",
+    "target": "UBE2N",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "MAP2K6_phosphorylated",
+    "target": "MAP3K7",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "MAP2K3_phosphorylated",
+    "target": "MAP3K7",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "MAP2K4_phosphorylated",
+    "target": "MAP3K7",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "MAP2K7_phosphorylated",
+    "target": "MAP3K7",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "MAPK14_phosphorylated",
+    "target": "MAP2K6_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "MAPK14_phosphorylated",
+    "target": "MAP2K3_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "ITCH",
+    "target": "Orf9",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Pyrimidine_deprivation.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Pyrimidine_deprivation.json
@@ -1,0 +1,1601 @@
+{
+ "header": {
+  "name": "Pyrimidine_deprivation",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Pyrimidine_deprivation",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "IFNB1_space_expression_space_complex_complex",
+    "name": "IFNB1_space_expression_space_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNA1_rna",
+    "name": "IFNA1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNB1_rna",
+    "name": "IFNB1_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NF-kB_complex",
+    "name": "NF-kB_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IRF3_phosphorylated",
+    "name": "IRF3_phosphorylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAMP:STING_complex_Golgi_apparatus",
+    "name": "cGAMP:STING_complex_Golgi_apparatus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STING:TBK1_complex_Golgi_apparatus",
+    "name": "STING:TBK1_complex_Golgi_apparatus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAMP:STING_complex_endoplasmic_reticulum",
+    "name": "cGAMP:STING_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAMP-STING_complex_COPII-coated_vesicle",
+    "name": "cGAMP-STING_complex_COPII-coated_vesicle",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAMP_simple_molecule",
+    "name": "cGAMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STING_endoplasmic_reticulum",
+    "name": "STING_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STING_Golgi_apparatus",
+    "name": "STING_Golgi_apparatus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAMP-STING_complex_endoplasmic_reticulum-Golgi_intermediate_compartment",
+    "name": "cGAMP-STING_complex_endoplasmic_reticulum-Golgi_intermediate_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAMP:STING:LC3_complex",
+    "name": "cGAMP:STING:LC3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HCoVs_autophagy_(WP4863)_phenotype",
+    "name": "HCoVs_autophagy_(WP4863)_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LC3",
+    "name": "LC3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "WIPI2",
+    "name": "WIPI2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAS:dsDNA_complex",
+    "name": "cGAS:dsDNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dsDNA_simple_molecule",
+    "name": "dsDNA_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRE11:dsDNA_complex",
+    "name": "MRE11:dsDNA_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNA_gene",
+    "name": "DNA_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cGAS",
+    "name": "cGAS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRE11:RAD50:DNA_complex_pulmonary_endothelial_cell",
+    "name": "MRE11:RAD50:DNA_complex_pulmonary_endothelial_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRE11",
+    "name": "MRE11",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "STING:TBK1_complex_endolysosome",
+    "name": "STING:TBK1_complex_endolysosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TBK1",
+    "name": "TBK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SAR1A",
+    "name": "SAR1A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRE11:RAD50:DNA_complex_endoplasmic_reticulum",
+    "name": "MRE11:RAD50:DNA_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RAD50",
+    "name": "RAD50",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cytidine_simple_molecule",
+    "name": "cytidine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CMP_simple_molecule",
+    "name": "CMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "uridine_simple_molecule",
+    "name": "uridine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H2O_simple_molecule",
+    "name": "H2O_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Pi_simple_molecule",
+    "name": "Pi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADP_simple_molecule",
+    "name": "ADP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Glu_simple_molecule",
+    "name": "L-Glu_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CAP_simple_molecule",
+    "name": "CAP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N-carbamoyl-L-aspartate_simple_molecule",
+    "name": "N-carbamoyl-L-aspartate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(S)-dihydroorotate_simple_molecule",
+    "name": "(S)-dihydroorotate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+simple_molecule",
+    "name": "H+simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CAD",
+    "name": "CAD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UMP_simple_molecule",
+    "name": "UMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UDP_simple_molecule",
+    "name": "UDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UCK2",
+    "name": "UCK2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "orotidine_space_5'-monophosphate_simple_molecule",
+    "name": "orotidine_space_5'-monophosphate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CO2_simple_molecule",
+    "name": "CO2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UMPS",
+    "name": "UMPS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PPi_simple_molecule",
+    "name": "PPi_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP_simple_molecule",
+    "name": "ATP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "GTP_simple_molecule",
+    "name": "GTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RTC_and_transcription_pw_phenotype",
+    "name": "RTC_and_transcription_pw_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RNA_space_biosynthesis_phenotype",
+    "name": "RNA_space_biosynthesis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dCDP_simple_molecule",
+    "name": "dCDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dCTP_simple_molecule",
+    "name": "dCTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CDP_simple_molecule",
+    "name": "CDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTP_simple_molecule",
+    "name": "CTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ribonucleoside-diphosphate_reductase_complex",
+    "name": "ribonucleoside-diphosphate_reductase_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dUDP_simple_molecule",
+    "name": "dUDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "UTP_simple_molecule",
+    "name": "UTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CMPK",
+    "name": "CMPK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dTMP_simple_molecule",
+    "name": "dTMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dTDP_simple_molecule",
+    "name": "dTDP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dUMP_simple_molecule",
+    "name": "dUMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TYMS",
+    "name": "TYMS",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNA1_pulmonary_endothelial_cell",
+    "name": "IFNA1_pulmonary_endothelial_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNA1_human_host",
+    "name": "IFNA1_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Gln_simple_molecule",
+    "name": "L-Gln_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HCO3-simple_molecule",
+    "name": "HCO3-simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "L-Asp_simple_molecule",
+    "name": "L-Asp_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "QH2_simple_molecule",
+    "name": "QH2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "orotate_simple_molecule",
+    "name": "orotate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dUTP_simple_molecule",
+    "name": "dUTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DUT",
+    "name": "DUT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dCMP_simple_molecule",
+    "name": "dCMP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DCTD",
+    "name": "DCTD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNB1_human_host",
+    "name": "IFNB1_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HCoVs_Type_I_Ifn_signalling(WP4868)_phenotype",
+    "name": "HCoVs_Type_I_Ifn_signalling(WP4868)_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Interferon_1_pathway_phenotype",
+    "name": "Interferon_1_pathway_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "HCoVs_IFN_induction_WP4880_phenotype",
+    "name": "HCoVs_IFN_induction_WP4880_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "IFNB1_pulmonary_endothelial_cell",
+    "name": "IFNB1_pulmonary_endothelial_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dTTP_simple_molecule",
+    "name": "dTTP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNA_space_biosynthesis_phenotype",
+    "name": "DNA_space_biosynthesis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "virus_space_replication_phenotype",
+    "name": "virus_space_replication_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dTYMK",
+    "name": "dTYMK",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DNA_damage_phenotype",
+    "name": "DNA_damage_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NME1",
+    "name": "NME1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRPP_simple_molecule",
+    "name": "PRPP_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CDA",
+    "name": "CDA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DCTPP1",
+    "name": "DCTPP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CoQ_simple_molecule",
+    "name": "CoQ_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "dihydroorotate_space_dehydrogenase_space_holoenzyme_simple_molecule",
+    "name": "dihydroorotate_space_dehydrogenase_space_holoenzyme_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "P1788_simple_molecule",
+    "name": "P1788_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Teriflunomide_drug",
+    "name": "Teriflunomide_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTPS1",
+    "name": "CTPS1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "IFNA1_rna",
+    "target": "IFNB1_space_expression_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "IFNB1_rna",
+    "target": "IFNB1_space_expression_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "IFNB1_space_expression_space_complex_complex",
+    "target": "NF-kB_complex",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "IFNB1_space_expression_space_complex_complex",
+    "target": "IRF3_phosphorylated",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "STING:TBK1_complex_Golgi_apparatus",
+    "target": "cGAMP:STING_complex_Golgi_apparatus",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "cGAMP:STING_complex_Golgi_apparatus",
+    "target": "cGAMP:STING_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "cGAMP-STING_complex_COPII-coated_vesicle",
+    "target": "cGAMP:STING_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "cGAMP:STING_complex_endoplasmic_reticulum",
+    "target": "cGAMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "cGAMP:STING_complex_endoplasmic_reticulum",
+    "target": "STING_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "STING_Golgi_apparatus",
+    "target": "STING_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "cGAMP:STING:LC3_complex",
+    "target": "cGAMP-STING_complex_endoplasmic_reticulum-Golgi_intermediate_compartment",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "cGAMP-STING_complex_endoplasmic_reticulum-Golgi_intermediate_compartment",
+    "target": "cGAMP-STING_complex_COPII-coated_vesicle",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "HCoVs_autophagy_(WP4863)_phenotype",
+    "target": "cGAMP:STING:LC3_complex",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "cGAMP:STING:LC3_complex",
+    "target": "LC3",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "cGAMP:STING:LC3_complex",
+    "target": "WIPI2",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "cGAMP_simple_molecule",
+    "target": "cGAS:dsDNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "cGAS:dsDNA_complex",
+    "target": "dsDNA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "MRE11:dsDNA_complex",
+    "target": "dsDNA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "DNA_gene",
+    "target": "dsDNA_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "cGAS:dsDNA_complex",
+    "target": "cGAS",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "MRE11:RAD50:DNA_complex_pulmonary_endothelial_cell",
+    "target": "MRE11:dsDNA_complex",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "MRE11:dsDNA_complex",
+    "target": "MRE11",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "STING:TBK1_complex_endolysosome",
+    "target": "STING:TBK1_complex_Golgi_apparatus",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "STING:TBK1_complex_Golgi_apparatus",
+    "target": "TBK1",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "STING:TBK1_complex_Golgi_apparatus",
+    "target": "STING_Golgi_apparatus",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "cGAMP-STING_complex_COPII-coated_vesicle",
+    "target": "SAR1A",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "IRF3_phosphorylated",
+    "target": "STING:TBK1_complex_endolysosome",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "STING_Golgi_apparatus",
+    "target": "MRE11:RAD50:DNA_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "MRE11:RAD50:DNA_complex_endoplasmic_reticulum",
+    "target": "MRE11:RAD50:DNA_complex_pulmonary_endothelial_cell",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "MRE11:RAD50:DNA_complex_pulmonary_endothelial_cell",
+    "target": "RAD50",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "CMP_simple_molecule",
+    "target": "cytidine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "uridine_simple_molecule",
+    "target": "cytidine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "Pi_simple_molecule",
+    "target": "H2O_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "ADP_simple_molecule",
+    "target": "H2O_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "L-Glu_simple_molecule",
+    "target": "H2O_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "CAP_simple_molecule",
+    "target": "H2O_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "H2O_simple_molecule",
+    "target": "N-carbamoyl-L-aspartate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "(S)-dihydroorotate_simple_molecule",
+    "target": "N-carbamoyl-L-aspartate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "H2O_simple_molecule",
+    "target": "H+simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "(S)-dihydroorotate_simple_molecule",
+    "target": "H+simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "H2O_simple_molecule",
+    "target": "CAD",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "Pi_simple_molecule",
+    "target": "CAD",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "(S)-dihydroorotate_simple_molecule",
+    "target": "CAD",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "ADP_simple_molecule",
+    "target": "CAD",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "N-carbamoyl-L-aspartate_simple_molecule",
+    "target": "CAD",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "L-Glu_simple_molecule",
+    "target": "CAD",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "CAP_simple_molecule",
+    "target": "CAD",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "UDP_simple_molecule",
+    "target": "UMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "UMP_simple_molecule",
+    "target": "uridine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "UMP_simple_molecule",
+    "target": "UCK2",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "CMP_simple_molecule",
+    "target": "UCK2",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "UMP_simple_molecule",
+    "target": "orotidine_space_5'-monophosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "CO2_simple_molecule",
+    "target": "orotidine_space_5'-monophosphate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "UMP_simple_molecule",
+    "target": "UMPS",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "PPi_simple_molecule",
+    "target": "UMPS",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "orotidine_space_5'-monophosphate_simple_molecule",
+    "target": "UMPS",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "CO2_simple_molecule",
+    "target": "UMPS",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "cGAMP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "Pi_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "ADP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "L-Glu_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "CAP_simple_molecule",
+    "target": "ATP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "cGAMP_simple_molecule",
+    "target": "GTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "RNA_space_biosynthesis_phenotype",
+    "target": "RTC_and_transcription_pw_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "dCTP_simple_molecule",
+    "target": "dCDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "dCDP_simple_molecule",
+    "target": "CDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "CTP_simple_molecule",
+    "target": "CDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "dCDP_simple_molecule",
+    "target": "ribonucleoside-diphosphate_reductase_complex",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "dUDP_simple_molecule",
+    "target": "ribonucleoside-diphosphate_reductase_complex",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "UTP_simple_molecule",
+    "target": "UDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "dUDP_simple_molecule",
+    "target": "UDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "UDP_simple_molecule",
+    "target": "CMPK",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "CDP_simple_molecule",
+    "target": "CMPK",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "dTDP_simple_molecule",
+    "target": "dTMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "dTMP_simple_molecule",
+    "target": "dUMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "dTMP_simple_molecule",
+    "target": "TYMS",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "IFNA1_human_host",
+    "target": "IFNA1_pulmonary_endothelial_cell",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "IFNA1_pulmonary_endothelial_cell",
+    "target": "IFNA1_rna",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "Pi_simple_molecule",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "ADP_simple_molecule",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "L-Glu_simple_molecule",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "CAP_simple_molecule",
+    "target": "L-Gln_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "Pi_simple_molecule",
+    "target": "HCO3-simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "ADP_simple_molecule",
+    "target": "HCO3-simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "L-Glu_simple_molecule",
+    "target": "HCO3-simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "CAP_simple_molecule",
+    "target": "HCO3-simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "Pi_simple_molecule",
+    "target": "CAP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "N-carbamoyl-L-aspartate_simple_molecule",
+    "target": "CAP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "Pi_simple_molecule",
+    "target": "L-Asp_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "N-carbamoyl-L-aspartate_simple_molecule",
+    "target": "L-Asp_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "QH2_simple_molecule",
+    "target": "(S)-dihydroorotate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "orotate_simple_molecule",
+    "target": "(S)-dihydroorotate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "dUMP_simple_molecule",
+    "target": "dUTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "dUMP_simple_molecule",
+    "target": "DUT",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "dUMP_simple_molecule",
+    "target": "dCMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "dUMP_simple_molecule",
+    "target": "DCTD",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "CDP_simple_molecule",
+    "target": "CMP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "HCoVs_Type_I_Ifn_signalling(WP4868)_phenotype",
+    "target": "IFNB1_human_host",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "Interferon_1_pathway_phenotype",
+    "target": "IFNB1_human_host",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "HCoVs_IFN_induction_WP4880_phenotype",
+    "target": "IFNB1_human_host",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "IFNB1_human_host",
+    "target": "IFNB1_pulmonary_endothelial_cell",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "DNA_gene",
+    "target": "dTTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t103",
+    "source": "DNA_gene",
+    "target": "DNA_space_biosynthesis_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "DNA_gene",
+    "target": "virus_space_replication_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t105",
+    "source": "dTTP_simple_molecule",
+    "target": "dTDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "dTDP_simple_molecule",
+    "target": "dTYMK",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "dsDNA_simple_molecule",
+    "target": "DNA_damage_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t108",
+    "source": "CTP_simple_molecule",
+    "target": "UTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "UTP_simple_molecule",
+    "target": "NME1",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "dCTP_simple_molecule",
+    "target": "NME1",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "dUTP_simple_molecule",
+    "target": "NME1",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "CTP_simple_molecule",
+    "target": "NME1",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "PPi_simple_molecule",
+    "target": "orotate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "orotidine_space_5'-monophosphate_simple_molecule",
+    "target": "orotate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "PPi_simple_molecule",
+    "target": "PRPP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "orotidine_space_5'-monophosphate_simple_molecule",
+    "target": "PRPP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t117",
+    "source": "uridine_simple_molecule",
+    "target": "CDA",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "IFNB1_pulmonary_endothelial_cell",
+    "target": "IFNB1_rna",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "HCoVs_Type_I_Ifn_signalling(WP4868)_phenotype",
+    "target": "IFNA1_human_host",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "Interferon_1_pathway_phenotype",
+    "target": "IFNA1_human_host",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "HCoVs_IFN_induction_WP4880_phenotype",
+    "target": "IFNA1_human_host",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "dCMP_simple_molecule",
+    "target": "dCTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "dCMP_simple_molecule",
+    "target": "DCTPP1",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "QH2_simple_molecule",
+    "target": "CoQ_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "orotate_simple_molecule",
+    "target": "CoQ_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "QH2_simple_molecule",
+    "target": "dihydroorotate_space_dehydrogenase_space_holoenzyme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "orotate_simple_molecule",
+    "target": "dihydroorotate_space_dehydrogenase_space_holoenzyme_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "QH2_simple_molecule",
+    "target": "P1788_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t129",
+    "source": "orotate_simple_molecule",
+    "target": "P1788_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t130",
+    "source": "QH2_simple_molecule",
+    "target": "Teriflunomide_drug",
+    "sign": false
+   },
+   {
+    "id": "t131",
+    "source": "orotate_simple_molecule",
+    "target": "Teriflunomide_drug",
+    "sign": false
+   },
+   {
+    "id": "t132",
+    "source": "DNA_damage_phenotype",
+    "target": "Teriflunomide_drug",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "dUTP_simple_molecule",
+    "target": "dUDP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "RTC_and_transcription_pw_phenotype",
+    "target": "CTP_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "CTP_simple_molecule",
+    "target": "CTPS1",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/RTC-and-transcription.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/RTC-and-transcription.json
@@ -1,0 +1,538 @@
+{
+ "header": {
+  "name": "RTC-and-transcription",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on RTC-and-transcription",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "name": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "CoV_space_poly-br_merase_space_complex_complex_double_membrane_vesicle_viral_factory",
+    "name": "CoV_space_poly-br_merase_space_complex_complex_double_membrane_vesicle_viral_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "complex_complex_double_membrane_vesicle_viral_factory",
+    "name": "complex_complex_double_membrane_vesicle_viral_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_double_membrane_vesicle_viral_factory",
+    "name": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_double_membrane_vesicle_viral_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp9_double_membrane_vesicle_viral_factory",
+    "name": "nsp9_double_membrane_vesicle_viral_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(-)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene",
+    "name": "(-)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(+)sgRNA_space_(2-9)_gene",
+    "name": "(+)sgRNA_space_(2-9)_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CoV_space_poly-br_merase_space_complex_complex_cell",
+    "name": "CoV_space_poly-br_merase_space_complex_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp9_cell",
+    "name": "nsp9_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "complex_complex_cell",
+    "name": "complex_complex_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_cell",
+    "name": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1ab_cell",
+    "name": "pp1ab_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1a_cell",
+    "name": "pp1a_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp8_space_(I)",
+    "name": "nsp8_space_(I)",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp8_space_(II)",
+    "name": "nsp8_space_(II)",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp7",
+    "name": "nsp7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp14",
+    "name": "nsp14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp10",
+    "name": "nsp10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp12",
+    "name": "nsp12",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp2",
+    "name": "nsp2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp5",
+    "name": "nsp5",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp3",
+    "name": "nsp3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp4",
+    "name": "nsp4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp1",
+    "name": "nsp1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp11",
+    "name": "nsp11",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp6",
+    "name": "nsp6",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp15",
+    "name": "nsp15",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp16",
+    "name": "nsp16",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "nsp13",
+    "name": "nsp13",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1a_double_membrane_vesicle_viral_factory",
+    "name": "pp1a_double_membrane_vesicle_viral_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1ab_double_membrane_vesicle_viral_factory",
+    "name": "pp1ab_double_membrane_vesicle_viral_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "viral_space_accessory",
+    "name": "viral_space_accessory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "structural_space_proteins",
+    "name": "structural_space_proteins",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "CoV_space_poly-br_merase_space_complex_complex_double_membrane_vesicle_viral_factory",
+    "target": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "complex_complex_double_membrane_vesicle_viral_factory",
+    "target": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_double_membrane_vesicle_viral_factory",
+    "target": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "nsp9_double_membrane_vesicle_viral_factory",
+    "target": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "(-)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene",
+    "target": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "(+)sgRNA_space_(2-9)_gene",
+    "target": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "target": "CoV_space_poly-br_merase_space_complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "target": "nsp9_cell",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "target": "complex_complex_cell",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "Replication_space_transcription_space_complex_space__complex_double_membrane_vesicle_viral_factory",
+    "target": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_cell",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "pp1ab_cell",
+    "target": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_cell",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "pp1a_cell",
+    "target": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_cell",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "complex_complex_cell",
+    "target": "nsp8_space_(I)",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "complex_complex_cell",
+    "target": "nsp8_space_(II)",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "complex_complex_cell",
+    "target": "nsp7",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "CoV_space_poly-br_merase_space_complex_complex_cell",
+    "target": "nsp14",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "CoV_space_poly-br_merase_space_complex_complex_cell",
+    "target": "nsp10",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "CoV_space_poly-br_merase_space_complex_complex_cell",
+    "target": "nsp12",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "nsp2",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "nsp5",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "nsp3",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "nsp4",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "nsp9_cell",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "nsp8_space_(I)",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "nsp1",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "nsp7",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "nsp10",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "nsp11",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "nsp8_space_(II)",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "nsp6",
+    "target": "pp1a_cell",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "nsp14",
+    "target": "pp1ab_cell",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "nsp15",
+    "target": "pp1ab_cell",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "nsp16",
+    "target": "pp1ab_cell",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "nsp12",
+    "target": "pp1ab_cell",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "nsp13",
+    "target": "pp1ab_cell",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "pp1a_double_membrane_vesicle_viral_factory",
+    "target": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "pp1ab_double_membrane_vesicle_viral_factory",
+    "target": "(+)gRNA_space_(including_space_ORF1a_space_ORF1b)_gene_double_membrane_vesicle_viral_factory",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "viral_space_accessory",
+    "target": "(+)sgRNA_space_(2-9)_gene",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "structural_space_proteins",
+    "target": "(+)sgRNA_space_(2-9)_gene",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Renin_angiotensin.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Renin_angiotensin.json
@@ -1,0 +1,1435 @@
+{
+ "header": {
+  "name": "Renin_angiotensin",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Renin_angiotensin",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "AGTR1_cell",
+    "name": "AGTR1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2:AGTR1_complex",
+    "name": "ACE2:AGTR1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AGTR1_cell_active",
+    "name": "AGTR1_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2_cell",
+    "name": "ACE2_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2-Spike_complex_complex",
+    "name": "ACE2-Spike_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_1-9_simple_molecule",
+    "name": "angiotensin_1-9_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_1-7_simple_molecule_cell",
+    "name": "angiotensin_1-7_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "alamandine_simple_molecule",
+    "name": "alamandine_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2,_soluble",
+    "name": "ACE2,_soluble",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2_cell_active",
+    "name": "ACE2_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_II_simple_molecule_cell",
+    "name": "angiotensin_II_simple_molecule_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AGTR2_cell_active",
+    "name": "AGTR2_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_A_simple_molecule",
+    "name": "angiotensin_A_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_III_simple_molecule",
+    "name": "angiotensin_III_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_3-7_simple_molecule",
+    "name": "angiotensin_3-7_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "viral_replication_cycle_phenotype",
+    "name": "viral_replication_cycle_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S",
+    "name": "S",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Camostat_mesilate_drug",
+    "name": "Camostat_mesilate_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TMPRSS2",
+    "name": "TMPRSS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAS1:AGTR1_complex",
+    "name": "MAS1:AGTR1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "vasoconstriction_phenotype",
+    "name": "vasoconstriction_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "inflammatory_response_phenotype",
+    "name": "inflammatory_response_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "oxidative_stress_phenotype",
+    "name": "oxidative_stress_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "fibrosis_phenotype",
+    "name": "fibrosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "thrombosis_phenotype",
+    "name": "thrombosis_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "aldosterone_simple_molecule",
+    "name": "aldosterone_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cognition_phenotype",
+    "name": "cognition_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pulmonary_edema_phenotype",
+    "name": "pulmonary_edema_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "platelet_aggregation_phenotype",
+    "name": "platelet_aggregation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAS1_cell",
+    "name": "MAS1_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAS1_cell_active",
+    "name": "MAS1_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_I_simple_molecule",
+    "name": "angiotensin_I_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AGT",
+    "name": "AGT",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "REN",
+    "name": "REN",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_1-12_simple_molecule",
+    "name": "angiotensin_1-12_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_1-4_simple_molecule",
+    "name": "angiotensin_1-4_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE_cell",
+    "name": "ACE_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE_cell_active",
+    "name": "ACE_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTSD",
+    "name": "CTSD",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTSG",
+    "name": "CTSG",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CMA1",
+    "name": "CMA1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "KLK1",
+    "name": "KLK1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_1-5_simple_molecule",
+    "name": "angiotensin_1-5_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRGPRD_cell_active",
+    "name": "MRGPRD_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MME_cell",
+    "name": "MME_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MME_cell_active",
+    "name": "MME_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PRCP",
+    "name": "PRCP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "THOP1",
+    "name": "THOP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PREP",
+    "name": "PREP",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AGTR2_cell",
+    "name": "AGTR2_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CGP42112A_drug",
+    "name": "CGP42112A_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "AR234960_drug",
+    "name": "AR234960_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Calcitriol_simple_molecule",
+    "name": "Calcitriol_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "estradiol_simple_molecule",
+    "name": "estradiol_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2_gene",
+    "name": "ACE2_gene",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS-CoV-2_infection_phenotype",
+    "name": "SARS-CoV-2_infection_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_II_simple_molecule_human_host",
+    "name": "angiotensin_II_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "aging_phenotype",
+    "name": "aging_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "hypertension_phenotype",
+    "name": "hypertension_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "_Diabetes_mellitus,_type_II_phenotype",
+    "name": "_Diabetes_mellitus,_type_II_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ethynylestradiol_simple_molecule",
+    "name": "ethynylestradiol_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "androgen_simple_molecule",
+    "name": "androgen_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MRGPRD_cell",
+    "name": "MRGPRD_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LNPEP_cell_active",
+    "name": "LNPEP_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "neurodegeneration_phenotype",
+    "name": "neurodegeneration_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_IV_simple_molecule",
+    "name": "angiotensin_IV_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENPEP_cell_active",
+    "name": "ENPEP_cell_active",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ANPEP_",
+    "name": "ANPEP_",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ENPEP_cell",
+    "name": "ENPEP_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "QGC001_drug",
+    "name": "QGC001_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "sex,_male_phenotype",
+    "name": "sex,_male_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "angiotensin_1-7_simple_molecule_human_host",
+    "name": "angiotensin_1-7_simple_molecule_human_host",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ADAM17",
+    "name": "ADAM17",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Lisinopril_drug",
+    "name": "Lisinopril_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ABO_blood_group_system_phenotype",
+    "name": "ABO_blood_group_system_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Losartan_drug",
+    "name": "Losartan_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LNPEP_cell",
+    "name": "LNPEP_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "ACE2:AGTR1_complex",
+    "target": "AGTR1_cell",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "AGTR1_cell_active",
+    "target": "AGTR1_cell",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "ACE2:AGTR1_complex",
+    "target": "ACE2_cell",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "ACE2-Spike_complex_complex",
+    "target": "ACE2_cell",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "angiotensin_1-9_simple_molecule",
+    "target": "ACE2_cell",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "ACE2_cell",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "alamandine_simple_molecule",
+    "target": "ACE2_cell",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "ACE2,_soluble",
+    "target": "ACE2_cell",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "ACE2_cell_active",
+    "target": "ACE2_cell",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "ACE2:AGTR1_complex",
+    "target": "angiotensin_II_simple_molecule_cell",
+    "sign": false
+   },
+   {
+    "id": "t11",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "angiotensin_II_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "AGTR2_cell_active",
+    "target": "angiotensin_II_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "angiotensin_A_simple_molecule",
+    "target": "angiotensin_II_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "angiotensin_III_simple_molecule",
+    "target": "angiotensin_II_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "AGTR1_cell_active",
+    "target": "angiotensin_II_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "angiotensin_3-7_simple_molecule",
+    "target": "angiotensin_II_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "viral_replication_cycle_phenotype",
+    "target": "ACE2-Spike_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "ACE2-Spike_complex_complex",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "angiotensin_II_simple_molecule_cell",
+    "target": "S",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "ACE2_cell",
+    "target": "S",
+    "sign": false
+   },
+   {
+    "id": "t21",
+    "source": "ACE2-Spike_complex_complex",
+    "target": "Camostat_mesilate_drug",
+    "sign": false
+   },
+   {
+    "id": "t22",
+    "source": "ACE2-Spike_complex_complex",
+    "target": "TMPRSS2",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "AGTR1_cell_active",
+    "target": "MAS1:AGTR1_complex",
+    "sign": false
+   },
+   {
+    "id": "t24",
+    "source": "MAS1:AGTR1_complex",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "vasoconstriction_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "inflammatory_response_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "ACE2,_soluble",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "oxidative_stress_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t29",
+    "source": "fibrosis_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "thrombosis_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "aldosterone_simple_molecule",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "cognition_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t33",
+    "source": "pulmonary_edema_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "platelet_aggregation_phenotype",
+    "target": "AGTR1_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "MAS1:AGTR1_complex",
+    "target": "MAS1_cell",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "MAS1_cell_active",
+    "target": "MAS1_cell",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "angiotensin_1-9_simple_molecule",
+    "target": "angiotensin_I_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "angiotensin_II_simple_molecule_cell",
+    "target": "angiotensin_I_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "angiotensin_I_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "AGT",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "REN",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "angiotensin_1-12_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t43",
+    "source": "angiotensin_II_simple_molecule_cell",
+    "target": "angiotensin_1-12_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "angiotensin_1-12_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "angiotensin_1-4_simple_molecule",
+    "target": "angiotensin_1-12_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "ACE_cell",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "angiotensin_II_simple_molecule_cell",
+    "target": "ACE_cell",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "ACE_cell_active",
+    "target": "ACE_cell",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "CTSD",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "angiotensin_I_simple_molecule",
+    "target": "CTSG",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "angiotensin_1-9_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "AGTR2_cell_active",
+    "target": "angiotensin_1-9_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "angiotensin_II_simple_molecule_cell",
+    "target": "CMA1",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "angiotensin_II_simple_molecule_cell",
+    "target": "KLK1",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "AGTR2_cell_active",
+    "target": "angiotensin_1-7_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "MAS1_cell_active",
+    "target": "angiotensin_1-7_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "angiotensin_1-5_simple_molecule",
+    "target": "angiotensin_1-7_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "alamandine_simple_molecule",
+    "target": "angiotensin_1-7_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "MRGPRD_cell_active",
+    "target": "angiotensin_1-7_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "AGTR1_cell_active",
+    "target": "angiotensin_1-7_simple_molecule_cell",
+    "sign": false
+   },
+   {
+    "id": "t61",
+    "source": "angiotensin_3-7_simple_molecule",
+    "target": "angiotensin_1-7_simple_molecule_cell",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "ACE_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "angiotensin_1-5_simple_molecule",
+    "target": "ACE_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "MME_cell",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "angiotensin_1-4_simple_molecule",
+    "target": "MME_cell",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "MME_cell_active",
+    "target": "MME_cell",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "PRCP",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "THOP1",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "angiotensin_1-7_simple_molecule_cell",
+    "target": "PREP",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "vasoconstriction_phenotype",
+    "target": "AGTR2_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t71",
+    "source": "fibrosis_phenotype",
+    "target": "AGTR2_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t72",
+    "source": "AGTR2_cell_active",
+    "target": "AGTR2_cell",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "AGTR2_cell_active",
+    "target": "CGP42112A_drug",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "AGTR2_cell_active",
+    "target": "angiotensin_A_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "alamandine_simple_molecule",
+    "target": "angiotensin_A_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "AGTR1_cell_active",
+    "target": "angiotensin_A_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "vasoconstriction_phenotype",
+    "target": "MAS1_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t78",
+    "source": "inflammatory_response_phenotype",
+    "target": "MAS1_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t79",
+    "source": "oxidative_stress_phenotype",
+    "target": "MAS1_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t80",
+    "source": "fibrosis_phenotype",
+    "target": "MAS1_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t81",
+    "source": "thrombosis_phenotype",
+    "target": "MAS1_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t82",
+    "source": "MAS1_cell_active",
+    "target": "angiotensin_1-5_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "MAS1_cell_active",
+    "target": "AR234960_drug",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "ACE_cell",
+    "target": "Calcitriol_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t85",
+    "source": "ACE2_cell",
+    "target": "Calcitriol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "REN",
+    "target": "Calcitriol_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t87",
+    "source": "ACE_cell",
+    "target": "estradiol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "ACE2_cell",
+    "target": "estradiol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "ACE2_cell",
+    "target": "ACE2_gene",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "ACE2_cell",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t91",
+    "source": "angiotensin_II_simple_molecule_human_host",
+    "target": "SARS-CoV-2_infection_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "ACE2_cell",
+    "target": "aging_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "ACE2_cell_active",
+    "target": "aging_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "ACE_cell_active",
+    "target": "aging_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t95",
+    "source": "ACE2_cell",
+    "target": "hypertension_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t96",
+    "source": "ACE2_cell_active",
+    "target": "hypertension_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "ACE_cell_active",
+    "target": "hypertension_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "ACE2_cell",
+    "target": "_Diabetes_mellitus,_type_II_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t99",
+    "source": "AGT",
+    "target": "ethynylestradiol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "TMPRSS2",
+    "target": "androgen_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "MRGPRD_cell_active",
+    "target": "alamandine_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "vasoconstriction_phenotype",
+    "target": "MRGPRD_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t103",
+    "source": "inflammatory_response_phenotype",
+    "target": "MRGPRD_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t104",
+    "source": "MRGPRD_cell_active",
+    "target": "MRGPRD_cell",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "vasoconstriction_phenotype",
+    "target": "LNPEP_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t106",
+    "source": "inflammatory_response_phenotype",
+    "target": "LNPEP_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t107",
+    "source": "neurodegeneration_phenotype",
+    "target": "LNPEP_cell_active",
+    "sign": false
+   },
+   {
+    "id": "t108",
+    "source": "cognition_phenotype",
+    "target": "LNPEP_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "angiotensin_IV_simple_molecule",
+    "target": "angiotensin_III_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "angiotensin_III_simple_molecule",
+    "target": "ENPEP_cell_active",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "AGTR1_cell_active",
+    "target": "angiotensin_IV_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "LNPEP_cell_active",
+    "target": "angiotensin_IV_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "angiotensin_3-7_simple_molecule",
+    "target": "angiotensin_IV_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t114",
+    "source": "angiotensin_IV_simple_molecule",
+    "target": "ANPEP_",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "ENPEP_cell_active",
+    "target": "ENPEP_cell",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "ENPEP_cell_active",
+    "target": "QGC001_drug",
+    "sign": false
+   },
+   {
+    "id": "t117",
+    "source": "ENPEP_cell_active",
+    "target": "sex,_male_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t118",
+    "source": "ACE2_cell_active",
+    "target": "sex,_male_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "ACE_cell_active",
+    "target": "sex,_male_phenotype",
+    "sign": false
+   },
+   {
+    "id": "t120",
+    "source": "MME_cell_active",
+    "target": "sex,_male_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "angiotensin_1-7_simple_molecule_human_host",
+    "target": "ACE2,_soluble",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "ACE2,_soluble",
+    "target": "ADAM17",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "MAS1_cell",
+    "target": "aldosterone_simple_molecule",
+    "sign": false
+   },
+   {
+    "id": "t124",
+    "source": "ACE_cell_active",
+    "target": "aldosterone_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "angiotensin_1-7_simple_molecule_human_host",
+    "target": "angiotensin_II_simple_molecule_human_host",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "ACE_cell_active",
+    "target": "Lisinopril_drug",
+    "sign": false
+   },
+   {
+    "id": "t127",
+    "source": "ACE_cell_active",
+    "target": "ABO_blood_group_system_phenotype",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "AGTR1_cell_active",
+    "target": "Losartan_drug",
+    "sign": false
+   },
+   {
+    "id": "t129",
+    "source": "LNPEP_cell_active",
+    "target": "LNPEP_cell",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "LNPEP_cell_active",
+    "target": "angiotensin_3-7_simple_molecule",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/TGFB_pathway.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/TGFB_pathway.json
@@ -1,0 +1,351 @@
+{
+ "header": {
+  "name": "TGFB_pathway",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on TGFB_pathway",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "SMAD1/5/8_complex",
+    "name": "SMAD1/5/8_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Modulation_of_cell_cycle_phenotype",
+    "name": "Modulation_of_cell_cycle_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BAMBI",
+    "name": "BAMBI",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SMAD2/3_complex",
+    "name": "SMAD2/3_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TGFB/TGFBR_complex",
+    "name": "TGFB/TGFBR_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "BMPR1/2/ACTR2_complex",
+    "name": "BMPR1/2/ACTR2_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "MAPK3",
+    "name": "MAPK3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a",
+    "name": "Orf3a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp7b_cell",
+    "name": "Nsp7b_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E",
+    "name": "E",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E3_ubiquitin_ligase_complex_complex",
+    "name": "E3_ubiquitin_ligase_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "PP2A_complex",
+    "name": "PP2A_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RHOA",
+    "name": "RHOA",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACVR1",
+    "name": "ACVR1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACVR1B",
+    "name": "ACVR1B",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp7b_default_compartment",
+    "name": "Nsp7b_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "LTBP1",
+    "name": "LTBP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8",
+    "name": "Orf8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "RPS6KB1_empty",
+    "name": "RPS6KB1_empty",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a",
+    "name": "Orf7a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp7",
+    "name": "Nsp7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Modulation_of_cell_cycle_phenotype",
+    "target": "SMAD1/5/8_complex",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "SMAD1/5/8_complex",
+    "target": "BAMBI",
+    "sign": false
+   },
+   {
+    "id": "t3",
+    "source": "SMAD2/3_complex",
+    "target": "BAMBI",
+    "sign": false
+   },
+   {
+    "id": "t4",
+    "source": "TGFB/TGFBR_complex",
+    "target": "BAMBI",
+    "sign": false
+   },
+   {
+    "id": "t5",
+    "source": "SMAD1/5/8_complex",
+    "target": "BMPR1/2/ACTR2_complex",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "SMAD1/5/8_complex",
+    "target": "MAPK3",
+    "sign": false
+   },
+   {
+    "id": "t7",
+    "source": "SMAD2/3_complex",
+    "target": "MAPK3",
+    "sign": false
+   },
+   {
+    "id": "t8",
+    "source": "SMAD1/5/8_complex",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "SMAD2/3_complex",
+    "target": "Orf3a",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "SMAD1/5/8_complex",
+    "target": "Nsp7b_cell",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "SMAD1/5/8_complex",
+    "target": "E",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "SMAD2/3_complex",
+    "target": "E3_ubiquitin_ligase_complex_complex",
+    "sign": false
+   },
+   {
+    "id": "t13",
+    "source": "Modulation_of_cell_cycle_phenotype",
+    "target": "SMAD2/3_complex",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "SMAD2/3_complex",
+    "target": "TGFB/TGFBR_complex",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "PP2A_complex",
+    "target": "TGFB/TGFBR_complex",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "RHOA",
+    "target": "TGFB/TGFBR_complex",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "SMAD2/3_complex",
+    "target": "ACVR1",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "SMAD2/3_complex",
+    "target": "ACVR1B",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "SMAD2/3_complex",
+    "target": "Nsp7b_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "TGFB/TGFBR_complex",
+    "target": "LTBP1",
+    "sign": false
+   },
+   {
+    "id": "t21",
+    "source": "TGFB/TGFBR_complex",
+    "target": "Orf8",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "RPS6KB1_empty",
+    "target": "PP2A_complex",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "PP2A_complex",
+    "target": "Orf7a",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "RHOA",
+    "target": "Nsp7",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}

--- a/scripts/covid19_diseasemaps/regnet_amr/Virus_replication_cycle.json
+++ b/scripts/covid19_diseasemaps/regnet_amr/Virus_replication_cycle.json
@@ -1,0 +1,3400 @@
+{
+ "header": {
+  "name": "Virus_replication_cycle",
+  "schema": "https://raw.githubusercontent.com/DARPA-ASKEM/Model-Representations/regnet_v0.2/regnet/regnet_schema.json",
+  "schema_name": "regnet",
+  "description": "A submodel of the COVID-10 Disease Map focusing on Virus_replication_cycle",
+  "model_version": "0.1"
+ },
+ "model": {
+  "vertices": [
+   {
+    "id": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Replication_space_transcription_space_complex:N_space_oligomer_complex",
+    "name": "Replication_space_transcription_space_complex:N_space_oligomer_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf9b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b_space_ds_space_sgmRNA_rna",
+    "name": "Orf9b_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf3a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "M_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf14_space_ds_space_sgmRNA_rna",
+    "name": "Orf14_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_space_ds_space_sgmRNA_rna",
+    "name": "E_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf7b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ds_space_gRNA_rna",
+    "name": "ds_space_gRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_space_ds_space_sgmRNA_rna",
+    "name": "M_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b_space_ds_space_sgmRNA_rna",
+    "name": "Orf7b_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N_space_ds_space_sgmRNA_rna",
+    "name": "N_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N_space_space_(-)ss_space_sgmRNA_rna",
+    "name": "N_space_space_(-)ss_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6_space_ds_space_sgmRNA_rna",
+    "name": "Orf6_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_space_ds_space_sgmRNA_rna",
+    "name": "Orf8_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "S_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf8_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf6_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "E_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf14_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf14_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_space_ds_space_sgmRNA_rna",
+    "name": "Orf7a_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf7a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "name": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_space_ds_space_sgmRNA_rna",
+    "name": "S_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_space_ds_space_sgmRNA_rna",
+    "name": "Orf3a_space_ds_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp16",
+    "name": "Nsp16",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp15",
+    "name": "Nsp15",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cellular_space_response_space_to_space_exogenous_space_dsRNA_phenotype",
+    "name": "cellular_space_response_space_to_space_exogenous_space_dsRNA_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp14",
+    "name": "Nsp14",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp13",
+    "name": "Nsp13",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp12",
+    "name": "Nsp12",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp9",
+    "name": "Nsp9",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp8",
+    "name": "Nsp8",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6_endoplasmic_reticulum",
+    "name": "Nsp6_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "double_membrane_vesicle_viral_factory_assembly_phenotype",
+    "name": "double_membrane_vesicle_viral_factory_assembly_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp3",
+    "name": "Nsp3",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_endoplasmic_reticulum",
+    "name": "Nsp4_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp7",
+    "name": "Nsp7",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp10",
+    "name": "Nsp10",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp2",
+    "name": "Nsp2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "name": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S2_epithelial_space_cell",
+    "name": "S2_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "ACE2_epithelial_space_cell",
+    "name": "ACE2_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2_default_compartment",
+    "name": "ACE2_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S1_default_compartment",
+    "name": "S1_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_SARS-CoV-2_space_virion",
+    "name": "S_SARS-CoV-2_space_virion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Heparan_space_sulfate_simple_molecule",
+    "name": "Heparan_space_sulfate_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nucleocapsid_complex_epithelial_space_cell",
+    "name": "Nucleocapsid_complex_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(+)ss_space_gRNA_rna",
+    "name": "(+)ss_space_gRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N_epithelial_space_cell",
+    "name": "N_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "name": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Orf7a_epithelial_space_cell",
+    "name": "Orf7a_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_epithelial_space_cell",
+    "name": "M_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_epithelial_space_cell",
+    "name": "E_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_SARS-CoV-2_space_virion",
+    "name": "Orf7a_SARS-CoV-2_space_virion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_SARS-CoV-2_space_virion",
+    "name": "E_SARS-CoV-2_space_virion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_SARS-CoV-2_space_virion",
+    "name": "M_SARS-CoV-2_space_virion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "cholesterol_simple_molecule",
+    "name": "cholesterol_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S1:NRP1_space_complex_complex",
+    "name": "S1:NRP1_space_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_endosome",
+    "name": "Orf7a_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_endosome",
+    "name": "E_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_endosome",
+    "name": "M_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S2_SARS-CoV-2_space_virion",
+    "name": "S2_SARS-CoV-2_space_virion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "NRP1",
+    "name": "NRP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nucleocapsid_complex_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Nucleocapsid_complex_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(+)ss_gRNA_rna_epithelial_space_cell",
+    "name": "(+)ss_gRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4:IDE_complex_epithelial_space_cell",
+    "name": "Nsp4:IDE_complex_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp4_IDE_complex",
+    "name": "Nsp4_IDE_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_epithelial_space_cell",
+    "name": "Nsp4_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "name": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "name": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IDE_epithelial_space_cell",
+    "name": "IDE_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "IDE_default_compartment",
+    "name": "IDE_default_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SARS-CoV2_candidate_drugs_complex",
+    "name": "SARS-CoV2_candidate_drugs_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1:_drug_complex_complex",
+    "name": "SIGMAR1:_drug_complex_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "viral_life_cycle_phenotype",
+    "name": "viral_life_cycle_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_endoplasmic_reticulum",
+    "name": "SIGMAR1_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "name": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_epithelial_space_cell",
+    "name": "SIGMAR1_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "SIGMAR1_nucleus",
+    "name": "SIGMAR1_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp4:NUP210_complex_nucleus",
+    "name": "Nsp4:NUP210_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP210_endoplasmic_reticulum",
+    "name": "NUP210_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP210:Selinexor_complex",
+    "name": "NUP210:Selinexor_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "NUP210_nucleus",
+    "name": "NUP210_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "name": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase:Nsp6_complex_endosome",
+    "name": "V-ATPase:Nsp6_complex_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6_epithelial_space_cell",
+    "name": "Nsp6_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase_complex_endoplasmic_reticulum",
+    "name": "V-ATPase_complex_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-ATPase_complex_endosome",
+    "name": "V-ATPase_complex_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "V-type_space_proton_space_ATPase_complex",
+    "name": "V-type_space_proton_space_ATPase_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "H+_ion",
+    "name": "H+_ion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP6AP1",
+    "name": "ATP6AP1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ATP6AP1:Bafilomycin_space_A1_complex",
+    "name": "ATP6AP1:Bafilomycin_space_A1_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6:SIGMAR1_complex_nucleus",
+    "name": "Nsp6:SIGMAR1_complex_nucleus",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp6:SIGMAR1_complex_epithelial_space_cell",
+    "name": "Nsp6:SIGMAR1_complex_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Selinexor_drug",
+    "name": "Selinexor_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "bafilomycin_space_A1_drug",
+    "name": "bafilomycin_space_A1_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ALG11_endoplasmic_reticulum",
+    "name": "ALG11_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "RAB7A",
+    "name": "RAB7A",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ARL8B",
+    "name": "ARL8B",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Ca+2_simple_molecule",
+    "name": "Ca+2_simple_molecule",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(-)ss_space_gRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "(-)ss_space_gRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "(+)ss_gRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "(+)ss_gRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Host_space_translation_phenotype",
+    "name": "Host_space_translation_phenotype",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp1",
+    "name": "Nsp1",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "S_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_rough_space_endoplasmic_space_reticulum",
+    "name": "S_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "E_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "E_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf9b_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf9b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "M_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "M_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b_rough_space_endoplasmic_space_reticulum",
+    "name": "Orf9b_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Orf9b_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1ab_space_nsp6-16",
+    "name": "pp1ab_space_nsp6-16",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1ab_space_Nsp3-16_endoplasmic_reticulum",
+    "name": "pp1ab_space_Nsp3-16_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "Nsp5_epithelial_space_cell",
+    "name": "Nsp5_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp3-4",
+    "name": "Nsp3-4",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_rough_space_endoplasmic_space_reticulum",
+    "name": "E_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "E_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "E_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "E_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "name": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_rough_space_endoplasmic_space_reticulum",
+    "name": "Orf3a_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6_rough_space_endoplasmic_space_reticulum",
+    "name": "Orf6_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_rough_space_endoplasmic_space_reticulum",
+    "name": "Orf7a_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf14_rough_space_endoplasmic_space_reticulum",
+    "name": "Orf14_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b_rough_space_endoplasmic_space_reticulum",
+    "name": "Orf7b_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_rough_space_endoplasmic_space_reticulum",
+    "name": "M_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_rough_space_endoplasmic_space_reticulum",
+    "name": "Orf8_rough_space_endoplasmic_space_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf14_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Orf14_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1a",
+    "name": "pp1a",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1a_space_Nsp3-11_endoplasmic_reticulum",
+    "name": "pp1a_space_Nsp3-11_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    },
+    "sign": true
+   },
+   {
+    "id": "pp1ab",
+    "name": "pp1ab",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Host_space_translation_space_complex_complex_epithelial_space_cell",
+    "name": "Host_space_translation_space_complex_complex_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf14_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf14_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf14_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf14_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp3-4_glycosylated",
+    "name": "Nsp3-4_glycosylated",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "pp1a_space_Nsp6-11",
+    "name": "pp1a_space_Nsp6-11",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp11",
+    "name": "Nsp11",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Nsp5_endoplasmic_reticulum",
+    "name": "Nsp5_endoplasmic_reticulum",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf8_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf8_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf6_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6__(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf6__(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "FURIN",
+    "name": "FURIN",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "TMPRSS2",
+    "name": "TMPRSS2",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Camostat_space_mesylate_drug",
+    "name": "Camostat_space_mesylate_drug",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf7b_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf7b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N_space_(-)ss_space_sgmRNA_rna",
+    "name": "N_space_(-)ss_space_sgmRNA_rna",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "N_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Orf7b_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Orf3a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf3a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf9b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf9b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Orf6_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf6__(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf6__(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Orf7a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf7a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf7a_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf7a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "M_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "N_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "N_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "S_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "S_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf14_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf14_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "S_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "ACE2:SPIKE_space_complex_complex_SARS-CoV-2_space_virion",
+    "name": "ACE2:SPIKE_space_complex_complex_SARS-CoV-2_space_virion",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "S1_endosome",
+    "name": "S1_endosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTSB",
+    "name": "CTSB",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "CTSL",
+    "name": "CTSL",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "name": "Orf8_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf7b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf7b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf3a_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "name": "Orf3a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "M_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "M_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf3a_lysosome",
+    "name": "Orf3a_lysosome",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "Orf8_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "name": "Orf8_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   },
+   {
+    "id": "DMV_molecular_pore_complex",
+    "name": "DMV_molecular_pore_complex",
+    "grounding": {
+     "identifiers": {},
+     "context": {}
+    }
+   }
+  ],
+  "edges": [
+   {
+    "id": "t1",
+    "source": "Replication_space_transcription_space_complex:N_space_oligomer_complex",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t2",
+    "source": "Orf9b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t3",
+    "source": "Orf9b_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t4",
+    "source": "Orf3a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t5",
+    "source": "M_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t6",
+    "source": "Orf14_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t7",
+    "source": "E_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t8",
+    "source": "Orf7b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t9",
+    "source": "ds_space_gRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t10",
+    "source": "M_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t11",
+    "source": "Orf7b_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t12",
+    "source": "N_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t13",
+    "source": "N_space_space_(-)ss_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t14",
+    "source": "Orf6_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t15",
+    "source": "Orf8_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t16",
+    "source": "S_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t17",
+    "source": "Orf8_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t18",
+    "source": "Orf6_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t19",
+    "source": "E_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t20",
+    "source": "Orf14_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t21",
+    "source": "Orf7a_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t22",
+    "source": "Orf7a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t23",
+    "source": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t24",
+    "source": "S_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t25",
+    "source": "Orf3a_space_ds_space_sgmRNA_rna",
+    "target": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t26",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp16",
+    "sign": true
+   },
+   {
+    "id": "t27",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp15",
+    "sign": true
+   },
+   {
+    "id": "t28",
+    "source": "cellular_space_response_space_to_space_exogenous_space_dsRNA_phenotype",
+    "target": "Nsp15",
+    "sign": false
+   },
+   {
+    "id": "t29",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp14",
+    "sign": true
+   },
+   {
+    "id": "t30",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp13",
+    "sign": true
+   },
+   {
+    "id": "t31",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp12",
+    "sign": true
+   },
+   {
+    "id": "t32",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp9",
+    "sign": true
+   },
+   {
+    "id": "t33",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp8",
+    "sign": true
+   },
+   {
+    "id": "t34",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp6_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t35",
+    "source": "double_membrane_vesicle_viral_factory_assembly_phenotype",
+    "target": "Nsp6_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t36",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp3",
+    "sign": true
+   },
+   {
+    "id": "t37",
+    "source": "double_membrane_vesicle_viral_factory_assembly_phenotype",
+    "target": "Nsp3",
+    "sign": true
+   },
+   {
+    "id": "t38",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp4_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t39",
+    "source": "double_membrane_vesicle_viral_factory_assembly_phenotype",
+    "target": "Nsp4_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t40",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp7",
+    "sign": true
+   },
+   {
+    "id": "t41",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp10",
+    "sign": true
+   },
+   {
+    "id": "t42",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Nsp2",
+    "sign": true
+   },
+   {
+    "id": "t44",
+    "source": "S2_epithelial_space_cell",
+    "target": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t45",
+    "source": "ACE2_epithelial_space_cell",
+    "target": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t46",
+    "source": "ACE2_default_compartment",
+    "target": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t47",
+    "source": "S1_default_compartment",
+    "target": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t48",
+    "source": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "target": "ACE2_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t49",
+    "source": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "target": "S_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t50",
+    "source": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "target": "Heparan_space_sulfate_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t51",
+    "source": "(+)ss_space_gRNA_rna",
+    "target": "Nucleocapsid_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t52",
+    "source": "N_epithelial_space_cell",
+    "target": "Nucleocapsid_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t53",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t54",
+    "source": "Orf7a_epithelial_space_cell",
+    "target": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t55",
+    "source": "M_epithelial_space_cell",
+    "target": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t56",
+    "source": "E_epithelial_space_cell",
+    "target": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t57",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "Orf7a_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t58",
+    "source": "Orf7a_epithelial_space_cell",
+    "target": "Orf7a_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t59",
+    "source": "M_epithelial_space_cell",
+    "target": "Orf7a_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t60",
+    "source": "E_epithelial_space_cell",
+    "target": "Orf7a_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t61",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "E_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t62",
+    "source": "Orf7a_epithelial_space_cell",
+    "target": "E_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t63",
+    "source": "M_epithelial_space_cell",
+    "target": "E_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t64",
+    "source": "E_epithelial_space_cell",
+    "target": "E_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t65",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "M_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t66",
+    "source": "Orf7a_epithelial_space_cell",
+    "target": "M_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t67",
+    "source": "M_epithelial_space_cell",
+    "target": "M_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t68",
+    "source": "E_epithelial_space_cell",
+    "target": "M_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t69",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "S2_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t70",
+    "source": "Orf7a_epithelial_space_cell",
+    "target": "S2_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t71",
+    "source": "M_epithelial_space_cell",
+    "target": "S2_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t72",
+    "source": "E_epithelial_space_cell",
+    "target": "S2_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t73",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "cholesterol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t74",
+    "source": "Orf7a_epithelial_space_cell",
+    "target": "cholesterol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t75",
+    "source": "M_epithelial_space_cell",
+    "target": "cholesterol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t76",
+    "source": "E_epithelial_space_cell",
+    "target": "cholesterol_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t77",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "S1:NRP1_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t78",
+    "source": "Orf7a_epithelial_space_cell",
+    "target": "S1:NRP1_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t79",
+    "source": "M_epithelial_space_cell",
+    "target": "S1:NRP1_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t80",
+    "source": "E_epithelial_space_cell",
+    "target": "S1:NRP1_space_complex_complex",
+    "sign": true
+   },
+   {
+    "id": "t81",
+    "source": "Orf7a_endosome",
+    "target": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t82",
+    "source": "E_endosome",
+    "target": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t83",
+    "source": "M_endosome",
+    "target": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t84",
+    "source": "Orf7a_endosome",
+    "target": "E_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t85",
+    "source": "E_endosome",
+    "target": "E_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t86",
+    "source": "M_endosome",
+    "target": "E_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t87",
+    "source": "Orf7a_endosome",
+    "target": "M_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t88",
+    "source": "E_endosome",
+    "target": "M_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t89",
+    "source": "M_endosome",
+    "target": "M_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t90",
+    "source": "Orf7a_endosome",
+    "target": "Orf7a_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t91",
+    "source": "E_endosome",
+    "target": "Orf7a_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t92",
+    "source": "M_endosome",
+    "target": "Orf7a_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t93",
+    "source": "Nucleocapsid_complex_epithelial_space_cell",
+    "target": "S2_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t94",
+    "source": "Orf7a_endosome",
+    "target": "S2_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t95",
+    "source": "E_endosome",
+    "target": "S2_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t96",
+    "source": "M_endosome",
+    "target": "S2_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t97",
+    "source": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "target": "ACE2:SPIKE_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t98",
+    "source": "S1:NRP1_space_complex_complex",
+    "target": "S1_default_compartment",
+    "sign": true
+   },
+   {
+    "id": "t99",
+    "source": "S1:NRP1_space_complex_complex",
+    "target": "NRP1",
+    "sign": true
+   },
+   {
+    "id": "t100",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Replication_space_transcription_space_complex:N_space_oligomer_complex",
+    "sign": true
+   },
+   {
+    "id": "t101",
+    "source": "Nucleocapsid_complex_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Replication_space_transcription_space_complex:N_space_oligomer_complex",
+    "sign": true
+   },
+   {
+    "id": "t102",
+    "source": "Replication_space_transcription_space_complex:N_space_oligomer_complex",
+    "target": "N_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t104",
+    "source": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "target": "Nucleocapsid_complex_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "sign": true
+   },
+   {
+    "id": "t105",
+    "source": "Replication_space_transcription_space_complex_complex_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "(+)ss_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t106",
+    "source": "Nucleocapsid_complex_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "(+)ss_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t107",
+    "source": "Nsp4_IDE_complex",
+    "target": "Nsp4:IDE_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t109",
+    "source": "Nsp4:IDE_complex_epithelial_space_cell",
+    "target": "Nsp4_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t110",
+    "source": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "target": "Nsp4_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t111",
+    "source": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "target": "Nsp4_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t112",
+    "source": "Nsp4:IDE_complex_epithelial_space_cell",
+    "target": "IDE_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t113",
+    "source": "IDE_default_compartment",
+    "target": "IDE_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t115",
+    "source": "SIGMAR1:_drug_complex_complex",
+    "target": "SARS-CoV2_candidate_drugs_complex",
+    "sign": true
+   },
+   {
+    "id": "t116",
+    "source": "viral_life_cycle_phenotype",
+    "target": "SARS-CoV2_candidate_drugs_complex",
+    "sign": false
+   },
+   {
+    "id": "t117",
+    "source": "SIGMAR1:_drug_complex_complex",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t118",
+    "source": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t119",
+    "source": "SIGMAR1_epithelial_space_cell",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t120",
+    "source": "SIGMAR1_nucleus",
+    "target": "SIGMAR1_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t121",
+    "source": "Nsp4:NUP210_complex_nucleus",
+    "target": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t122",
+    "source": "Nsp4:NUP210_complex_endoplasmic_reticulum",
+    "target": "NUP210_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t123",
+    "source": "NUP210:Selinexor_complex",
+    "target": "NUP210_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t124",
+    "source": "NUP210_nucleus",
+    "target": "NUP210_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t125",
+    "source": "V-ATPase:Nsp6_complex_endosome",
+    "target": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t126",
+    "source": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "target": "Nsp6_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t127",
+    "source": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "target": "Nsp6_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t128",
+    "source": "V-ATPase:Nsp6_complex_endoplasmic_reticulum",
+    "target": "V-ATPase_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t129",
+    "source": "V-ATPase_complex_endosome",
+    "target": "V-ATPase_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t130",
+    "source": "V-ATPase_complex_endoplasmic_reticulum",
+    "target": "V-type_space_proton_space_ATPase_complex",
+    "sign": true
+   },
+   {
+    "id": "t131",
+    "source": "H+_ion",
+    "target": "V-type_space_proton_space_ATPase_complex",
+    "sign": true
+   },
+   {
+    "id": "t132",
+    "source": "V-ATPase_complex_endoplasmic_reticulum",
+    "target": "ATP6AP1",
+    "sign": true
+   },
+   {
+    "id": "t133",
+    "source": "ATP6AP1:Bafilomycin_space_A1_complex",
+    "target": "ATP6AP1",
+    "sign": true
+   },
+   {
+    "id": "t134",
+    "source": "Nsp6:SIGMAR1_complex_nucleus",
+    "target": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t135",
+    "source": "Nsp6:SIGMAR1_complex_epithelial_space_cell",
+    "target": "Nsp6:SIGMAR1_complex_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t136",
+    "source": "NUP210:Selinexor_complex",
+    "target": "Selinexor_drug",
+    "sign": true
+   },
+   {
+    "id": "t137",
+    "source": "ATP6AP1:Bafilomycin_space_A1_complex",
+    "target": "bafilomycin_space_A1_drug",
+    "sign": true
+   },
+   {
+    "id": "t138",
+    "source": "viral_life_cycle_phenotype",
+    "target": "bafilomycin_space_A1_drug",
+    "sign": false
+   },
+   {
+    "id": "t140",
+    "source": "Nsp4_ALG11_complex_endoplasmic_reticulum",
+    "target": "ALG11_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t142",
+    "source": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "target": "RAB7A",
+    "sign": true
+   },
+   {
+    "id": "t143",
+    "source": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "target": "ARL8B",
+    "sign": true
+   },
+   {
+    "id": "t144",
+    "source": "Nucleocapsid_complex_SARS-CoV-2_space_virion",
+    "target": "Ca+2_simple_molecule",
+    "sign": true
+   },
+   {
+    "id": "t145",
+    "source": "(-)ss_space_gRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "ds_space_gRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t146",
+    "source": "(+)ss_gRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "ds_space_gRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t147",
+    "source": "Host_space_translation_phenotype",
+    "target": "Nsp1",
+    "sign": false
+   },
+   {
+    "id": "t148",
+    "source": "S_SARS-CoV-2_space_virion",
+    "target": "S_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "sign": true
+   },
+   {
+    "id": "t149",
+    "source": "S_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "S_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t150",
+    "source": "Orf9b_space_ds_space_sgmRNA_rna",
+    "target": "Orf9b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t151",
+    "source": "Orf9b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t152",
+    "source": "Orf3a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t153",
+    "source": "M_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t154",
+    "source": "Orf7b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t155",
+    "source": "ds_space_gRNA_rna",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t156",
+    "source": "N_space_space_(-)ss_space_sgmRNA_rna",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t157",
+    "source": "S_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t158",
+    "source": "Orf8_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t159",
+    "source": "Orf6_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t160",
+    "source": "E_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t161",
+    "source": "Orf14_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t162",
+    "source": "Orf7a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "target": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t163",
+    "source": "E_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "E_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t164",
+    "source": "E_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "E_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t165",
+    "source": "Orf9b_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf9b_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t166",
+    "source": "Orf9b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf9b_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t167",
+    "source": "M_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "M_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t168",
+    "source": "M_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "M_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t169",
+    "source": "Orf9b_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Orf9b_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t170",
+    "source": "Orf3a_space_ds_space_sgmRNA_rna",
+    "target": "Orf3a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t171",
+    "source": "Nsp13",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t172",
+    "source": "Nsp7",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t173",
+    "source": "Nsp16",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t174",
+    "source": "Nsp12",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t175",
+    "source": "Nsp14",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t176",
+    "source": "Nsp10",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t177",
+    "source": "Nsp9",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t178",
+    "source": "Nsp8",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t179",
+    "source": "Nsp6_endoplasmic_reticulum",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t180",
+    "source": "Nsp15",
+    "target": "pp1ab_space_nsp6-16",
+    "sign": true
+   },
+   {
+    "id": "t181",
+    "source": "pp1ab_space_nsp6-16",
+    "target": "pp1ab_space_Nsp3-16_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t182",
+    "source": "Nsp5_epithelial_space_cell",
+    "target": "pp1ab_space_Nsp3-16_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t183",
+    "source": "Nsp3-4",
+    "target": "pp1ab_space_Nsp3-16_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t185",
+    "source": "E_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "E_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t186",
+    "source": "E_rough_space_endoplasmic_space_reticulum",
+    "target": "E_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t187",
+    "source": "E_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t188",
+    "source": "Orf3a_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t189",
+    "source": "Orf9b_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t190",
+    "source": "Orf6_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t191",
+    "source": "Orf7a_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t192",
+    "source": "Orf14_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t193",
+    "source": "S_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t194",
+    "source": "Orf7b_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t195",
+    "source": "M_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t196",
+    "source": "Orf8_rough_space_endoplasmic_space_reticulum",
+    "target": "Host_space_translation_space_complex_complex_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t197",
+    "source": "Orf14_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Orf14_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t198",
+    "source": "M_space_ds_space_sgmRNA_rna",
+    "target": "M_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t199",
+    "source": "Nsp13",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t200",
+    "source": "Nsp7",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t201",
+    "source": "Nsp16",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t202",
+    "source": "Nsp12",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t203",
+    "source": "Nsp14",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t204",
+    "source": "Nsp10",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t205",
+    "source": "Nsp9",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t206",
+    "source": "Nsp8",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t207",
+    "source": "Nsp6_endoplasmic_reticulum",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t208",
+    "source": "Nsp15",
+    "target": "Nsp5_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t209",
+    "source": "Nsp1",
+    "target": "pp1a",
+    "sign": true
+   },
+   {
+    "id": "t210",
+    "source": "Nsp2",
+    "target": "pp1a",
+    "sign": true
+   },
+   {
+    "id": "t211",
+    "source": "pp1a_space_Nsp3-11_endoplasmic_reticulum",
+    "target": "pp1a",
+    "sign": true
+   },
+   {
+    "id": "t212",
+    "source": "pp1a",
+    "target": "(+)ss_space_gRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t213",
+    "source": "pp1ab",
+    "target": "(+)ss_space_gRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t214",
+    "source": "(-)ss_space_gRNA_rna_epithelial_space_cell",
+    "target": "(+)ss_space_gRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t215",
+    "source": "pp1a",
+    "target": "Host_space_translation_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t216",
+    "source": "pp1ab",
+    "target": "Host_space_translation_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t217",
+    "source": "Nsp1",
+    "target": "pp1ab",
+    "sign": true
+   },
+   {
+    "id": "t218",
+    "source": "Nsp2",
+    "target": "pp1ab",
+    "sign": true
+   },
+   {
+    "id": "t219",
+    "source": "pp1ab_space_Nsp3-16_endoplasmic_reticulum",
+    "target": "pp1ab",
+    "sign": true
+   },
+   {
+    "id": "t220",
+    "source": "Orf14_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf14_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t221",
+    "source": "Orf14_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf14_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t222",
+    "source": "Orf14_space_ds_space_sgmRNA_rna",
+    "target": "Orf14_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t223",
+    "source": "E_space_ds_space_sgmRNA_rna",
+    "target": "E_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t224",
+    "source": "Orf7b_space_ds_space_sgmRNA_rna",
+    "target": "Orf7b_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t226",
+    "source": "Nsp3",
+    "target": "Nsp3-4_glycosylated",
+    "sign": true
+   },
+   {
+    "id": "t227",
+    "source": "Nsp4_endoplasmic_reticulum",
+    "target": "Nsp3-4_glycosylated",
+    "sign": true
+   },
+   {
+    "id": "t228",
+    "source": "Nsp3-4_glycosylated",
+    "target": "Nsp3-4",
+    "sign": true
+   },
+   {
+    "id": "t229",
+    "source": "Nsp7",
+    "target": "pp1a_space_Nsp6-11",
+    "sign": true
+   },
+   {
+    "id": "t230",
+    "source": "Nsp10",
+    "target": "pp1a_space_Nsp6-11",
+    "sign": true
+   },
+   {
+    "id": "t231",
+    "source": "Nsp9",
+    "target": "pp1a_space_Nsp6-11",
+    "sign": true
+   },
+   {
+    "id": "t232",
+    "source": "Nsp8",
+    "target": "pp1a_space_Nsp6-11",
+    "sign": true
+   },
+   {
+    "id": "t233",
+    "source": "Nsp6_endoplasmic_reticulum",
+    "target": "pp1a_space_Nsp6-11",
+    "sign": true
+   },
+   {
+    "id": "t234",
+    "source": "Nsp11",
+    "target": "pp1a_space_Nsp6-11",
+    "sign": true
+   },
+   {
+    "id": "t235",
+    "source": "Nsp7",
+    "target": "Nsp5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t236",
+    "source": "Nsp10",
+    "target": "Nsp5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t237",
+    "source": "Nsp9",
+    "target": "Nsp5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t238",
+    "source": "Nsp8",
+    "target": "Nsp5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t239",
+    "source": "Nsp6_endoplasmic_reticulum",
+    "target": "Nsp5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t240",
+    "source": "Nsp11",
+    "target": "Nsp5_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t241",
+    "source": "Orf8_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf8_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t242",
+    "source": "Orf8_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf8_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t243",
+    "source": "Orf6_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf6_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t244",
+    "source": "Orf6__(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf6_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t245",
+    "source": "S2_epithelial_space_cell",
+    "target": "FURIN",
+    "sign": true
+   },
+   {
+    "id": "t246",
+    "source": "ACE2_epithelial_space_cell",
+    "target": "FURIN",
+    "sign": true
+   },
+   {
+    "id": "t247",
+    "source": "ACE2_default_compartment",
+    "target": "FURIN",
+    "sign": true
+   },
+   {
+    "id": "t248",
+    "source": "S1_default_compartment",
+    "target": "FURIN",
+    "sign": true
+   },
+   {
+    "id": "t249",
+    "source": "S2_epithelial_space_cell",
+    "target": "TMPRSS2",
+    "sign": true
+   },
+   {
+    "id": "t250",
+    "source": "ACE2_epithelial_space_cell",
+    "target": "TMPRSS2",
+    "sign": true
+   },
+   {
+    "id": "t251",
+    "source": "ACE2_default_compartment",
+    "target": "TMPRSS2",
+    "sign": true
+   },
+   {
+    "id": "t252",
+    "source": "S1_default_compartment",
+    "target": "TMPRSS2",
+    "sign": true
+   },
+   {
+    "id": "t253",
+    "source": "S2_epithelial_space_cell",
+    "target": "Camostat_space_mesylate_drug",
+    "sign": false
+   },
+   {
+    "id": "t254",
+    "source": "ACE2_epithelial_space_cell",
+    "target": "Camostat_space_mesylate_drug",
+    "sign": false
+   },
+   {
+    "id": "t255",
+    "source": "ACE2_default_compartment",
+    "target": "Camostat_space_mesylate_drug",
+    "sign": false
+   },
+   {
+    "id": "t256",
+    "source": "S1_default_compartment",
+    "target": "Camostat_space_mesylate_drug",
+    "sign": false
+   },
+   {
+    "id": "t257",
+    "source": "Orf7b_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf7b_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t258",
+    "source": "Orf7b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf7b_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t259",
+    "source": "N_space_(-)ss_space_sgmRNA_rna",
+    "target": "N_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t260",
+    "source": "N_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "N_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t261",
+    "source": "N_space_ds_space_sgmRNA_rna",
+    "target": "N_space_space_(-)ss_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t263",
+    "source": "E_SARS-CoV-2_space_virion",
+    "target": "E_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "sign": true
+   },
+   {
+    "id": "t264",
+    "source": "Nsp3-4",
+    "target": "pp1a_space_Nsp3-11_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t265",
+    "source": "pp1a_space_Nsp6-11",
+    "target": "pp1a_space_Nsp3-11_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t266",
+    "source": "Nsp5_endoplasmic_reticulum",
+    "target": "pp1a_space_Nsp3-11_endoplasmic_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t267",
+    "source": "Orf7b_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Orf7b_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t268",
+    "source": "Orf3a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Orf3a_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t269",
+    "source": "Orf3a_rough_space_endoplasmic_space_reticulum",
+    "target": "Orf3a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t270",
+    "source": "Orf9b_rough_space_endoplasmic_space_reticulum",
+    "target": "Orf9b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t271",
+    "source": "Orf6_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Orf6_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t272",
+    "source": "Orf6_rough_space_endoplasmic_space_reticulum",
+    "target": "Orf6__(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t273",
+    "source": "Orf6_space_ds_space_sgmRNA_rna",
+    "target": "Orf6_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t274",
+    "source": "Orf7a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Orf7a_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t275",
+    "source": "Orf7a_rough_space_endoplasmic_space_reticulum",
+    "target": "Orf7a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t277",
+    "source": "Orf8_space_ds_space_sgmRNA_rna",
+    "target": "Orf8_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t278",
+    "source": "Orf7a_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf7a_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t279",
+    "source": "Orf7a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf7a_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t280",
+    "source": "M_SARS-CoV-2_space_virion",
+    "target": "M_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "sign": true
+   },
+   {
+    "id": "t281",
+    "source": "N_epithelial_space_cell",
+    "target": "N_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t282",
+    "source": "N_epithelial_space_cell",
+    "target": "Host_space_translation_space_complex_complex_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t283",
+    "source": "S_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "S_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t284",
+    "source": "S_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "S_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t285",
+    "source": "S_space_ds_space_sgmRNA_rna",
+    "target": "S_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t286",
+    "source": "Orf7a_SARS-CoV-2_space_virion",
+    "target": "Orf7a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "sign": true
+   },
+   {
+    "id": "t287",
+    "source": "Orf14_rough_space_endoplasmic_space_reticulum",
+    "target": "Orf14_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t288",
+    "source": "S_rough_space_endoplasmic_space_reticulum",
+    "target": "S_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t290",
+    "source": "S2_SARS-CoV-2_space_virion",
+    "target": "ACE2:SPIKE_space_complex_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t291",
+    "source": "S1_endosome",
+    "target": "ACE2:SPIKE_space_complex_complex_SARS-CoV-2_space_virion",
+    "sign": true
+   },
+   {
+    "id": "t292",
+    "source": "S2_SARS-CoV-2_space_virion",
+    "target": "CTSB",
+    "sign": true
+   },
+   {
+    "id": "t293",
+    "source": "S1_endosome",
+    "target": "CTSB",
+    "sign": true
+   },
+   {
+    "id": "t294",
+    "source": "S2_SARS-CoV-2_space_virion",
+    "target": "CTSL",
+    "sign": true
+   },
+   {
+    "id": "t295",
+    "source": "S1_endosome",
+    "target": "CTSL",
+    "sign": true
+   },
+   {
+    "id": "t296",
+    "source": "Orf8_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "Orf8_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t297",
+    "source": "Orf7b_rough_space_endoplasmic_space_reticulum",
+    "target": "Orf7b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t298",
+    "source": "Orf7a_space_ds_space_sgmRNA_rna",
+    "target": "Orf7a_space_(-)ss_space_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t299",
+    "source": "Orf3a_space_(-)ss_space_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf3a_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t300",
+    "source": "Orf3a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "target": "Orf3a_space_ds_space_sgmRNA_rna",
+    "sign": true
+   },
+   {
+    "id": "t301",
+    "source": "M_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "target": "M_rough_space_endoplasmic_space_reticulum",
+    "sign": true
+   },
+   {
+    "id": "t302",
+    "source": "M_rough_space_endoplasmic_space_reticulum",
+    "target": "M_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t303",
+    "source": "Orf3a_lysosome",
+    "target": "Orf3a_endoplasmic_space_reticulum-Golgi_space_intermediate_space_compartment",
+    "sign": true
+   },
+   {
+    "id": "t304",
+    "source": "Orf8_rough_space_endoplasmic_space_reticulum",
+    "target": "Orf8_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "sign": true
+   },
+   {
+    "id": "t305",
+    "source": "(+)ss_gRNA_rna_epithelial_space_cell",
+    "target": "(+)ss_gRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t306",
+    "source": "N_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "N_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t307",
+    "source": "M_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "M_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t308",
+    "source": "S_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "S_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t309",
+    "source": "E_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "E_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t310",
+    "source": "Orf6__(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "Orf6__(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t311",
+    "source": "Orf7a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "Orf7a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t312",
+    "source": "Orf3a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "Orf3a_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t313",
+    "source": "Orf8_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "Orf8_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t314",
+    "source": "Orf7a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t315",
+    "source": "S_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t316",
+    "source": "Orf6__(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t317",
+    "source": "E_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t318",
+    "source": "Orf3a_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t319",
+    "source": "M_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t320",
+    "source": "Orf8_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t321",
+    "source": "N_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t322",
+    "source": "(+)ss_gRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t323",
+    "source": "Orf9b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t324",
+    "source": "Orf14_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t325",
+    "source": "Orf7b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "DMV_molecular_pore_complex",
+    "sign": true
+   },
+   {
+    "id": "t326",
+    "source": "Orf9b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "Orf9b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t327",
+    "source": "Orf14_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "Orf14_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   },
+   {
+    "id": "t328",
+    "source": "Orf7b_(+)ss_sgmRNA_rna_epithelial_space_cell",
+    "target": "Orf7b_(+)ss_sgmRNA_rna_double_space_membrane_space_vesicle_space_viral_space_factory",
+    "sign": true
+   }
+  ],
+  "parameters": []
+ },
+ "metadata": {
+  "annotations": {
+   "license": null,
+   "authors": [],
+   "references": [
+    "pubmed:34664389"
+   ],
+   "time_scale": null,
+   "time_start": null,
+   "time_end": null,
+   "locations": [],
+   "pathogens": [
+    "ncbitaxon:2697049"
+   ],
+   "diseases": [
+    "doid:0080600"
+   ],
+   "hosts": [
+    "ncbitaxon:9606"
+   ],
+   "model_types": []
+  }
+ }
+}


### PR DESCRIPTION
This PR is a follow-up to #283 to add the actual AMR JSONs for the COVID-19 Disease Map, along with a few improvements in the core modules as well as the generation script.