### PR TITLE
Handle superscripts in expressions

### DIFF
--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -12,6 +12,8 @@ def get_parseable_expression(s: str) -> str:
     s = s.replace('lambda', 'XXlambdaXX')
     # Handle dots which also cannot be parsed
     s = re.sub(r'\.(?=\D)', 'XX_XX', s)
+    # Handle superscripts which are not allowed in sympy
+    s = re.sub(r"\^{(.*?)}", r"XXCXX{_\1}", s)
     # Handle curly braces which are not allowed in sympy
     s = s.replace('{', 'XXCBO').replace('}', 'XXCBC')
     s = unicodedata.normalize('NFKC', s)
@@ -20,6 +22,7 @@ def get_parseable_expression(s: str) -> str:
 
 def revert_parseable_expression(s: str) -> str:
     """Return an expression to its original form."""
+    s = s.replace('XXCXX', '^')
     s = s.replace('XXCBO', '{').replace('XXCBC', '}')
     s = s.replace('XX_XX', '.')
     s = s.replace('XXlambdaXX', 'lambda')

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -251,6 +251,10 @@ def test_safe_parse_curly_braces():
     var_sym = sympy.Symbol('x_{a}')
     assert safe_parse_expr(var, local_dict={var: var_sym}) == var_sym
 
+    var = 'x_{z}^{abc}'
+    var_sym = sympy.Symbol('x_{z}^{abc}')
+    assert safe_parse_expr(var, local_dict={var: var_sym}) == var_sym
+
 
 def test_initial_expression_float():
     init = Initial(concept=Concept(name='x'), expression=1.0)


### PR DESCRIPTION
This PR handles things like `a_{b}^{xyz}` where `^` cannot typically be parsed in expressions, even if a local symbol is declared containing it.