### PR TITLE
Rename templates during stratification

### DIFF
--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -176,6 +176,7 @@ def stratify(
         for stratum, stratum_idx in stratum_index_map.items():
             template_strata = []
             new_template = deepcopy(template)
+            new_template.name = f"{template.name}_{stratum}"
             # We have to make sure that we only add the stratum to the
             # list of template strata if we stratified any of the non-controllers
             # in this first for loop
@@ -232,6 +233,7 @@ def stratify(
                         template_strata.append(c_stratum if param_renaming_uses_strata_names
                                                else stratum_index_map[c_stratum])
 
+                    stratified_template.name = f"{stratified_template.name}_{'_'.join(template_strata)}"
                     # Wew can now rewrite the rate law for this stratified template,
                     # then append the new template
                     param_mappings = rewrite_rate_law(template_model=template_model,
@@ -297,7 +299,8 @@ def stratify(
         observables[observable_key].expression = SympyExprStr(expr)
 
     # Generate a conversion between each concept of each strata based on the network structure
-    for (source_stratum, target_stratum), concept in itt.product(structure, concept_map.values()):
+    for idx, ((source_stratum, target_stratum), concept) in \
+            enumerate(itt.product(structure, concept_map.values())):
         if concept.name in exclude_concepts:
             continue
         # Get stratum names from map if provided, otherwise use the stratum
@@ -317,14 +320,16 @@ def stratify(
                                        curie_to_name_map=strata_curie_to_name,
                                        **{key: target_stratum})
         # todo will need to generalize for different kwargs for different conversions
-        template = conversion_cls(subject=subject, outcome=outcome)
+        template = conversion_cls(subject=subject, outcome=outcome,
+                                  name=f't{idx}_{source_stratum_name}_{target_stratum_name}')
         template.set_mass_action_rate_law(param_name)
         templates.append(template)
         if not directed:
             param_name = f"p_{target_stratum_name}_{source_stratum_name}"
             if param_name not in parameters:
                 parameters[param_name] = Parameter(name=param_name, value=0.1)
-            reverse_template = conversion_cls(subject=outcome, outcome=subject)
+            reverse_template = conversion_cls(subject=outcome, outcome=subject,
+                                              name=f't{idx}_{target_stratum_name}_{source_stratum_name}')
             reverse_template.set_mass_action_rate_law(param_name)
             templates.append(reverse_template)
 

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -176,7 +176,8 @@ def stratify(
         for stratum, stratum_idx in stratum_index_map.items():
             template_strata = []
             new_template = deepcopy(template)
-            new_template.name = f"{template.name}_{stratum}"
+            new_template.name = \
+                f"{template.name if template.name else 't'}_{stratum}"
             # We have to make sure that we only add the stratum to the
             # list of template strata if we stratified any of the non-controllers
             # in this first for loop
@@ -233,7 +234,9 @@ def stratify(
                         template_strata.append(c_stratum if param_renaming_uses_strata_names
                                                else stratum_index_map[c_stratum])
 
-                    stratified_template.name = f"{stratified_template.name}_{'_'.join(template_strata)}"
+                    tname = stratified_template.name if stratified_template.name \
+                        else 't' + '_'.join(template_strata)
+                    stratified_template.name = tname
                     # Wew can now rewrite the rate law for this stratified template,
                     # then append the new template
                     param_mappings = rewrite_rate_law(template_model=template_model,

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -229,14 +229,12 @@ def stratify(
                     # We now apply the stratum assigned to each controller in this particular
                     # tuple to the controller
                     for controller, c_stratum in zip(stratified_controllers, c_strata_tuple):
+                        stratified_template.name += f"_{c_stratum}"
                         controller.with_context(do_rename=modify_names, inplace=True,
                                                 **{key: c_stratum})
                         template_strata.append(c_stratum if param_renaming_uses_strata_names
                                                else stratum_index_map[c_stratum])
 
-                    tname = stratified_template.name if stratified_template.name \
-                        else 't' + '_'.join(template_strata)
-                    stratified_template.name = tname
                     # Wew can now rewrite the rate law for this stratified template,
                     # then append the new template
                     param_mappings = rewrite_rate_law(template_model=template_model,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -42,6 +42,7 @@ class TestOperations(unittest.TestCase):
         )
 
         expected_0 = ControlledConversion(
+            name="t_unvaccinated_unvaccinated",
             subject=susceptible.with_context(vaccination_status="unvaccinated",
                                              do_rename=True),
             outcome=infected.with_context(vaccination_status="unvaccinated",
@@ -54,6 +55,7 @@ class TestOperations(unittest.TestCase):
             )
         )
         expected_1 = ControlledConversion(
+            name="t_unvaccinated_vaccinated",
             subject=susceptible.with_context(vaccination_status="unvaccinated",
                                              do_rename=True),
             outcome=infected.with_context(vaccination_status="unvaccinated",
@@ -66,6 +68,7 @@ class TestOperations(unittest.TestCase):
             )
         )
         expected_2 = ControlledConversion(
+            name="t_vaccinated_unvaccinated",
             subject=susceptible.with_context(vaccination_status="vaccinated",
                                              do_rename=True),
             outcome=infected.with_context(vaccination_status="vaccinated",
@@ -78,6 +81,7 @@ class TestOperations(unittest.TestCase):
             )
         )
         expected_3 = ControlledConversion(
+            name="t_vaccinated_vaccinated",
             subject=susceptible.with_context(vaccination_status="vaccinated",
                                              do_rename=True),
             outcome=infected.with_context(vaccination_status="vaccinated",


### PR DESCRIPTION
This PR implements renaming of templates during stratification which was previously ignored. The names generated are meant to be unique, and will generally have some interpretability depending on the nature of stratification.

Fixes #336 