### PR TITLE
Reimplement stratification logic for parameter consistency

### DIFF
--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -73,7 +73,7 @@ def get_entity(
     curie: str = Path(
         ...,
         description="A compact URI (CURIE) for an entity in the form of ``<prefix>:<local unique identifier>``",
-        example="ido:0000511",
+        examples=["ido:0000511"],
     ),
 ):
     """Get information about an entity (e.g., its name, description synonyms, alternative identifiers,
@@ -97,7 +97,7 @@ def get_entities(
         ...,
         description="A comma-separated list of compact URIs (CURIEs) for an "
         "entity in the form of ``<prefix>:<local unique identifier>,...``",
-        example="ido:0000511,ido:0000512",
+        examples=["ido:0000511,ido:0000512"],
     ),
 ):
     """
@@ -158,7 +158,7 @@ def get_transitive_closure(
     relation_types: List[str] = Query(
         ...,
         description="A list of relation types to get a transitive closure for",
-        example=DKG_REFINER_RELS,
+        examples=[DKG_REFINER_RELS],
     ),
 ):
     """Get a transitive closure of the requested type(s)"""
@@ -384,13 +384,13 @@ def is_ontological_child(
 )
 def search(
     request: Request,
-    q: str = Query(..., example="infect", description="The search query"),
+    q: str = Query(..., examples=["infect"], description="The search query"),
     limit: int = 25,
     offset: int = 0,
     prefixes: Optional[str] = Query(
         default=None,
         description="A comma-separated list of prefixes",
-        examples={
+        examples=[{
             "no prefix filter": {
                 "summary": "Don't filter by prefix",
                 "value": None,
@@ -399,7 +399,7 @@ def search(
                 "summary": "Search for units, which have Wikidata prefixes",
                 "value": "wikidata",
             },
-        },
+        }],
     ),
     labels: Optional[str] = Query(
         default=None,

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -149,7 +149,7 @@ def ground_get(
         description="The text to be grounded. Warning: grounding does not work well for "
         "substring matches, i.e., if searching only for 'infected'. In these "
         "cases, using the search API is more appropriate.",
-        example="Infected Population",
+        examples=["Infected Population"],
     ),
 ):
     """Ground text with Gilda."""

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -110,8 +110,6 @@ def stratify(
     :
         A stratified template model
     """
-    strata = sorted(strata)
-
     if strata_name_lookup and strata_curie_to_name is None:
         from mira.dkg.web_client import get_entities_web, MissingBaseUrlError
         try:

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -199,8 +199,8 @@ def stratify(
             if not stratify_controllers:
                 # We only need to do this if we stratified any of the non-controllers
                 if any_noncontrollers_stratified:
-                    template_strata = [stratum_idx if
-                                       param_renaming_uses_strata_names else stratum]
+                    template_strata = [stratum if
+                                       param_renaming_uses_strata_names else stratum_idx]
                     param_mappings = rewrite_rate_law(template_model=template_model,
                                                       old_template=template,
                                                       new_template=new_template,
@@ -222,14 +222,15 @@ def stratify(
                 for c_strata_tuple in itt.product(strata, repeat=ncontrollers):
                     stratified_template = deepcopy(new_template)
                     stratified_controllers = stratified_template.get_controllers()
-                    template_strata = [stratum_idx if param_renaming_uses_strata_names else stratum]
+                    template_strata = [stratum if param_renaming_uses_strata_names
+                                       else stratum_idx]
                     # We now apply the stratum assigned to each controller in this particular
                     # tuple to the controller
                     for controller, c_stratum in zip(stratified_controllers, c_strata_tuple):
                         controller.with_context(do_rename=modify_names, inplace=True,
                                                 **{key: c_stratum})
-                        template_strata.append(stratum_index_map[c_stratum]
-                                               if param_renaming_uses_strata_names else c_stratum)
+                        template_strata.append(c_stratum if param_renaming_uses_strata_names
+                                               else stratum_index_map[c_stratum])
 
                     # Wew can now rewrite the rate law for this stratified template,
                     # then append the new template

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -380,7 +380,7 @@ def rewrite_rate_law(
                                          old_template.get_controllers()}:
             has_subject_controller_overlap = True
 
-    # Step 2. Rename symbols based on the new concepts
+    # Step 1. Rename controllers
     for old_controller, new_controller in zip(
         old_template.get_controllers(), new_template.get_controllers(),
     ):
@@ -402,7 +402,7 @@ def rewrite_rate_law(
                 sympy.Symbol(new_controller.name),
             )
 
-    # Step 3. Rename subject and object
+    # Step 2. Rename subject and object
     old_cbr = old_template.get_concepts_by_role()
     new_cbr = new_template.get_concepts_by_role()
     if "subject" in old_cbr and "subject" in new_cbr:
@@ -416,7 +416,9 @@ def rewrite_rate_law(
             sympy.Symbol(new_template.outcome.name),
         )
 
-    # Step 1. Identify the mass action symbol and rename it with a
+    # Step 3. Rename parameters by generating new parameters
+    # named according to the strata that were applied to the
+    # given template
     parameters = list(template_model.get_parameters_from_rate_law(rate_law))
     param_mappings = {}
     for parameter in parameters:

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -28,7 +28,6 @@ logger = logging.getLogger(__name__)
 
 def stratify(
     template_model: TemplateModel,
-    *,
     key: str,
     strata: Collection[str],
     strata_curie_to_name: Optional[Mapping[str, str]] = None,
@@ -181,7 +180,8 @@ def stratify(
             # We apply this stratum to each concept except for controllers
             # in case we will separately stratify those
             for concept in new_template.get_concepts_flat(
-                    exclude_controllers=stratify_controllers):
+                    exclude_controllers=stratify_controllers,
+                    refresh=True):
                 if concept.name in exclude_concepts:
                     continue
                 concept.with_context(

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -165,7 +165,7 @@ def stratify(
             templates.append(deepcopy(template))
             continue
 
-        # Generate a derived template for each strata
+        # Generate a derived template for each stratum
         for stratum in strata:
             new_template = template.with_context(
                 do_rename=modify_names, exclude_concepts=exclude_concepts,
@@ -362,27 +362,6 @@ def rewrite_rate_law(
                                          old_template.get_controllers()}:
             has_subject_controller_overlap = True
 
-    # Step 1. Identify the mass action symbol and rename it with a
-    parameters = list(template_model.get_parameters_from_rate_law(rate_law))
-    for parameter in parameters:
-        # If a parameter is explicitly listed as one to preserve, then
-        # don't stratify it
-        if params_to_preserve is not None and parameter in params_to_preserve:
-            continue
-        # If we have an explicit stratification list then if something isn't
-        # in the list then don't stratify it.
-        elif params_to_stratify is not None and parameter not in params_to_stratify:
-            continue
-        # Otherwise we go ahead with stratification, i.e., in cases
-        # where nothing was said about parameter stratification or the
-        # parameter was listed explicitly to be stratified
-        else:
-            rate_law = rate_law.subs(
-                parameter,
-                sympy.Symbol(f"{parameter}_{params_count[parameter]}")
-            )
-            params_count[parameter] += 1  # increment this each time to keep unique
-
     # Step 2. Rename symbols based on the new concepts
     for old_controller, new_controller in zip(
         old_template.get_controllers(), new_template.get_controllers(),
@@ -418,6 +397,28 @@ def rewrite_rate_law(
             sympy.Symbol(old_template.outcome.name),
             sympy.Symbol(new_template.outcome.name),
         )
+
+    # Step 1. Identify the mass action symbol and rename it with a
+    parameters = list(template_model.get_parameters_from_rate_law(rate_law))
+    for parameter in parameters:
+        # If a parameter is explicitly listed as one to preserve, then
+        # don't stratify it
+        if params_to_preserve is not None and parameter in params_to_preserve:
+            continue
+        # If we have an explicit stratification list then if something isn't
+        # in the list then don't stratify it.
+        elif params_to_stratify is not None and parameter not in params_to_stratify:
+            continue
+        # Otherwise we go ahead with stratification, i.e., in cases
+        # where nothing was said about parameter stratification or the
+        # parameter was listed explicitly to be stratified
+        else:
+            rate_law = rate_law.subs(
+                parameter,
+                sympy.Symbol(f"{parameter}_{params_count[parameter]}")
+            )
+            params_count[parameter] += 1  # increment this each time to keep unique
+
 
     new_template.rate_law = rate_law
 

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -590,7 +590,8 @@ class Template(BaseModel):
             )
         return [getattr(self, k) for k in self.concept_keys]
 
-    def get_concepts_flat(self, exclude_controllers=False) -> List[Concept]:
+    def get_concepts_flat(self, exclude_controllers=False,
+                          refresh=False) -> List[Concept]:
         """Return the concepts in this template as a flat list.
 
         Attributes where a list of concepts is expected are flattened.
@@ -600,9 +601,13 @@ class Template(BaseModel):
             if role in {'controllers', 'controller'} and exclude_controllers:
                 continue
             if isinstance(value, list):
-                concepts_flat.extend(value)
+                if refresh:
+                    setattr(self, role, [deepcopy(v) for v in value])
+                concepts_flat.extend(getattr(self, role))
             else:
-                concepts_flat.append(value)
+                if refresh:
+                    setattr(self, role, deepcopy(value))
+                concepts_flat.append(getattr(self, role))
         return concepts_flat
 
     def get_concepts_by_role(self) -> Dict[str, Concept]:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -590,17 +590,19 @@ class Template(BaseModel):
             )
         return [getattr(self, k) for k in self.concept_keys]
 
-    def get_concepts_flat(self) -> List[Concept]:
+    def get_concepts_flat(self, exclude_controllers=False) -> List[Concept]:
         """Return the concepts in this template as a flat list.
 
         Attributes where a list of concepts is expected are flattened.
         """
         concepts_flat = []
-        for concept in self.get_concepts():
-            if isinstance(concept, list):
-                concepts_flat.extend(concept)
+        for role, value in self.get_concepts_by_role().items():
+            if role in {'controllers', 'controller'} and exclude_controllers:
+                continue
+            if isinstance(value, list):
+                concepts_flat.extend(value)
             else:
-                concepts_flat.append(concept)
+                concepts_flat.append(value)
         return concepts_flat
 
     def get_concepts_by_role(self) -> Dict[str, Concept]:

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -132,7 +132,8 @@ class Concept(BaseModel):
             SympyExprStr: lambda e: sympy.parse_expr(e)
         }
 
-    def with_context(self, do_rename=False, curie_to_name_map=None, **context) -> "Concept":
+    def with_context(self, do_rename=False, curie_to_name_map=None,
+                     inplace=False, **context) -> "Concept":
         """Return this concept with extra context.
 
         Parameters
@@ -146,6 +147,10 @@ class Concept(BaseModel):
             the context values are e.g. curies or longer names that should
             be shortened, like {"New York City": "nyc"}. If not provided (
             default behavior), the context values will be used as names.
+        inplace : bool
+            If True, modify the concept in place. Default: False.
+        **context :
+            The context to add to the concept.
 
         Returns
         -------
@@ -164,14 +169,20 @@ class Concept(BaseModel):
             name = '_'.join(name_list)
         else:
             name = self.name
-        concept = Concept(
-            name=name,
-            display_name=self.display_name,
-            identifiers=self.identifiers,
-            context=dict(ChainMap(context, self.context)),
-            units=self.units,
-        )
-        concept._base_name = self._base_name
+        full_context = dict(ChainMap(context, self.context))
+        if inplace:
+            self.name = name
+            self.context = full_context
+            concept = self
+        else:
+            concept = Concept(
+                name=name,
+                display_name=self.display_name,
+                identifiers=self.identifiers,
+                context=full_context,
+                units=self.units,
+            )
+            concept._base_name = self._base_name
         return concept
 
     def get_curie(self, config: Optional[Config] = None) -> Tuple[str, str]:
@@ -565,7 +576,7 @@ class Template(BaseModel):
         """
         raise NotImplementedError("This method can only be called on subclasses")
 
-    def get_concepts(self) -> List[Concept]:
+    def get_concepts(self) -> List[Union[Concept, List[Concept]]]:
         """Return the concepts in this template.
 
         Returns
@@ -578,6 +589,19 @@ class Template(BaseModel):
                 "This method can only be called on subclasses of Template"
             )
         return [getattr(self, k) for k in self.concept_keys]
+
+    def get_concepts_flat(self) -> List[Concept]:
+        """Return the concepts in this template as a flat list.
+
+        Attributes where a list of concepts is expected are flattened.
+        """
+        concepts_flat = []
+        for concept in self.get_concepts():
+            if isinstance(concept, list):
+                concepts_flat.extend(concept)
+            else:
+                concepts_flat.append(concept)
+        return concepts_flat
 
     def get_concepts_by_role(self) -> Dict[str, Concept]:
         """Return the concepts in this template as a dict keyed by role.
@@ -620,7 +644,7 @@ class Template(BaseModel):
         interactors = controllers + ([subject] if subject else [])
         return interactors
 
-    def get_controllers(self):
+    def get_controllers(self) -> List[Concept]:
         """Return the controllers in this template.
 
         Returns

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -231,12 +231,13 @@ class TestModelApi(unittest.TestCase):
         response = self.client.post("/api/stratify", json=query_json)
         self.assertEqual(200, response.status_code)
         resp_json_str = sorted_json_str(response.json())
+        strat_tm_api = TemplateModel.from_json(response.json())
 
         strat_templ_model = stratify(
             template_model=sir_templ_model,
             key=key,
-            strata=set(strata),
-            strata_curie_to_name=strata_name_map
+            strata=strata,
+            strata_curie_to_name=strata_name_map,
         )
         strat_str = sorted_json_str(strat_templ_model.dict())
 

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -231,7 +231,6 @@ class TestModelApi(unittest.TestCase):
         response = self.client.post("/api/stratify", json=query_json)
         self.assertEqual(200, response.status_code)
         resp_json_str = sorted_json_str(response.json())
-        strat_tm_api = TemplateModel.from_json(response.json())
 
         strat_templ_model = stratify(
             template_model=sir_templ_model,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -5,8 +5,6 @@ from collections import Counter
 from copy import deepcopy as _d
 
 import sympy
-import requests
-import itertools
 
 from mira.metamodel import *
 from mira.metamodel.ops import stratify, simplify_rate_law, counts_to_dimensionless
@@ -51,8 +49,8 @@ class TestOperations(unittest.TestCase):
             controller=infected.with_context(vaccination_status="unvaccinated",
                                              do_rename=True),
             rate_law=safe_parse_expr(
-                'beta_0 * susceptible_population_unvaccinated * infected_population_unvaccinated',
-                local_dict={'beta_0': sympy.Symbol('beta_0')}
+                'beta_0_0 * susceptible_population_unvaccinated * infected_population_unvaccinated',
+                local_dict={'beta_0_0': sympy.Symbol('beta_0_0')}
             )
         )
         expected_1 = ControlledConversion(
@@ -63,8 +61,8 @@ class TestOperations(unittest.TestCase):
             controller=infected.with_context(vaccination_status="vaccinated",
                                              do_rename=True),
             rate_law=safe_parse_expr(
-                'beta_1 * susceptible_population_unvaccinated * infected_population_vaccinated',
-                local_dict={'beta_1': sympy.Symbol('beta_1')}
+                'beta_0_1 * susceptible_population_unvaccinated * infected_population_vaccinated',
+                local_dict={'beta_0_1': sympy.Symbol('beta_0_1')}
             )
         )
         expected_2 = ControlledConversion(
@@ -72,11 +70,11 @@ class TestOperations(unittest.TestCase):
                                              do_rename=True),
             outcome=infected.with_context(vaccination_status="vaccinated",
                                           do_rename=True),
-            controller=infected.with_context(vaccination_status="vaccinated",
+            controller=infected.with_context(vaccination_status="unvaccinated",
                                              do_rename=True),
             rate_law=safe_parse_expr(
-                'beta_2 * susceptible_population_vaccinated * infected_population_vaccinated',
-                local_dict={'beta_2': sympy.Symbol('beta_2')}
+                'beta_1_0 * susceptible_population_vaccinated * infected_population_unvaccinated',
+                local_dict={'beta_1_0': sympy.Symbol('beta_1_0')}
             )
         )
         expected_3 = ControlledConversion(
@@ -84,11 +82,11 @@ class TestOperations(unittest.TestCase):
                                              do_rename=True),
             outcome=infected.with_context(vaccination_status="vaccinated",
                                           do_rename=True),
-            controller=infected.with_context(vaccination_status="unvaccinated",
+            controller=infected.with_context(vaccination_status="vaccinated",
                                              do_rename=True),
             rate_law=safe_parse_expr(
-                'beta_3 * susceptible_population_vaccinated * infected_population_unvaccinated',
-                local_dict={'beta_3': sympy.Symbol('beta_3')}
+                'beta_1_1 * susceptible_population_vaccinated * infected_population_vaccinated',
+                local_dict={'beta_1_1': sympy.Symbol('beta_1_1')}
             )
         )
 
@@ -105,10 +103,10 @@ class TestOperations(unittest.TestCase):
         tm_stratified = TemplateModel(
             templates=[expected_0, expected_1, expected_2, expected_3],
             parameters={
-                "beta_0": Parameter(name="beta_0", value=0.1),
-                "beta_1": Parameter(name="beta_1", value=0.1),
-                "beta_2": Parameter(name="beta_2", value=0.1),
-                "beta_3": Parameter(name="beta_3", value=0.1),
+                "beta_0_0": Parameter(name="beta_0_0", value=0.1),
+                "beta_1_0": Parameter(name="beta_1_0", value=0.1),
+                "beta_1_1": Parameter(name="beta_1_1", value=0.1),
+                "beta_0_1": Parameter(name="beta_0_1", value=0.1),
             },
             initials={
                 f"{susceptible.name}_vaccinated": Initial(
@@ -139,7 +137,7 @@ class TestOperations(unittest.TestCase):
         )
         self.assertEqual(4, len(actual.templates))
         self.assertEqual(
-            {"beta_0": 0.1, "beta_1": 0.1, "beta_2": 0.1, "beta_3": 0.1},
+            {"beta_0_0": 0.1, "beta_0_1": 0.1, "beta_1_0": 0.1, "beta_1_1": 0.1},
             {k: p.value for k, p in actual.parameters.items()}
         )
         self.assertEqual(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -130,7 +130,7 @@ class TestOperations(unittest.TestCase):
 
         actual = stratify(
             tm, key="vaccination_status",
-            strata=["vaccinated", "unvaccinated"],
+            strata=["unvaccinated", "vaccinated"],
             cartesian_control=True,
             structure=[],
             modify_names=True,
@@ -559,3 +559,21 @@ def test_stratify_excluded_species():
                   concepts_to_stratify=['susceptible_population'])
 
     assert len(tm.templates) == 5, templates
+
+
+def test_stratify_parameter_consistency():
+    templates = [
+        NaturalDegradation(subject=Concept(name='A'),
+                           rate_law=sympy.Symbol('alpha') * sympy.Symbol('A')),
+        NaturalDegradation(subject=Concept(name='A'),
+                           rate_law=sympy.Symbol('alpha') * sympy.Symbol('A')),
+        NaturalDegradation(subject=Concept(name='B'),
+                           rate_law=sympy.Symbol('alpha') * sympy.Symbol('B')),
+    ]
+    tm = TemplateModel(templates=templates,
+                       parameters={'alpha': Parameter(name='alpha', value=0.1)})
+    tm = stratify(tm, key='age', strata=['young', 'old'], structure=[])
+    # This should be two (alpha_0 and alpha_1 instead of 6 which used to
+    # be the case when parameters would be incrementally numbered for each
+    # new template
+    assert len(tm.parameters) == 2


### PR DESCRIPTION
This PR refactors the core of the stratification implementation to generate new, stratified parameters based on the actual stratification that was performed, instead of the previous approach which simply generated a new index suffix for each parameter instance associated with a newly generated template. This has several benefits including (1) stratified parameter naming is based on actual strata indices that correspond to concepts in the stratified template that the parameter is part of, and (2) stratified parameters are named consistently across multiple templates if the stratification applied to those templates was identical.

FIxes #331 