### PR TITLE
Process ODE semantics from regnet AMR

### DIFF
--- a/mira/sources/amr/regnet.py
+++ b/mira/sources/amr/regnet.py
@@ -97,7 +97,7 @@ def template_model_from_amr_json(model_json) -> TemplateModel:
             rate_obj = rates.get(vertex['id'], {})
             if rate_obj:
                 rate_law = get_sympy(rate_obj, local_dict=symbols)
-                template.rate_law = rate_law
+                template.rate_law = SympyExprStr(rate_law)
             elif vertex.get('rate_constant') is not None:
                 template.set_mass_action_rate_law(vertex['rate_constant'])
             templates.append(template)
@@ -140,7 +140,7 @@ def template_model_from_amr_json(model_json) -> TemplateModel:
         rate_obj = rates.get(edge_id, {})
         if rate_obj:
             rate_law = get_sympy(rate_obj, local_dict=symbols)
-            template.rate_law = rate_law
+            template.rate_law = SympyExprStr(rate_law)
         else:
             rate_constant = props.get('rate_constant')
             if rate_constant is not None:

--- a/tests/test_amr_source.py
+++ b/tests/test_amr_source.py
@@ -124,17 +124,27 @@ def test_regnet_rate_laws():
                 name='replication',
                 controller=Concept(name='A'),
                 subject=Concept(name='B'),
-                rate_law=SympyExprStr(sympy.sympify('k * A * B'))
+                rate_law=SympyExprStr(sympy.sympify('k * A * B / (1 + B)'))
             ),
-            ControlledDegradation(
+            NaturalDegradation(
                 name='degradation',
-                controller=Concept(name='A'),
                 subject=Concept(name='B'),
                 rate_law=SympyExprStr(sympy.sympify('k * B'))
             )
-        ]
+        ],
+        observables={
+            'obs1': Observable(
+                name='obs1',
+                expression=SympyExprStr(sympy.sympify('A + B')),
+                display_name='obs1'
+            )
+        },
+        time=Time(name='timexx')
     )
     amr_json = template_model_to_regnet_json(template_model)
     tm = regnet.template_model_from_amr_json(amr_json)
     assert isinstance(tm.templates[0].rate_law, SympyExprStr)
     assert isinstance(tm.templates[1].rate_law, SympyExprStr)
+    assert tm.templates[1].rate_law.args[0].equals(sympy.sympify('k * A * B / (1 + B)'))
+    assert tm.time.name == 'timexx'
+    assert isinstance(tm.observables['obs1'].expression, SympyExprStr)


### PR DESCRIPTION
This PR implements processing custom ODE semantics from regnets when ingesting AMRs. This is a follow up to #296 which implemented this on the output side.

Fixes #304