### PR TITLE
Handle float and int in expression constructor

### DIFF
--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -43,6 +43,10 @@ class SympyExprStr(sympy.Expr):
     def validate(cls, v):
         if isinstance(v, cls):
             return v
+        elif isinstance(v, float):
+            return cls(sympy.Float(v))
+        elif isinstance(v, int):
+            return cls(sympy.Integer(v))
         return cls(v)
 
     @classmethod

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -250,3 +250,12 @@ def test_safe_parse_curly_braces():
     var = 'x_{a}'
     var_sym = sympy.Symbol('x_{a}')
     assert safe_parse_expr(var, local_dict={var: var_sym}) == var_sym
+
+
+def test_initial_expression_float():
+    init = Initial(concept=Concept(name='x'), expression=1.0)
+    assert isinstance(init.expression, SympyExprStr)
+    assert isinstance(init.expression.args[0], sympy.Expr)
+    init = Initial(concept=Concept(name='x'), expression=1)
+    assert isinstance(init.expression, SympyExprStr)
+    assert isinstance(init.expression.args[0], sympy.Expr)


### PR DESCRIPTION
This PR streamlines the construction of expressions that are just numbers, for instance, when constructing `Initial` objects. Previously, one had to do
```python
Initial(expression=sympy.Float(0.1)
```
to get a valid `Initial`. After this PR, it suffices to do
```python
Initial(expression=0.1)
```
Important to note that this only works in _constructors_ of pydantic classes where the given Field is a SympyExprStr. If an expression is _assigned_ to an attribute of an existing object, one still has to explicitly construct e.g., `SympyExprStr(sympy.Float(0.1))`.