### PR TITLE
Fix TemplateModel json I/O

### DIFF
--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -427,7 +427,13 @@ class Template(BaseModel):
         # Handle concepts
         for concept_key in stmt_cls.concept_keys:
             if concept_key in data:
-                data[concept_key] = Concept.from_json(data[concept_key])
+                concept_data = data[concept_key]
+                # Handle lists of concepts for e.g. controllers in
+                # GroupedControlledConversion
+                if isinstance(concept_data, list):
+                    data[concept_key] = [Concept.from_json(c) for c in concept_data]
+                else:
+                    data[concept_key] = Concept.from_json(data[concept_key])
 
         return stmt_cls(**{k: v for k, v in data.items()
                            if k not in {'rate_law', 'type'}},

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -48,5 +48,7 @@ def test_templates():
         except Exception as e:
             failed.append((templ_cls, str(e)))
     if failed:
-        print(failed)
+        print(f"{len(failed)} roundtrips failed")
+        for f in failed:
+            print(f)
         raise AssertionError(f"{len(failed)} roundtrips failed")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,52 @@
+"""Test for metamodel io operations."""
+import tempfile
+
+from mira.metamodel import *
+
+# List all templates classes
+template_cls_list = Template.__subclasses__()
+
+# Create Concepts for testing
+controller1 = Concept(name="controller1")
+controller2 = Concept(name="controller2")
+subject = Concept(name="subject1")
+outcome = Concept(name="outcome1")
+
+
+def _check_roundtrip(tm: TemplateModel):
+    # Test json serialization and deserialization
+
+    # Get a temporary file
+    with tempfile.NamedTemporaryFile(suffix=".json") as temp_file:
+        # Write the model to the file
+        model_to_json_file(tm, temp_file.name)
+        # Read the model from the file
+        tm2 = model_from_json_file(temp_file.name)
+        # Check that the models are the same
+        for t1, t2 in zip(tm.templates, tm2.templates):
+            assert t1.is_equal_to(t2)
+
+
+def test_templates():
+    failed = []
+    for templ_cls in template_cls_list:
+        # Create the template
+        template = templ_cls(
+            # As long as the BaseModel is allowed to accept unused
+            # arguments, we can pass all the arguments to the constructor.
+            # The unused arguments will be ignored.
+            controller=controller1,
+            subject=subject,
+            outcome=outcome,
+            controllers=[controller1, controller2]
+        )
+        # Create the template model
+        tm = TemplateModel(templates=[template])
+        # Check the roundtrip
+        try:
+            _check_roundtrip(tm)
+        except Exception as e:
+            failed.append((templ_cls, str(e)))
+    if failed:
+        print(failed)
+        raise AssertionError(f"{len(failed)} roundtrips failed")


### PR DESCRIPTION
This PR fixes a bug in the JSON deserialization to TemplateModel in mira/metamodel/io.py where `Grouped...` type templates errored.

A test is added to test the roundtrip to JSON.