### PR TITLE
Support expressions in parameters of distributions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           pip install "tox<4.0.0"
       - name: Test with pytest
         run: |
-          export MIRA_REST_URL=http://34.230.33.149:8771
+          export MIRA_REST_URL=http://mira-epi-dkg-lb-c7b58edea41524e6.elb.us-east-1.amazonaws.com:8771
           tox -e py
 #      - name: Upload coverage report to codecov
 #        uses: codecov/codecov-action@v1

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -951,7 +951,7 @@
         },
         "parameters": {
           "title": "Parameters",
-          "description": "The parameters of the distribution keyed by parameter names controlled by ProbOnto and values that are either floatingpoint values or symbolic expressions over other parameters.",
+          "description": "The parameters of the distribution keyed by parameter names controlled by ProbOnto and values that are either floating point values or symbolic expressions over other parameters.",
           "type": "object",
           "additionalProperties": {
             "anyOf": [

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -946,15 +946,23 @@
       "properties": {
         "type": {
           "title": "Type",
-          "description": "The type of distribution, e.g. 'uniform', 'normal', etc.",
+          "description": "The type of distribution as provided by ProbOnto e.g. 'StandardUniform1', 'Beta1', etc.",
           "type": "string"
         },
         "parameters": {
           "title": "Parameters",
-          "description": "The parameters of the distribution.",
+          "description": "The parameters of the distribution keyed by parameter names controlled by ProbOnto and values that are either floatingpoint values or symbolic expressions over other parameters.",
           "type": "object",
           "additionalProperties": {
-            "type": "number"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "example": "2*x"
+              }
+            ]
           }
         }
       },

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -104,10 +104,14 @@ class Distribution(BaseModel):
     """A distribution of values for a parameter."""
 
     type: str = Field(
-        description="The type of distribution, e.g. 'uniform', 'normal', etc."
+        description="The type of distribution as provided by ProbOnto "
+                    "e.g. 'StandardUniform1', 'Beta1', etc."
     )
-    parameters: Dict[str, float] = Field(
-        description="The parameters of the distribution."
+    parameters: Dict[str, SympyExprStr] = Field(
+        description="The parameters of the distribution keyed by parameter names "
+                    "controlled by ProbOnto and values that are expressions "
+                    "and contain numerical values or expressions over other "
+                    "parameters."
     )
 
 

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -109,7 +109,7 @@ class Distribution(BaseModel):
     )
     parameters: Dict[str, Union[float, SympyExprStr]] = Field(
         description="The parameters of the distribution keyed by parameter names "
-                    "controlled by ProbOnto and values that are either floating"
+                    "controlled by ProbOnto and values that are either floating "
                     "point values or symbolic expressions over other "
                     "parameters."
     )

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -107,10 +107,10 @@ class Distribution(BaseModel):
         description="The type of distribution as provided by ProbOnto "
                     "e.g. 'StandardUniform1', 'Beta1', etc."
     )
