### PR TITLE
Adjust test that are affected by the sympy 1.13 update

### DIFF
--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -3,6 +3,7 @@
 import unittest
 from collections import Counter
 from copy import deepcopy as _d
+from fractions import Fraction
 
 import sympy
 
@@ -189,8 +190,8 @@ class TestOperations(unittest.TestCase):
             self.assertIn(key, actual.initials, msg="")
             # Cannot use .args[0] here as .args[0] not a primitive data type
             self.assertEqual(
-                SympyExprStr(float(str(sir_parameterized.initials[original_name].expression)) / len(cities)),
-                actual.initials[key].expression,
+                float(SympyExprStr(float(sir_parameterized.initials[original_name].expression.__str__()) / len(cities)).__str__()),
+                float(Fraction(actual.initials[key].expression.__str__())),
                 msg=f"initial value was not copied from original compartment "
                     f"({original_name}) to stratified compartment ({key})"
             )
@@ -225,8 +226,8 @@ class TestOperations(unittest.TestCase):
             self.assertIn(key, actual.initials, msg=f"Key '{key}' not in initials")
             # Cannot use .args[0] here as .args[0] not a primitive data type
             self.assertEqual(
-                SympyExprStr(float(str(sir_parameterized.initials[original_name].expression)) / len(cities)),
-                actual.initials[key].expression,
+                float(SympyExprStr(float(sir_parameterized.initials[original_name].expression.__str__()) / len(cities)).__str__()),
+                float(Fraction(actual.initials[key].expression.__str__())),
                 msg=f"initial value was not copied from original compartment "
                     f"({original_name}) to stratified compartment ({key})"
             )
@@ -261,8 +262,8 @@ class TestOperations(unittest.TestCase):
             self.assertIn(key, actual.initials, msg=f"Key '{key}' not in initials")
             # Cannot use .args[0] here as .args[0] not a primitive data type
             self.assertEqual(
-                SympyExprStr(float(str(sir_parameterized.initials[original_name].expression)) / len(cities)),
-                actual.initials[key].expression,
+                float(SympyExprStr(float(sir_parameterized.initials[original_name].expression.__str__()) / len(cities)).__str__()),
+                float(Fraction(actual.initials[key].expression.__str__())),
                 msg=f"initial value was not copied from original compartment "
                     f"({original_name}) to stratified compartment ({key})"
             )

--- a/tests/test_petri_source.py
+++ b/tests/test_petri_source.py
@@ -55,6 +55,6 @@ def test_petri_reverse_parameterized():
         susceptible.name
     assert tm.initials['susceptible_population'].concept.identifiers == \
         susceptible.identifiers
-    assert SympyExprStr(1).equals(tm.initials['susceptible_population'].expression)
+    assert SympyExprStr(1.0) == tm.initials['susceptible_population'].expression
     assert tm.templates[0].rate_law
     assert tm.templates[1].rate_law


### PR DESCRIPTION
This PR adjusts some of the testing code regarding equality testing with sympy objects reflecting the `sympy` 1.13 update. 