-    parameters: Dict[str, SympyExprStr] = Field(
+    parameters: Dict[str, Union[float, SympyExprStr]] = Field(
         description="The parameters of the distribution keyed by parameter names "
-                    "controlled by ProbOnto and values that are expressions "
-                    "and contain numerical values or expressions over other "
+                    "controlled by ProbOnto and values that are either floating"
+                    "point values or symbolic expressions over other "
                     "parameters."
     )
 

--- a/mira/modeling/amr/petrinet.py
+++ b/mira/modeling/amr/petrinet.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-from mira.metamodel import expression_to_mathml, TemplateModel
+from mira.metamodel import expression_to_mathml, TemplateModel, SympyExprStr
 from mira.sources.amr import sanity_check_amr
 
 from .. import Model
@@ -188,9 +188,16 @@ class AMRPetriNetModel:
             elif param.distribution.type is None:
                 logger.warning("can not add distribution without type: %s", param.distribution)
             else:
+                serialized_distr_parameters = {}
+                for param_key, param_value in param.distribution.parameters.items():
+                    if isinstance(param_value, SympyExprStr):
+                        serialized_distr_parameters[param_key] = \
+                            str(param_value.args[0])
+                    else:
+                        serialized_distr_parameters[param_key] = param_value
                 param_dict['distribution'] = {
                     'type': param.distribution.type,
-                    'parameters': param.distribution.parameters,
+                    'parameters': serialized_distr_parameters,
                 }
             if param.concept and param.concept.units:
                 param_dict['units'] = {

--- a/mira/sources/amr/petrinet.py
+++ b/mira/sources/amr/petrinet.py
@@ -109,15 +109,16 @@ def template_model_from_amr_json(model_json) -> TemplateModel:
     # }
     ode_semantics = model_json.get("semantics", {}).get("ode", {})
     symbols = {state_id: sympy.Symbol(state_id) for state_id in concepts}
-    mira_parameters = {}
+
+    # We first make symbols for all the parameters
     for parameter in ode_semantics.get('parameters', []):
-        mira_parameters[parameter['id']] = parameter_to_mira(parameter)
         symbols[parameter['id']] = sympy.Symbol(parameter['id'])
 
-    param_values = {
-        p['id']: p['value'] for p in ode_semantics.get('parameters', [])
-        if p.get('value') is not None
-    }
+    # We then process the parameters into MIRA Parameter objects
+    mira_parameters = {}
+    for parameter in ode_semantics.get('parameters', []):
+        mira_parameters[parameter['id']] = \
+            parameter_to_mira(parameter, param_symbols=symbols)
 
     # Next we process initial conditions
     initials = {}

--- a/mira/sources/amr/stockflow.py
+++ b/mira/sources/amr/stockflow.py
@@ -42,12 +42,16 @@ def template_model_from_amr_json(model_json) -> TemplateModel:
         all_stocks.add(stock['id'])
         symbols[stock['id']] = sympy.Symbol(stock['id'])
 
-    # Process parameters
+    # Process parameters, first to get all symbols, then
+    # processing the parameters to get the MIRA parameters
     ode_semantics = model_json.get("semantics", {}).get("ode", {})
+    for parameter in ode_semantics.get('parameters', []):
+        symbols[parameter['id']] = sympy.Symbol(parameter['id'])
+
     mira_parameters = {}
     for parameter in ode_semantics.get('parameters', []):
-        mira_parameters[parameter['id']] = parameter_to_mira(parameter)
-        symbols[parameter['id']] = sympy.Symbol(parameter['id'])
+        mira_parameters[parameter['id']] = \
+            parameter_to_mira(parameter, param_symbols=symbols)
 
     # Process auxiliaries
     aux_expressions = {}

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -1,0 +1,51 @@
+import sympy
+
+from mira.metamodel import *
+from mira.modeling import Model
+from mira.modeling.amr.petrinet import template_model_to_petrinet_json
+
+
+def test_distribution_expressions():
+    beta_mean = Parameter(name='beta_mean',
+                          distribution=Distribution(type="Beta1",
+                                                    parameters={'alpha': sympy.Integer(1),
+                                                                'beta': sympy.Integer(10)}))
+    gamma_mean = Parameter(name='gamma_mean',
+                           distribution=Distribution(type="Beta1",
+                                                     parameters={'alpha': sympy.Integer(10),
+                                                                 'beta': sympy.Integer(10)}))
+    beta = Parameter(name='beta',
+                     distribution=Distribution(type="InverseGamma1",
+                                               parameters={'shape': sympy.Symbol('beta_mean'),
+                                                           'scale': sympy.Float(0.01)}))
+    gamma = Parameter(name='gamma',
+                      distribution=Distribution(type="InverseGamma1",
+                                                parameters={'shape': sympy.Symbol('gamma_mean'),
+                                                            'scale': sympy.Float(0.01)}))
+
+    # Make an SIR model with beta and gamma in rate laws
+    sir_model = TemplateModel(
+        templates=[
+            ControlledConversion(
+                subject=Concept(name='S'),
+                outcome=Concept(name='I'),
+                controller=Concept(name='I'),
+                rate_law=sympy.Symbol('S') * sympy.Symbol('I') * sympy.Symbol('beta')
+            ),
+            NaturalConversion(
+                subject=Concept(name='I'),
+                outcome=Concept(name='R'),
+                rate_law=sympy.Symbol('I') * sympy.Symbol('gamma')
+            ),
+        ],
+        parameters={
+            'beta': beta,
+            'gamma': gamma,
+            'beta_mean': beta_mean,
+            'gamma_mean': gamma_mean,
+            }
+    )
+
+    model = Model(sir_model)
+    pn_json = template_model_to_petrinet_json(sir_model)
+    print(pn_json)


### PR DESCRIPTION
This PR allows for the parameter values associated with a model parameter's distribution to be symbolic expressions. This makes it possible to represent hierarchical dependencies between the distributions of different parameters.