### PR TITLE
Update code to be compatible with Pydantic2 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           pip install "tox<4.0.0"
       - name: Test with pytest
         run: |
-          export MIRA_REST_URL=http://34.230.33.149:8771
+          export MIRA_REST_URL=http://mira-epi-dkg-lb-c7b58edea41524e6.elb.us-east-1.amazonaws.com:8771
           tox -e py
 #      - name: Upload coverage report to codecov
 #        uses: codecov/codecov-action@v1

--- a/mira/dkg/api.py
+++ b/mira/dkg/api.py
@@ -25,18 +25,18 @@ api_blueprint = APIRouter()
 class RelationQuery(BaseModel):
     """A query for relations in the domain knowledge graph."""
 
-    source_type: Optional[str] = Field(description="The source type (i.e., prefix)", example="vo")
+    source_type: Optional[str] = Field(None, description="The source type (i.e., prefix)", examples=["vo"])
     source_curie: Optional[str] = Field(
-        description="The source compact URI (CURIE)", example="doid:946"
+        None, description="The source compact URI (CURIE)", examples=["doid:946"]
     )
     target_type: Optional[str] = Field(
-        description="The target type (i.e., prefix)", example="ncbitaxon"
+        None, description="The target type (i.e., prefix)", examples=["ncbitaxon"]
     )
     target_curie: Optional[str] = Field(
-        description="The target compact URI (CURIE)", example="ncbitaxon:10090"
+        None, description="The target compact URI (CURIE)", examples=["ncbitaxon:10090"]
     )
     relations: Union[None, str, List[str]] = Field(
-        description="A relation string or list of relation strings", example="vo:0001243"
+        None, description="A relation string or list of relation strings", examples=["vo:0001243"]
     )
     relation_direction: Literal["right", "left", "both"] = Field(
         "right", description="The direction of the relationship"
@@ -50,7 +50,7 @@ class RelationQuery(BaseModel):
         ge=0,
     )
     limit: Optional[int] = Field(
-        description="A limit on the number of records returned", example=50, ge=0
+        None, description="A limit on the number of records returned", examples=[50], ge=0
     )
     full: bool = Field(
         False,
@@ -178,12 +178,12 @@ def get_transitive_closure(
 class RelationResponse(BaseModel):
     """A triple (or multi-predicate triple) with abbreviated data."""
 
-    subject: str = Field(description="The CURIE of the subject of the triple", example="doid:96")
+    subject: str = Field(description="The CURIE of the subject of the triple", examples=["doid:96"])
     predicate: Union[str, List[str]] = Field(
         description="A predicate or list of predicates as CURIEs",
-        example="ro:0002452",
+        examples=["ro:0002452"],
     )
-    object: str = Field(description="The CURIE of the object of the triple", example="symp:0000001")
+    object: str = Field(description="The CURIE of the object of the triple", examples=["symp:0000001"])
 
 
 class FullRelationResponse(BaseModel):
@@ -396,10 +396,10 @@ class IsOntChildResult(BaseModel):
     """Result of a query to /is_ontological_child"""
 
     child_curie: str = Field(...,
-                             example="vo:0001113",
+                             examples=["vo:0001113"],
                              description="The child CURIE")
     parent_curie: str = Field(...,
-                              example="obi:0000047",
+                              examples=["obi:0000047"],
                               description="The parent CURIE")
     is_child: bool = Field(
         ...,

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -111,7 +111,7 @@ class Entity(BaseModel):
     link: Optional[str] = None
 
     @field_validator("link")
-    def set_link(cls, value, values):
+    def set_link(cls, value, validation_info):
         """
         Set the value of the ``link`` field based on the value of the ``id``
         field. This gets run as a post-init hook by Pydantic
@@ -119,7 +119,7 @@ class Entity(BaseModel):
         See also:
         https://stackoverflow.com/questions/54023782/pydantic-make-field-none-in-validator-based-on-other-fields-value
         """
-        curie = values["id"]
+        curie = validation_info.data["id"]
         return f"{METAREGISTRY_BASE}/{curie}"
 
     @property

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -14,7 +14,7 @@ import networkx
 import pystow
 import requests
 from neo4j import GraphDatabase, Transaction, unit_of_work
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, field_validator
 from tqdm import tqdm
 from typing_extensions import Literal, TypeAlias
 
@@ -110,9 +110,7 @@ class Entity(BaseModel):
     # Gets auto-populated
     link: Optional[str] = None
 
-    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
-    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
-    @validator("link")
+    @field_validator("link")
     def set_link(cls, value, values):
         """
         Set the value of the ``link`` field based on the value of the ``id``

--- a/mira/dkg/client.py
+++ b/mira/dkg/client.py
@@ -44,28 +44,28 @@ TxResult: TypeAlias = Optional[List[List[Any]]]
 class Relation(BaseModel):
     """A relationship between two entities in the DKG"""
     source_curie: str = Field(
-        description="The curie of the source node", example="probonto:k0000000"
+        description="The curie of the source node", examples=["probonto:k0000000"]
     )
     target_curie: str = Field(
-        description="The curie of the target node", example="probonto:k0000007"
+        description="The curie of the target node", examples=["probonto:k0000007"]
     )
     type: str = Field(
-        description="The type of the relation", example="has_parameter"
+        description="The type of the relation", examples=["has_parameter"]
     )
     pred: str = Field(
         description="The curie of the relation type",
-        example="probonto:c0000062"
+        examples=["probonto:c0000062"]
     )
     source: str = Field(
-        description="The prefix of the relation curie", example="probonto"
+        description="The prefix of the relation curie", examples=["probonto"]
     )
     graph: str = Field(
         description="The URI of the relation",
-        example="https://raw.githubusercontent.com/probonto"
-                "/ontology/master/probonto4ols.owl"
+        examples=["https://raw.githubusercontent.com/probonto"
+                "/ontology/master/probonto4ols.owl"]
     )
     version: str = Field(
-        description="The version number", example="2.5"
+        description="The version number", examples=["2.5"]
     )
 
 
@@ -73,43 +73,45 @@ class Entity(BaseModel):
     """An entity in the domain knowledge graph."""
 
     id: str = Field(
-        ..., title="Compact URI", description="The CURIE of the entity", example="ido:0000511"
+        ..., title="Compact URI", description="The CURIE of the entity", examples=["ido:0000511"]
     )
-    name: Optional[str] = Field(description="The name of the entity", example="infected population")
-    type: EntityType = Field(..., description="The type of the entity", example="class")
-    obsolete: bool = Field(..., description="Is the entity marked obsolete?", example=False)
+    name: Optional[str] = Field(None, description="The name of the entity", examples=["infected population"])
+    type: EntityType = Field(..., description="The type of the entity", examples=["class"])
+    obsolete: bool = Field(..., description="Is the entity marked obsolete?", examples=[False])
     description: Optional[str] = Field(
-        description="The description of the entity.",
-        example="An organism population whose members have an infection.",
+        None, description="The description of the entity.",
+        examples=["An organism population whose members have an infection."],
     )
     synonyms: List[Synonym] = Field(
-        default_factory=list, description="A list of string synonyms", example=[]
+        default_factory=list, description="A list of string synonyms", examples=[[]]
     )
     alts: List[str] = Field(
         title="Alternative Identifiers",
         default_factory=list,
-        example=[],
+        examples=[[]],
         description="A list of alternative identifiers, given as CURIE strings.",
     )
     xrefs: List[Xref] = Field(
         title="Database Cross-references",
         default_factory=list,
-        example=[],
+        examples=[[]],
         description="A list of database cross-references, given as CURIE strings.",
     )
     labels: List[str] = Field(
         default_factory=list,
-        example=["ido"],
+        examples=[["ido"]],
         description="A list of Neo4j labels assigned to the entity.",
     )
     properties: Dict[str, List[str]] = Field(
         default_factory=dict,
         description="A mapping of properties to their values",
-        example={},
+        examples=[{}],
     )
     # Gets auto-populated
     link: Optional[str] = None
 
+    # TODO[pydantic]: We couldn't refactor the `validator`, please replace it by `field_validator` manually.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-validators for more information.
     @validator("link")
     def set_link(cls, value, values):
         """
@@ -235,12 +237,12 @@ class AskemEntity(Entity):
     """An extended entity with more ASKEM stuff loaded in."""
 
     # TODO @ben please write descriptions for these
-    physical_min: Optional[float] = Field(description="")
-    physical_max: Optional[float] = Field(description="")
-    suggested_data_type: Optional[str] = Field(description="")
-    suggested_unit: Optional[str] = Field(description="")
-    typical_min: Optional[float] = Field(description="")
-    typical_max: Optional[float] = Field(description="")
+    physical_min: Optional[float] = Field(None, description="")
+    physical_max: Optional[float] = Field(None, description="")
+    suggested_data_type: Optional[str] = Field(None, description="")
+    suggested_unit: Optional[str] = Field(None, description="")
+    typical_min: Optional[float] = Field(None, description="")
+    typical_max: Optional[float] = Field(None, description="")
 
 
 class Neo4jClient:

--- a/mira/dkg/grounding.py
+++ b/mira/dkg/grounding.py
@@ -18,16 +18,16 @@ BR_BASE = "https://bioregistry.io"
 class GroundRequest(BaseModel):
     """A model representing the parameters to be passed to :func:`gilda.ground` for grounding."""
 
-    text: str = Field(..., description="The text to be grounded", example="Infected Population")
+    text: str = Field(..., description="The text to be grounded", examples=["Infected Population"])
     context: Optional[str] = Field(
         None,
         description="Context around the text to be grounded",
-        example="The infected population increased over the past month",
+        examples=["The infected population increased over the past month"],
     )
     namespaces: Optional[List[str]] = Field(
         None,
         description="A list of namespaces to filter groundings to.",
-        example=["do", "mondo", "ido"],
+        examples=[["do", "mondo", "ido"]],
     )
 
 
@@ -37,30 +37,30 @@ class GroundResult(BaseModel):
     url: str = Field(
         ...,
         description="A URL that resolves the term to an external web service",
-        example=f"{BR_BASE}/ido:0000511",
+        examples=[f"{BR_BASE}/ido:0000511"],
     )
     score: float = Field(
-        ..., description="The matching score calculated by Gilda", ge=0.0, le=1.0, example=0.78
+        ..., description="The matching score calculated by Gilda", ge=0.0, le=1.0, examples=[0.78]
     )
     prefix: str = Field(
         ...,
         description="The prefix corresponding to the ontology/database from which the term comes",
-        example="ido",
+        examples=["ido"],
     )
     identifier: str = Field(
         ...,
         description="The local unique identifier for the term in the ontology/database denoted by the prefix",
-        example="0000511",
+        examples=["0000511"],
     )
     curie: str = Field(
         ...,
         description="The compact URI that combines the prefix and local identifier.",
-        example="ido:0000511",
+        examples=["ido:0000511"],
     )
     name: str = Field(
-        ..., description="The standard entity name for the term", example="infected population"
+        ..., description="The standard entity name for the term", examples=["infected population"]
     )
-    status: str = Field(..., description="The match status, e.g., name, synonym", example="name")
+    status: str = Field(..., description="The match status, e.g., name, synonym", examples=["name"])
 
     @classmethod
     def from_scored_match(cls, scored_match: ScoredMatch) -> "GroundResult":

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -181,17 +181,17 @@ class StratificationQuery(BaseModel):
     template_model: Dict[str, Any] = Field(
         ...,
         description="The template model to stratify",
-        example=template_model_example
+        examples=[template_model_example]
     )
     key: str = Field(
         ...,
         description="The (singular) name of the stratification",
-        example="city"
+        examples=["city"]
     )
     strata: Set[str] = Field(
         ...,
         description="A list of the values for stratification",
-        example=["boston", "nyc"]
+        examples=[["boston", "nyc"]]
     )
     strata_name_map: Union[Dict[str, str], None] = Field(
         None,
@@ -199,9 +199,9 @@ class StratificationQuery(BaseModel):
                     "renaming the concepts. If none given, will use the "
                     "strata values as the names. This option only has an "
                     "effect if ``modify_names`` is true.",
-        example={
+        examples=[{
             "geonames:4930956": "Boston", "geonames:5128581": "New York City"
-        },
+        }],
     )
     strata_name_lookup: bool = Field(
         False,
@@ -209,26 +209,26 @@ class StratificationQuery(BaseModel):
                     "strata values under the assumption that they are "
                     "curies. This flag has no impact if ``strata_name_map`` "
                     "is given.",
-        example=True
+        examples=[True]
     )
     structure: Union[List[List[str]], None] = Field(
         None,
         description="An iterable of pairs corresponding to a directed network "
         "structure where each of the pairs has two strata. If none given, "
         "will assume a complete network structure.",
-        example=[["boston", "nyc"]],
+        examples=[[["boston", "nyc"]]],
     )
     directed: bool = Field(
         False,
         description="Whether the model has directed edges or not.",
-        example=True
+        examples=[True]
     )
     conversion_cls: Literal["natural_conversion",
                             "controlled_conversion"] = Field(
         "natural_conversion",
         description="The template class to be used for conversions between "
                     "strata defined by the network structure.",
-        example="natural_conversion",
+        examples=["natural_conversion"],
     )
     cartesian_control: bool = Field(
         False,
@@ -247,38 +247,38 @@ class StratificationQuery(BaseModel):
         through the perspective of the model) affect the infection of susceptible
         population in another city.
         """),
-        example=True
+        examples=[True]
     )
     modify_names: bool = Field(
         True,
         description="If true, will modify the names of the concepts to "
                     "include the strata (e.g., ``'S'`` becomes "
                     "``'S_boston'``). If false, will keep the original names.",
-        example=True
+        examples=[True]
     )
     params_to_stratify: Optional[List[str]] = Field(
         None,
         description="A list of parameters to stratify. If none given, "
                     "will stratify all parameters.",
-        example=["beta"]
+        examples=[["beta"]]
     )
     params_to_preserve: Optional[List[str]] = Field(
         None,
         description="A list of parameters to preserve. If none given, "
                     "will stratify all parameters.",
-        example=["gamma"]
+        examples=[["gamma"]]
     )
     concepts_to_stratify: Optional[List[str]] = Field(
         None,
         description="A list of concepts to stratify. If none given, "
                     "will stratify all concepts.",
-        example=["susceptible", "infected"],
+        examples=[["susceptible", "infected"]],
     )
     concepts_to_preserve: Optional[List[str]] = Field(
         None,
         description="A list of concepts to preserve. If none given, "
                     "will stratify all concepts.",
-        example=["recovered"],
+        examples=[["recovered"]],
     )
 
     def get_conversion_cls(self) -> Type[Template]:
@@ -554,9 +554,9 @@ def model_to_graph_image(
 
 
 class TemplateModelDeltaQuery(BaseModel):
-    template_model1: Dict[str, Any] = Field(..., example=template_model_example)
+    template_model1: Dict[str, Any] = Field(..., examples=[template_model_example])
     template_model2: Dict[str, Any] = Field(
-        ..., example=template_model_example_w_context
+        ..., examples=[template_model_example_w_context]
     )
 
 
@@ -629,7 +629,7 @@ def models_to_delta_image(
 
 class AddTranstitionQuery(BaseModel):
     template_model: Dict[str, Any] = Field(
-        ..., description="The template model to add the transition to", example=template_model_example
+        ..., description="The template model to add the transition to", examples=[template_model_example]
     )
     subject_concept: Concept = Field(..., description="The subject concept")
     outcome_concept: Concept = Field(..., description="The outcome concept")
@@ -661,9 +661,9 @@ def add_transition(
 
 class ModelComparisonQuery(BaseModel):
     template_models: List[Dict[str, Any]] = Field(
-        ..., example=[
+        ..., examples=[[
             template_model_example, template_model_example_w_context
-        ]
+        ]]
     )
 
 
@@ -700,7 +700,7 @@ def model_comparison(
 
 class AMRComparisonQuery(BaseModel):
     petrinet_models: List[Dict[str, Any]] = Field(
-        ..., example=[amr_petrinet_json, amr_petrinet_json_2_city]
+        ..., examples=[[amr_petrinet_json, amr_petrinet_json_2_city]]
     )
 
 
@@ -742,7 +742,7 @@ else:
 class FluxSpanQuery(BaseModel):
     model: Dict[str, Any] = Field(
         ...,
-        example=flux_span_query_example,
+        examples=[flux_span_query_example],
         description="The model to recover the ODE-semantics from.",
     )
 

--- a/mira/dkg/model.py
+++ b/mira/dkg/model.py
@@ -668,7 +668,7 @@ class ModelComparisonQuery(BaseModel):
 
 
 class ModelComparisonResponse(BaseModel):
-    graph_comparison_data: Dict[str, Any] #ModelComparisonGraphdata
+    graph_comparison_data: Union[Dict[str, Any], ModelComparisonGraphdata] #ModelComparisonGraphdata
     similarity_scores: List[Dict[str, Union[List[int], float]]] = Field(
         ..., description="A dictionary of similarity scores between all the "
                          "provided models."

--- a/mira/dkg/models.py
+++ b/mira/dkg/models.py
@@ -37,7 +37,7 @@ class Xref(BaseModel):
     id: str = Field(description="The CURIE of the cross reference")
     type: str = Field(
         description="The CURIE for the cross reference predicate",
-        example="skos:exactMatch",
+        examples=["skos:exactMatch"],
     )
 
 
@@ -47,5 +47,5 @@ class Synonym(BaseModel):
     value: str = Field(description="The text of the synonym")
     type: str = Field(
         description="The CURIE for the synonym predicate",
-        example="skos:exactMatch",
+        examples=["skos:exactMatch"],
     )

--- a/mira/metamodel/comparison.py
+++ b/mira/metamodel/comparison.py
@@ -30,6 +30,7 @@ MERGE_COLOR = "orange"
 class DataNode(BaseModel):
     """A node in a ModelComparisonGraphdata"""
 
+    model_config = ConfigDict(protected_namespaces=())
     node_type: Literal["template", "concept"]
     model_id: Annotated[int, Field(ge=0, strict=True)]
 
@@ -37,6 +38,7 @@ class DataNode(BaseModel):
 class TemplateNode(DataNode):
     """A node in a ModelComparisonGraphdata representing a Template"""
 
+    model_config = ConfigDict(protected_namespaces=())
     type: str
     rate_law: Optional[SympyExprStr] = \
         Field(default=None, description="The rate law of this template")

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -723,6 +723,9 @@ def counts_to_dimensionless(tm: TemplateModel,
                     SympyExprStr(p.units.expression.args[0] /
                                  (counts_unit_symbol ** exponent))
                 p.value /= (norm_factor ** exponent)
+                # Previously was sympy.Float object, cannot be serialized in
+                # Pydantic2 type enforcement
+                p.value = float(p.value)
 
     return tm
 

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -269,7 +269,14 @@
         },
         "context": {
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "description": "A mapping of context keys to values.",
           "title": "Context",
@@ -1322,7 +1329,14 @@
         },
         "context": {
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "description": "A mapping of context keys to values.",
           "title": "Context",
@@ -1399,7 +1413,14 @@
         },
         "context": {
           "additionalProperties": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           },
           "description": "A mapping of context keys to values.",
           "title": "Context",

--- a/mira/metamodel/schema.json
+++ b/mira/metamodel/schema.json
@@ -3,1407 +3,1905 @@
   "$id": "https://raw.githubusercontent.com/indralab/mira/main/mira/metamodel/schema.json",
   "title": "MIRA Metamodel Template Schema",
   "description": "MIRA metamodel templates give a high-level abstraction of modeling appropriate for many domains.",
-  "definitions": {
-    "Unit": {
-      "title": "Unit",
-      "description": "A unit of measurement.",
-      "type": "object",
-      "properties": {
-        "expression": {
-          "title": "Expression",
-          "description": "The expression for the unit.",
-          "type": "string",
-          "example": "2*x"
-        }
-      },
-      "required": [
-        "expression"
-      ]
-    },
-    "Concept": {
-      "title": "Concept",
-      "description": "A concept is specified by its identifier(s), name, and - optionally -\nits context.",
-      "type": "object",
+  "$defs": {
+    "Annotations": {
+      "description": "A metadata model for model-level annotations.\n\nExamples in this metadata model are taken from\nhttps://www.ebi.ac.uk/biomodels/BIOMD0000000956,\na well-annotated SIR model in the BioModels database.",
       "properties": {
         "name": {
-          "title": "Name",
-          "description": "The name of the concept.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "An optional display name for the concept. If not provided, the name can be used for display purposes.",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A human-readable label for the model",
+          "examples": [
+            "SIR model of scenarios of COVID-19 spread in CA and NY"
+          ],
+          "title": "Name"
         },
         "description": {
-          "title": "Description",
-          "description": "An optional description of the concept.",
-          "type": "string"
-        },
-        "identifiers": {
-          "title": "Identifiers",
-          "description": "A mapping of namespaces to identifiers.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "context": {
-          "title": "Context",
-          "description": "A mapping of context keys to values.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
-        },
-        "units": {
-          "title": "Units",
-          "description": "The units of the concept.",
-          "allOf": [
+          "anyOf": [
             {
-              "$ref": "#/definitions/Unit"
+              "type": "string"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "A description of the model",
+          "examples": [
+            "The coronavirus disease 2019 (COVID-19) pandemic has placed epidemic modeling at the forefront of worldwide public policy making. Nonetheless, modeling and forecasting the spread of COVID-19 remains a challenge. Here, we detail three regional scale models for forecasting and assessing the course of the pandemic. This work demonstrates the utility of parsimonious models for early-time data and provides an accessible framework for generating policy-relevant insights into its course. We show how these models can be connected to each other and to time series data for a particular region. Capable of measuring and forecasting the impacts of social distancing, these models highlight the dangers of relaxing nonpharmaceutical public health interventions in the absence of a vaccine or antiviral therapies."
+          ],
+          "title": "Description"
+        },
+        "license": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Information about the licensing of the model artifact. Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, models from the BioModels databases are all licensed under the CC0 public attribution license.",
+          "examples": [
+            "CC0"
+          ],
+          "title": "License"
+        },
+        "authors": {
+          "description": "A list of authors/creators of the model. This is not the same as the people who e.g., submitted the model to BioModels",
+          "examples": [
+            [
+              {
+                "name": "Andrea L Bertozzi"
+              },
+              {
+                "name": "Elisa Franco"
+              },
+              {
+                "name": "George Mohler"
+              },
+              {
+                "name": "Martin B Short"
+              },
+              {
+                "name": "Daniel Sledge"
+              }
+            ]
+          ],
+          "items": {
+            "$ref": "#/$defs/Author"
+          },
+          "title": "Authors",
+          "type": "array"
+        },
+        "references": {
+          "description": "A list of CURIEs (i.e., <prefix>:<identifier>) corresponding to literature references that describe the model. Do **not** duplicate the same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
+          "examples": [
+            [
+              "pubmed:32616574"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "References",
+          "type": "array"
+        },
+        "time_scale": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The granularity of the time element of the model, typically on the scale of days, weeks, or months for epidemiology models",
+          "examples": [
+            "day"
+          ],
+          "title": "Time Scale"
+        },
+        "time_start": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The start time of the applicability of a model, given as a datetime. When the time scale is not so granular, leave the less granular fields as default, i.e., if the time scale is on months, give dates like YYYY-MM-01 00:00",
+          "title": "Time Start"
+        },
+        "time_end": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Similar to the start time of the applicability of a model, the end time is given as a datetime. For example, the Bertozzi 2020 model is applicable between March and August 2020, so this field is annotated with August 1st, 2020.",
+          "title": "Time End"
+        },
+        "locations": {
+          "description": "A location or list of locations where this model is applicable, ideally annotated using a CURIEs referencing a controlled vocabulary such as GeoNames, which has multiple levels of granularity including city/state/country level terms. For example,the Bertozzi 2020 model was for New York City (geonames:5128581) and California (geonames:5332921)",
+          "examples": [
+            [
+              "geonames:5128581",
+              "geonames:5332921"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Locations",
+          "type": "array"
+        },
+        "pathogens": {
+          "description": "The pathogens present in the model, given with CURIEs referencing vocabulary for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about SARS-CoV-2, this is ncbitaxon:2697049. Do not confuse this field with terms for annotating the disease caused by the pathogen. Note that some models may have multiple pathogens, for simulating double pandemics such as the interaction with SARS-CoV-2 and the seasonal flu.",
+          "examples": [
+            [
+              "ncbitaxon:2697049"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Pathogens",
+          "type": "array"
+        },
+        "diseases": {
+          "description": "The diseases caused by pathogens in the model, given with CURIEs referencing vocabulary for dieases, such as DOID, EFO, or MONDO. For example, the Bertozzi 2020 model is about SARS-CoV-2, which causes COVID-19. In the Human Disease Ontology (DOID), this is referenced by doid:0080600.",
+          "examples": [
+            [
+              "doid:0080600"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Diseases",
+          "type": "array"
+        },
+        "hosts": {
+          "description": "The hosts present in the model, given with CURIEs referencing vocabulary for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about human infection by SARS-CoV-2. Therefore, the appropriate annotation for this field would be ncbitaxon:9606. Note that some models have multiple hosts, such as Malaria models that consider humans and mosquitos.",
+          "examples": [
+            [
+              "ncbitaxon:9606"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Hosts",
+          "type": "array"
+        },
+        "model_types": {
+          "description": "This field describes the type(s) of the model using the Mathematical Modeling Ontology (MAMO), which has terms like 'ordinary differential equation  model', 'population model', etc. These should be annotated as CURIEs in the form of mamo:<local unique identifier>. For example, the Bertozzi 2020 model is a population model (mamo:0000028) and ordinary differential equation model (mamo:0000046)",
+          "examples": [
+            [
+              "mamo:0000028",
+              "mamo:0000046"
+            ]
+          ],
+          "items": {
+            "type": "string"
+          },
+          "title": "Model Types",
+          "type": "array"
+        }
+      },
+      "title": "Annotations",
+      "type": "object"
+    },
+    "Author": {
+      "description": "A metadata model for an author.",
+      "properties": {
+        "name": {
+          "description": "The name of the author",
+          "title": "Name",
+          "type": "string"
         }
       },
       "required": [
         "name"
-      ]
+      ],
+      "title": "Author",
+      "type": "object"
     },
-    "Template": {
-      "title": "Template",
-      "description": "The Template is a parent class for model processes",
-      "type": "object",
+    "Concept": {
+      "description": "A concept is specified by its identifier(s), name, and - optionally -\nits context.",
       "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
         "name": {
+          "description": "The name of the concept.",
           "title": "Name",
-          "description": "The name of the template.",
           "type": "string"
         },
         "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An optional display name for the concept. If not provided, the name can be used for display purposes.",
+          "title": "Display Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An optional description of the concept.",
+          "title": "Description"
+        },
+        "identifiers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A mapping of namespaces to identifiers.",
+          "title": "Identifiers",
+          "type": "object"
+        },
+        "context": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A mapping of context keys to values.",
+          "title": "Context",
+          "type": "object"
+        },
+        "units": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Unit"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The units of the concept."
         }
-      }
-    },
-    "Provenance": {
-      "title": "Provenance",
-      "type": "object",
-      "properties": {}
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Concept",
+      "type": "object"
     },
     "ControlledConversion": {
-      "title": "ControlledConversion",
       "description": "Specifies a process of controlled conversion from subject to outcome,\ncontrolled by the controller.",
-      "type": "object",
       "properties": {
         "rate_law": {
-          "title": "Rate Law",
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
+          "title": "Rate Law"
         },
         "name": {
-          "title": "Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The name of the template.",
-          "type": "string"
+          "title": "Name"
         },
         "display_name": {
-          "title": "Display Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The display name of the template.",
-          "type": "string"
+          "title": "Display Name"
         },
         "type": {
-          "title": "Type",
-          "default": "ControlledConversion",
           "const": "ControlledConversion",
+          "default": "ControlledConversion",
           "enum": [
             "ControlledConversion"
           ],
+          "title": "Type",
           "type": "string"
         },
         "controller": {
-          "title": "Controller",
-          "description": "The controller of the conversion.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The controller of the conversion."
         },
         "subject": {
-          "title": "Subject",
-          "description": "The subject of the conversion.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the conversion."
         },
         "outcome": {
-          "title": "Outcome",
-          "description": "The outcome of the conversion.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The outcome of the conversion."
         },
         "provenance": {
-          "title": "Provenance",
           "description": "The provenance of the conversion.",
-          "type": "array",
           "items": {
-            "$ref": "#/definitions/Provenance"
-          }
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
         }
       },
       "required": [
         "controller",
         "subject",
         "outcome"
-      ]
-    },
-    "GroupedControlledConversion": {
-      "title": "GroupedControlledConversion",
-      "description": "The Template is a parent class for model processes",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "GroupedControlledConversion",
-          "const": "GroupedControlledConversion",
-          "enum": [
-            "GroupedControlledConversion"
-          ],
-          "type": "string"
-        },
-        "controllers": {
-          "title": "Controllers",
-          "description": "The controllers of the conversion.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Concept"
-          }
-        },
-        "subject": {
-          "title": "Subject",
-          "description": "The subject of the conversion.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "outcome": {
-          "title": "Outcome",
-          "description": "The outcome of the conversion.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the conversion.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "controllers",
-        "subject",
-        "outcome"
-      ]
-    },
-    "GroupedControlledProduction": {
-      "title": "GroupedControlledProduction",
-      "description": "Specifies a process of production controlled by several controllers",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "GroupedControlledProduction",
-          "const": "GroupedControlledProduction",
-          "enum": [
-            "GroupedControlledProduction"
-          ],
-          "type": "string"
-        },
-        "controllers": {
-          "title": "Controllers",
-          "description": "The controllers of the production.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Concept"
-          }
-        },
-        "outcome": {
-          "title": "Outcome",
-          "description": "The outcome of the production.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the production.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "controllers",
-        "outcome"
-      ]
-    },
-    "ControlledProduction": {
-      "title": "ControlledProduction",
-      "description": "Specifies a process of production controlled by one controller",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "ControlledProduction",
-          "const": "ControlledProduction",
-          "enum": [
-            "ControlledProduction"
-          ],
-          "type": "string"
-        },
-        "controller": {
-          "title": "Controller",
-          "description": "The controller of the production.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "outcome": {
-          "title": "Outcome",
-          "description": "The outcome of the production.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "Provenance of the template",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "controller",
-        "outcome"
-      ]
-    },
-    "NaturalConversion": {
-      "title": "NaturalConversion",
-      "description": "Specifies a process of natural conversion from subject to outcome",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "NaturalConversion",
-          "const": "NaturalConversion",
-          "enum": [
-            "NaturalConversion"
-          ],
-          "type": "string"
-        },
-        "subject": {
-          "title": "Subject",
-          "description": "The subject of the conversion.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "outcome": {
-          "title": "Outcome",
-          "description": "The outcome of the conversion.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the conversion.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "subject",
-        "outcome"
-      ]
-    },
-    "MultiConversion": {
-      "title": "MultiConversion",
-      "description": "Specifies a conversion process of multiple subjects and outcomes.",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "MultiConversion",
-          "const": "MultiConversion",
-          "enum": [
-            "MultiConversion"
-          ],
-          "type": "string"
-        },
-        "subjects": {
-          "title": "Subjects",
-          "description": "The subjects of the conversion.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Concept"
-          }
-        },
-        "outcomes": {
-          "title": "Outcomes",
-          "description": "The outcomes of the conversion.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Concept"
-          }
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the conversion.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "subjects",
-        "outcomes"
-      ]
-    },
-    "ReversibleFlux": {
-      "title": "ReversibleFlux",
-      "description": "Specifies a reversible flux between a left and right side.",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "ReversibleFlux",
-          "const": "ReversibleFlux",
-          "enum": [
-            "ReversibleFlux"
-          ],
-          "type": "string"
-        },
-        "left": {
-          "title": "Left",
-          "description": "The left hand side of the flux.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Concept"
-          }
-        },
-        "right": {
-          "title": "Right",
-          "description": "The right hand side of the flux.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Concept"
-          }
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the flux.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "left",
-        "right"
-      ]
-    },
-    "NaturalProduction": {
-      "title": "NaturalProduction",
-      "description": "A template for the production of a species at a constant rate.",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "NaturalProduction",
-          "const": "NaturalProduction",
-          "enum": [
-            "NaturalProduction"
-          ],
-          "type": "string"
-        },
-        "outcome": {
-          "title": "Outcome",
-          "description": "The outcome of the production.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the production.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "outcome"
-      ]
-    },
-    "NaturalDegradation": {
-      "title": "NaturalDegradation",
-      "description": "A template for the degradataion of a species at a proportional rate to its amount.",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "NaturalDegradation",
-          "const": "NaturalDegradation",
-          "enum": [
-            "NaturalDegradation"
-          ],
-          "type": "string"
-        },
-        "subject": {
-          "title": "Subject",
-          "description": "The subject of the degradation.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the degradation.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "subject"
-      ]
+      ],
+      "title": "ControlledConversion",
+      "type": "object"
     },
     "ControlledDegradation": {
-      "title": "ControlledDegradation",
       "description": "Specifies a process of degradation controlled by one controller",
-      "type": "object",
       "properties": {
         "rate_law": {
-          "title": "Rate Law",
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
+          "title": "Rate Law"
         },
         "name": {
-          "title": "Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The name of the template.",
-          "type": "string"
+          "title": "Name"
         },
         "display_name": {
-          "title": "Display Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The display name of the template.",
-          "type": "string"
+          "title": "Display Name"
         },
         "type": {
-          "title": "Type",
-          "default": "ControlledDegradation",
           "const": "ControlledDegradation",
+          "default": "ControlledDegradation",
           "enum": [
             "ControlledDegradation"
           ],
+          "title": "Type",
           "type": "string"
         },
         "controller": {
-          "title": "Controller",
-          "description": "The controller of the degradation.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The controller of the degradation."
         },
         "subject": {
-          "title": "Subject",
-          "description": "The subject of the degradation.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the degradation."
         },
         "provenance": {
-          "title": "Provenance",
           "description": "The provenance of the degradation.",
-          "type": "array",
           "items": {
-            "$ref": "#/definitions/Provenance"
-          }
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
         }
       },
       "required": [
         "controller",
         "subject"
-      ]
+      ],
+      "title": "ControlledDegradation",
+      "type": "object"
     },
-    "GroupedControlledDegradation": {
-      "title": "GroupedControlledDegradation",
-      "description": "Specifies a process of degradation controlled by several controllers",
-      "type": "object",
+    "ControlledProduction": {
+      "description": "Specifies a process of production controlled by one controller",
       "properties": {
         "rate_law": {
-          "title": "Rate Law",
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
+          "title": "Rate Law"
         },
         "name": {
-          "title": "Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The name of the template.",
-          "type": "string"
+          "title": "Name"
         },
         "display_name": {
-          "title": "Display Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The display name of the template.",
-          "type": "string"
+          "title": "Display Name"
         },
         "type": {
-          "title": "Type",
-          "default": "GroupedControlledDegradation",
-          "const": "GroupedControlledDegradation",
+          "const": "ControlledProduction",
+          "default": "ControlledProduction",
           "enum": [
-            "GroupedControlledDegradation"
+            "ControlledProduction"
           ],
+          "title": "Type",
           "type": "string"
         },
-        "controllers": {
-          "title": "Controllers",
-          "description": "The controllers of the degradation.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Concept"
-          }
+        "controller": {
+          "$ref": "#/$defs/Concept",
+          "description": "The controller of the production."
         },
-        "subject": {
-          "title": "Subject",
-          "description": "The subject of the degradation.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+        "outcome": {
+          "$ref": "#/$defs/Concept",
+          "description": "The outcome of the production."
         },
         "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the degradation.",
-          "type": "array",
+          "description": "Provenance of the template",
           "items": {
-            "$ref": "#/definitions/Provenance"
-          }
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
         }
       },
       "required": [
-        "controllers",
-        "subject"
-      ]
-    },
-    "NaturalReplication": {
-      "title": "NaturalReplication",
-      "description": "Specifies a process of natural replication of a subject.",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "NaturalReplication",
-          "const": "NaturalReplication",
-          "enum": [
-            "NaturalReplication"
-          ],
-          "type": "string"
-        },
-        "subject": {
-          "title": "Subject",
-          "description": "The subject of the replication.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance of the template.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "subject"
-      ]
+        "controller",
+        "outcome"
+      ],
+      "title": "ControlledProduction",
+      "type": "object"
     },
     "ControlledReplication": {
-      "title": "ControlledReplication",
       "description": "Specifies a process of replication controlled by one controller",
-      "type": "object",
       "properties": {
         "rate_law": {
-          "title": "Rate Law",
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
+          "title": "Rate Law"
         },
         "name": {
-          "title": "Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The name of the template.",
-          "type": "string"
+          "title": "Name"
         },
         "display_name": {
-          "title": "Display Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The display name of the template.",
-          "type": "string"
+          "title": "Display Name"
         },
         "type": {
-          "title": "Type",
-          "default": "ControlledReplication",
           "const": "ControlledReplication",
+          "default": "ControlledReplication",
           "enum": [
             "ControlledReplication"
           ],
+          "title": "Type",
           "type": "string"
         },
         "controller": {
-          "title": "Controller",
-          "description": "The controller of the replication.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The controller of the replication."
         },
         "subject": {
-          "title": "Subject",
-          "description": "The subject of the replication.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the replication."
         },
         "provenance": {
-          "title": "Provenance",
           "description": "The provenance of the replication.",
-          "type": "array",
           "items": {
-            "$ref": "#/definitions/Provenance"
-          }
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
         }
       },
       "required": [
         "controller",
         "subject"
-      ]
-    },
-    "StaticConcept": {
-      "title": "StaticConcept",
-      "description": "Specifies a standalone Concept that is not part of a process.",
-      "type": "object",
-      "properties": {
-        "rate_law": {
-          "title": "Rate Law",
-          "description": "The rate law for the template.",
-          "type": "string",
-          "example": "2*x"
-        },
-        "name": {
-          "title": "Name",
-          "description": "The name of the template.",
-          "type": "string"
-        },
-        "display_name": {
-          "title": "Display Name",
-          "description": "The display name of the template.",
-          "type": "string"
-        },
-        "type": {
-          "title": "Type",
-          "default": "StaticConcept",
-          "const": "StaticConcept",
-          "enum": [
-            "StaticConcept"
-          ],
-          "type": "string"
-        },
-        "subject": {
-          "title": "Subject",
-          "description": "The subject.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
-        },
-        "provenance": {
-          "title": "Provenance",
-          "description": "The provenance.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Provenance"
-          }
-        }
-      },
-      "required": [
-        "subject"
-      ]
+      ],
+      "title": "ControlledReplication",
+      "type": "object"
     },
     "Distribution": {
-      "title": "Distribution",
       "description": "A distribution of values for a parameter.",
-      "type": "object",
       "properties": {
         "type": {
-          "title": "Type",
           "description": "The type of distribution, e.g. 'uniform', 'normal', etc.",
+          "title": "Type",
           "type": "string"
         },
         "parameters": {
-          "title": "Parameters",
-          "description": "The parameters of the distribution.",
-          "type": "object",
           "additionalProperties": {
             "type": "number"
-          }
+          },
+          "description": "The parameters of the distribution.",
+          "title": "Parameters",
+          "type": "object"
         }
       },
       "required": [
         "type",
         "parameters"
-      ]
+      ],
+      "title": "Distribution",
+      "type": "object"
     },
-    "Parameter": {
-      "title": "Parameter",
-      "description": "A Parameter is a special type of Concept that carries a value.",
-      "type": "object",
+    "GroupedControlledConversion": {
       "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
         "name": {
-          "title": "Name",
-          "description": "The name of the concept.",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
         },
         "display_name": {
-          "title": "Display Name",
-          "description": "An optional display name for the concept. If not provided, the name can be used for display purposes.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "GroupedControlledConversion",
+          "default": "GroupedControlledConversion",
+          "enum": [
+            "GroupedControlledConversion"
+          ],
+          "title": "Type",
           "type": "string"
         },
-        "description": {
-          "title": "Description",
-          "description": "An optional description of the concept.",
-          "type": "string"
+        "controllers": {
+          "description": "The controllers of the conversion.",
+          "items": {
+            "$ref": "#/$defs/Concept"
+          },
+          "title": "Controllers",
+          "type": "array"
         },
-        "identifiers": {
-          "title": "Identifiers",
-          "description": "A mapping of namespaces to identifiers.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+        "subject": {
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the conversion."
         },
-        "context": {
-          "title": "Context",
-          "description": "A mapping of context keys to values.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          }
+        "outcome": {
+          "$ref": "#/$defs/Concept",
+          "description": "The outcome of the conversion."
         },
-        "units": {
-          "title": "Units",
-          "description": "The units of the concept.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Unit"
-            }
-          ]
-        },
-        "value": {
-          "title": "Value",
-          "description": "Value of the parameter.",
-          "type": "number"
-        },
-        "distribution": {
-          "title": "Distribution",
-          "description": "A distribution of values for the parameter.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Distribution"
-            }
-          ]
+        "provenance": {
+          "description": "The provenance of the conversion.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
         }
       },
       "required": [
-        "name"
-      ]
+        "controllers",
+        "subject",
+        "outcome"
+      ],
+      "title": "GroupedControlledConversion",
+      "type": "object"
+    },
+    "GroupedControlledDegradation": {
+      "description": "Specifies a process of degradation controlled by several controllers",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "GroupedControlledDegradation",
+          "default": "GroupedControlledDegradation",
+          "enum": [
+            "GroupedControlledDegradation"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "controllers": {
+          "description": "The controllers of the degradation.",
+          "items": {
+            "$ref": "#/$defs/Concept"
+          },
+          "title": "Controllers",
+          "type": "array"
+        },
+        "subject": {
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the degradation."
+        },
+        "provenance": {
+          "description": "The provenance of the degradation.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "controllers",
+        "subject"
+      ],
+      "title": "GroupedControlledDegradation",
+      "type": "object"
+    },
+    "GroupedControlledProduction": {
+      "description": "Specifies a process of production controlled by several controllers",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "GroupedControlledProduction",
+          "default": "GroupedControlledProduction",
+          "enum": [
+            "GroupedControlledProduction"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "controllers": {
+          "description": "The controllers of the production.",
+          "items": {
+            "$ref": "#/$defs/Concept"
+          },
+          "title": "Controllers",
+          "type": "array"
+        },
+        "outcome": {
+          "$ref": "#/$defs/Concept",
+          "description": "The outcome of the production."
+        },
+        "provenance": {
+          "description": "The provenance of the production.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "controllers",
+        "outcome"
+      ],
+      "title": "GroupedControlledProduction",
+      "type": "object"
     },
     "Initial": {
-      "title": "Initial",
       "description": "Represents the initial conditions for parameters present in the\nmodel.",
-      "type": "object",
       "properties": {
         "concept": {
-          "title": "Concept",
-          "description": "The concept associated with the initial.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Concept"
-            }
-          ]
+          "$ref": "#/$defs/Concept",
+          "description": "The concept associated with the initial."
         },
         "expression": {
-          "title": "Expression",
+          "anyOf": [],
           "description": "The expression for the initial.",
-          "type": "string",
-          "example": "2*x"
+          "format": "sympy-expr",
+          "title": "Expression",
+          "type": "string"
         }
       },
       "required": [
         "concept",
         "expression"
-      ]
+      ],
+      "title": "Initial",
+      "type": "object"
+    },
+    "MultiConversion": {
+      "description": "Specifies a conversion process of multiple subjects and outcomes.",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "MultiConversion",
+          "default": "MultiConversion",
+          "enum": [
+            "MultiConversion"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "subjects": {
+          "description": "The subjects of the conversion.",
+          "items": {
+            "$ref": "#/$defs/Concept"
+          },
+          "title": "Subjects",
+          "type": "array"
+        },
+        "outcomes": {
+          "description": "The outcomes of the conversion.",
+          "items": {
+            "$ref": "#/$defs/Concept"
+          },
+          "title": "Outcomes",
+          "type": "array"
+        },
+        "provenance": {
+          "description": "The provenance of the conversion.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "subjects",
+        "outcomes"
+      ],
+      "title": "MultiConversion",
+      "type": "object"
+    },
+    "NaturalConversion": {
+      "description": "Specifies a process of natural conversion from subject to outcome",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "NaturalConversion",
+          "default": "NaturalConversion",
+          "enum": [
+            "NaturalConversion"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the conversion."
+        },
+        "outcome": {
+          "$ref": "#/$defs/Concept",
+          "description": "The outcome of the conversion."
+        },
+        "provenance": {
+          "description": "The provenance of the conversion.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "subject",
+        "outcome"
+      ],
+      "title": "NaturalConversion",
+      "type": "object"
+    },
+    "NaturalDegradation": {
+      "description": "A template for the degradataion of a species at a proportional rate to its amount.",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "NaturalDegradation",
+          "default": "NaturalDegradation",
+          "enum": [
+            "NaturalDegradation"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the degradation."
+        },
+        "provenance": {
+          "description": "The provenance of the degradation.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "subject"
+      ],
+      "title": "NaturalDegradation",
+      "type": "object"
+    },
+    "NaturalProduction": {
+      "description": "A template for the production of a species at a constant rate.",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "NaturalProduction",
+          "default": "NaturalProduction",
+          "enum": [
+            "NaturalProduction"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "outcome": {
+          "$ref": "#/$defs/Concept",
+          "description": "The outcome of the production."
+        },
+        "provenance": {
+          "description": "The provenance of the production.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "outcome"
+      ],
+      "title": "NaturalProduction",
+      "type": "object"
+    },
+    "NaturalReplication": {
+      "description": "Specifies a process of natural replication of a subject.",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "NaturalReplication",
+          "default": "NaturalReplication",
+          "enum": [
+            "NaturalReplication"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/Concept",
+          "description": "The subject of the replication."
+        },
+        "provenance": {
+          "description": "The provenance of the template.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "subject"
+      ],
+      "title": "NaturalReplication",
+      "type": "object"
     },
     "Observable": {
-      "title": "Observable",
       "description": "An observable is a special type of Concept that carries an expression.\n\nObservables are used to define the readouts of a model, useful when a\nreadout is not defined as a state variable but is rather a function of\nstate variables.",
-      "type": "object",
       "properties": {
         "name": {
-          "title": "Name",
           "description": "The name of the concept.",
+          "title": "Name",
           "type": "string"
         },
         "display_name": {
-          "title": "Display Name",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "An optional display name for the concept. If not provided, the name can be used for display purposes.",
-          "type": "string"
+          "title": "Display Name"
         },
         "description": {
-          "title": "Description",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "An optional description of the concept.",
-          "type": "string"
+          "title": "Description"
         },
         "identifiers": {
-          "title": "Identifiers",
-          "description": "A mapping of namespaces to identifiers.",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "A mapping of namespaces to identifiers.",
+          "title": "Identifiers",
+          "type": "object"
         },
         "context": {
-          "title": "Context",
-          "description": "A mapping of context keys to values.",
-          "type": "object",
           "additionalProperties": {
             "type": "string"
-          }
+          },
+          "description": "A mapping of context keys to values.",
+          "title": "Context",
+          "type": "object"
         },
         "units": {
-          "title": "Units",
-          "description": "The units of the concept.",
-          "allOf": [
+          "anyOf": [
             {
-              "$ref": "#/definitions/Unit"
+              "$ref": "#/$defs/Unit"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "The units of the concept."
         },
         "expression": {
-          "title": "Expression",
+          "anyOf": [],
           "description": "The expression for the observable.",
-          "type": "string",
-          "example": "2*x"
+          "format": "sympy-expr",
+          "title": "Expression",
+          "type": "string"
         }
       },
       "required": [
         "name",
         "expression"
-      ]
+      ],
+      "title": "Observable",
+      "type": "object"
     },
-    "Author": {
-      "title": "Author",
-      "description": "A metadata model for an author.",
-      "type": "object",
+    "Parameter": {
+      "description": "A Parameter is a special type of Concept that carries a value.",
       "properties": {
         "name": {
+          "description": "The name of the concept.",
           "title": "Name",
-          "description": "The name of the author",
           "type": "string"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An optional display name for the concept. If not provided, the name can be used for display purposes.",
+          "title": "Display Name"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An optional description of the concept.",
+          "title": "Description"
+        },
+        "identifiers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A mapping of namespaces to identifiers.",
+          "title": "Identifiers",
+          "type": "object"
+        },
+        "context": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A mapping of context keys to values.",
+          "title": "Context",
+          "type": "object"
+        },
+        "units": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Unit"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The units of the concept."
+        },
+        "value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Value of the parameter.",
+          "title": "Value"
+        },
+        "distribution": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Distribution"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A distribution of values for the parameter."
         }
       },
       "required": [
         "name"
-      ]
+      ],
+      "title": "Parameter",
+      "type": "object"
     },
-    "Annotations": {
-      "title": "Annotations",
-      "description": "A metadata model for model-level annotations.\n\nExamples in this metadata model are taken from\nhttps://www.ebi.ac.uk/biomodels/BIOMD0000000956,\na well-annotated SIR model in the BioModels database.",
-      "type": "object",
+    "Provenance": {
+      "properties": {},
+      "title": "Provenance",
+      "type": "object"
+    },
+    "ReversibleFlux": {
+      "description": "Specifies a reversible flux between a left and right side.",
       "properties": {
-        "name": {
-          "title": "Name",
-          "description": "A human-readable label for the model",
-          "example": "SIR model of scenarios of COVID-19 spread in CA and NY",
-          "type": "string"
-        },
-        "description": {
-          "title": "Description",
-          "description": "A description of the model",
-          "example": "The coronavirus disease 2019 (COVID-19) pandemic has placed epidemic modeling at the forefront of worldwide public policy making. Nonetheless, modeling and forecasting the spread of COVID-19 remains a challenge. Here, we detail three regional scale models for forecasting and assessing the course of the pandemic. This work demonstrates the utility of parsimonious models for early-time data and provides an accessible framework for generating policy-relevant insights into its course. We show how these models can be connected to each other and to time series data for a particular region. Capable of measuring and forecasting the impacts of social distancing, these models highlight the dangers of relaxing nonpharmaceutical public health interventions in the absence of a vaccine or antiviral therapies.",
-          "type": "string"
-        },
-        "license": {
-          "title": "License",
-          "description": "Information about the licensing of the model artifact. Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, models from the BioModels databases are all licensed under the CC0 public attribution license.",
-          "example": "CC0",
-          "type": "string"
-        },
-        "authors": {
-          "title": "Authors",
-          "description": "A list of authors/creators of the model. This is not the same as the people who e.g., submitted the model to BioModels",
-          "example": [
+        "rate_law": {
+          "anyOf": [
             {
-              "name": "Andrea L Bertozzi"
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
             },
             {
-              "name": "Elisa Franco"
-            },
-            {
-              "name": "George Mohler"
-            },
-            {
-              "name": "Martin B Short"
-            },
-            {
-              "name": "Daniel Sledge"
+              "type": "null"
             }
           ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Author"
-          }
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
         },
-        "references": {
-          "title": "References",
-          "description": "A list of CURIEs (i.e., <prefix>:<identifier>) corresponding to literature references that describe the model. Do **not** duplicate the same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
-          "example": [
-            "pubmed:32616574"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "time_scale": {
-          "title": "Time Scale",
-          "description": "The granularity of the time element of the model, typically on the scale of days, weeks, or months for epidemiology models",
-          "example": "day",
-          "type": "string"
-        },
-        "time_start": {
-          "title": "Time Start",
-          "description": "The start time of the applicability of a model, given as a datetime. When the time scale is not so granular, leave the less granular fields as default, i.e., if the time scale is on months, give dates like YYYY-MM-01 00:00",
-          "type": "string",
-          "format": "date-time"
-        },
-        "time_end": {
-          "title": "Time End",
-          "description": "Similar to the start time of the applicability of a model, the end time is given as a datetime. For example, the Bertozzi 2020 model is applicable between March and August 2020, so this field is annotated with August 1st, 2020.",
-          "type": "string",
-          "format": "date-time"
-        },
-        "locations": {
-          "title": "Locations",
-          "description": "A location or list of locations where this model is applicable, ideally annotated using a CURIEs referencing a controlled vocabulary such as GeoNames, which has multiple levels of granularity including city/state/country level terms. For example,the Bertozzi 2020 model was for New York City (geonames:5128581) and California (geonames:5332921)",
-          "example": [
-            "geonames:5128581",
-            "geonames:5332921"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "pathogens": {
-          "title": "Pathogens",
-          "description": "The pathogens present in the model, given with CURIEs referencing vocabulary for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about SARS-CoV-2, this is ncbitaxon:2697049. Do not confuse this field with terms for annotating the disease caused by the pathogen. Note that some models may have multiple pathogens, for simulating double pandemics such as the interaction with SARS-CoV-2 and the seasonal flu.",
-          "example": [
-            "ncbitaxon:2697049"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "diseases": {
-          "title": "Diseases",
-          "description": "The diseases caused by pathogens in the model, given with CURIEs referencing vocabulary for dieases, such as DOID, EFO, or MONDO. For example, the Bertozzi 2020 model is about SARS-CoV-2, which causes COVID-19. In the Human Disease Ontology (DOID), this is referenced by doid:0080600.",
-          "example": [
-            "doid:0080600"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "hosts": {
-          "title": "Hosts",
-          "description": "The hosts present in the model, given with CURIEs referencing vocabulary for taxa, ideally, NCBI Taxonomy. For example, the Bertozzi 2020 model is about human infection by SARS-CoV-2. Therefore, the appropriate annotation for this field would be ncbitaxon:9606. Note that some models have multiple hosts, such as Malaria models that consider humans and mosquitos.",
-          "example": [
-            "ncbitaxon:9606"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "model_types": {
-          "title": "Model Types",
-          "description": "This field describes the type(s) of the model using the Mathematical Modeling Ontology (MAMO), which has terms like 'ordinary differential equation  model', 'population model', etc. These should be annotated as CURIEs in the form of mamo:<local unique identifier>. For example, the Bertozzi 2020 model is a population model (mamo:0000028) and ordinary differential equation model (mamo:0000046)",
-          "example": [
-            "mamo:0000028",
-            "mamo:0000046"
-          ],
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "Time": {
-      "title": "Time",
-      "description": "A special type of Concept that represents time.",
-      "type": "object",
-      "properties": {
         "name": {
-          "title": "Name",
-          "description": "The symbol of the time variable in the model.",
-          "default": "t",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "ReversibleFlux",
+          "default": "ReversibleFlux",
+          "enum": [
+            "ReversibleFlux"
+          ],
+          "title": "Type",
           "type": "string"
         },
-        "units": {
-          "title": "Units",
-          "description": "The units of the time variable.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Unit"
-            }
-          ]
+        "left": {
+          "description": "The left hand side of the flux.",
+          "items": {
+            "$ref": "#/$defs/Concept"
+          },
+          "title": "Left",
+          "type": "array"
+        },
+        "right": {
+          "description": "The right hand side of the flux.",
+          "items": {
+            "$ref": "#/$defs/Concept"
+          },
+          "title": "Right",
+          "type": "array"
+        },
+        "provenance": {
+          "description": "The provenance of the flux.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
         }
-      }
+      },
+      "required": [
+        "left",
+        "right"
+      ],
+      "title": "ReversibleFlux",
+      "type": "object"
+    },
+    "StaticConcept": {
+      "description": "Specifies a standalone Concept that is not part of a process.",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        },
+        "type": {
+          "const": "StaticConcept",
+          "default": "StaticConcept",
+          "enum": [
+            "StaticConcept"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "subject": {
+          "$ref": "#/$defs/Concept",
+          "description": "The subject."
+        },
+        "provenance": {
+          "description": "The provenance.",
+          "items": {
+            "$ref": "#/$defs/Provenance"
+          },
+          "title": "Provenance",
+          "type": "array"
+        }
+      },
+      "required": [
+        "subject"
+      ],
+      "title": "StaticConcept",
+      "type": "object"
+    },
+    "Template": {
+      "description": "The Template is a parent class for model processes",
+      "properties": {
+        "rate_law": {
+          "anyOf": [
+            {
+              "anyOf": [],
+              "format": "sympy-expr",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rate law for the template.",
+          "title": "Rate Law"
+        },
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The name of the template.",
+          "title": "Name"
+        },
+        "display_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The display name of the template.",
+          "title": "Display Name"
+        }
+      },
+      "title": "Template",
+      "type": "object"
     },
     "TemplateModel": {
-      "title": "TemplateModel",
       "description": "A template model.",
-      "type": "object",
       "properties": {
         "templates": {
-          "title": "Templates",
           "description": "A list of any child class of Templates",
-          "type": "array",
           "items": {
+            "description": "Any child class of a Template",
             "discriminator": {
-              "propertyName": "type",
               "mapping": {
-                "NaturalConversion": "#/definitions/NaturalConversion",
-                "MultiConversion": "#/definitions/MultiConversion",
-                "ControlledConversion": "#/definitions/ControlledConversion",
-                "NaturalDegradation": "#/definitions/NaturalDegradation",
-                "ControlledDegradation": "#/definitions/ControlledDegradation",
-                "GroupedControlledDegradation": "#/definitions/GroupedControlledDegradation",
-                "NaturalProduction": "#/definitions/NaturalProduction",
-                "ControlledProduction": "#/definitions/ControlledProduction",
-                "GroupedControlledConversion": "#/definitions/GroupedControlledConversion",
-                "GroupedControlledProduction": "#/definitions/GroupedControlledProduction",
-                "NaturalReplication": "#/definitions/NaturalReplication",
-                "ControlledReplication": "#/definitions/ControlledReplication",
-                "StaticConcept": "#/definitions/StaticConcept",
-                "ReversibleFlux": "#/definitions/ReversibleFlux"
-              }
+                "ControlledConversion": "#/$defs/ControlledConversion",
+                "ControlledDegradation": "#/$defs/ControlledDegradation",
+                "ControlledProduction": "#/$defs/ControlledProduction",
+                "ControlledReplication": "#/$defs/ControlledReplication",
+                "GroupedControlledConversion": "#/$defs/GroupedControlledConversion",
+                "GroupedControlledDegradation": "#/$defs/GroupedControlledDegradation",
+                "GroupedControlledProduction": "#/$defs/GroupedControlledProduction",
+                "MultiConversion": "#/$defs/MultiConversion",
+                "NaturalConversion": "#/$defs/NaturalConversion",
+                "NaturalDegradation": "#/$defs/NaturalDegradation",
+                "NaturalProduction": "#/$defs/NaturalProduction",
+                "NaturalReplication": "#/$defs/NaturalReplication",
+                "ReversibleFlux": "#/$defs/ReversibleFlux",
+                "StaticConcept": "#/$defs/StaticConcept"
+              },
+              "propertyName": "type"
             },
             "oneOf": [
               {
-                "$ref": "#/definitions/NaturalConversion"
+                "$ref": "#/$defs/NaturalConversion"
               },
               {
-                "$ref": "#/definitions/MultiConversion"
+                "$ref": "#/$defs/MultiConversion"
               },
               {
-                "$ref": "#/definitions/ControlledConversion"
+                "$ref": "#/$defs/ControlledConversion"
               },
               {
-                "$ref": "#/definitions/NaturalDegradation"
+                "$ref": "#/$defs/NaturalDegradation"
               },
               {
-                "$ref": "#/definitions/ControlledDegradation"
+                "$ref": "#/$defs/ControlledDegradation"
               },
               {
-                "$ref": "#/definitions/GroupedControlledDegradation"
+                "$ref": "#/$defs/GroupedControlledDegradation"
               },
               {
-                "$ref": "#/definitions/NaturalProduction"
+                "$ref": "#/$defs/NaturalProduction"
               },
               {
-                "$ref": "#/definitions/ControlledProduction"
+                "$ref": "#/$defs/ControlledProduction"
               },
               {
-                "$ref": "#/definitions/GroupedControlledConversion"
+                "$ref": "#/$defs/GroupedControlledConversion"
               },
               {
-                "$ref": "#/definitions/GroupedControlledProduction"
+                "$ref": "#/$defs/GroupedControlledProduction"
               },
               {
-                "$ref": "#/definitions/NaturalReplication"
+                "$ref": "#/$defs/NaturalReplication"
               },
               {
-                "$ref": "#/definitions/ControlledReplication"
+                "$ref": "#/$defs/ControlledReplication"
               },
               {
-                "$ref": "#/definitions/StaticConcept"
+                "$ref": "#/$defs/StaticConcept"
               },
               {
-                "$ref": "#/definitions/ReversibleFlux"
+                "$ref": "#/$defs/ReversibleFlux"
               }
             ]
-          }
+          },
+          "title": "Templates",
+          "type": "array"
         },
         "parameters": {
-          "title": "Parameters",
-          "description": "A dict of parameter values where keys correspond to how the parameter appears in rate laws.",
-          "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/Parameter"
-          }
+            "$ref": "#/$defs/Parameter"
+          },
+          "description": "A dict of parameter values where keys correspond to how the parameter appears in rate laws.",
+          "title": "Parameters",
+          "type": "object"
         },
         "initials": {
-          "title": "Initials",
-          "description": "A dict of initial condition values where keyscorrespond to concept names they apply to.",
-          "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/Initial"
-          }
+            "$ref": "#/$defs/Initial"
+          },
+          "description": "A dict of initial condition values where keyscorrespond to concept names they apply to.",
+          "title": "Initials",
+          "type": "object"
         },
         "observables": {
-          "title": "Observables",
-          "description": "A list of observables that are readouts from the model.",
-          "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/Observable"
-          }
+            "$ref": "#/$defs/Observable"
+          },
+          "description": "A list of observables that are readouts from the model.",
+          "title": "Observables",
+          "type": "object"
         },
         "annotations": {
-          "title": "Annotations",
-          "description": "A structure containing model-level annotations. Note that all annotations are optional.",
-          "allOf": [
+          "anyOf": [
             {
-              "$ref": "#/definitions/Annotations"
+              "$ref": "#/$defs/Annotations"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "A structure containing model-level annotations. Note that all annotations are optional."
         },
         "time": {
-          "title": "Time",
-          "description": "A structure containing time-related annotations. Note that all annotations are optional.",
-          "allOf": [
+          "anyOf": [
             {
-              "$ref": "#/definitions/Time"
+              "$ref": "#/$defs/Time"
+            },
+            {
+              "type": "null"
             }
-          ]
+          ],
+          "default": null,
+          "description": "A structure containing time-related annotations. Note that all annotations are optional."
         }
       },
       "required": [
         "templates"
-      ]
+      ],
+      "title": "TemplateModel",
+      "type": "object"
+    },
+    "Time": {
+      "description": "A special type of Concept that represents time.",
+      "properties": {
+        "name": {
+          "default": "t",
+          "description": "The symbol of the time variable in the model.",
+          "title": "Name",
+          "type": "string"
+        },
+        "units": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Unit"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The units of the time variable."
+        }
+      },
+      "title": "Time",
+      "type": "object"
+    },
+    "Unit": {
+      "description": "A unit of measurement.",
+      "properties": {
+        "expression": {
+          "anyOf": [],
+          "description": "The expression for the unit.",
+          "format": "sympy-expr",
+          "title": "Expression",
+          "type": "string"
+        }
+      },
+      "required": [
+        "expression"
+      ],
+      "title": "Unit",
+      "type": "object"
     }
-  }
+  },
+  "properties": {
+    "Concept": {
+      "$ref": "#/$defs/Concept"
+    },
+    "Template": {
+      "$ref": "#/$defs/Template"
+    },
+    "ControlledConversion": {
+      "$ref": "#/$defs/ControlledConversion"
+    },
+    "GroupedControlledConversion": {
+      "$ref": "#/$defs/GroupedControlledConversion"
+    },
+    "GroupedControlledProduction": {
+      "$ref": "#/$defs/GroupedControlledProduction"
+    },
+    "ControlledProduction": {
+      "$ref": "#/$defs/ControlledProduction"
+    },
+    "NaturalConversion": {
+      "$ref": "#/$defs/NaturalConversion"
+    },
+    "MultiConversion": {
+      "$ref": "#/$defs/MultiConversion"
+    },
+    "ReversibleFlux": {
+      "$ref": "#/$defs/ReversibleFlux"
+    },
+    "NaturalProduction": {
+      "$ref": "#/$defs/NaturalProduction"
+    },
+    "NaturalDegradation": {
+      "$ref": "#/$defs/NaturalDegradation"
+    },
+    "ControlledDegradation": {
+      "$ref": "#/$defs/ControlledDegradation"
+    },
+    "GroupedControlledDegradation": {
+      "$ref": "#/$defs/GroupedControlledDegradation"
+    },
+    "NaturalReplication": {
+      "$ref": "#/$defs/NaturalReplication"
+    },
+    "ControlledReplication": {
+      "$ref": "#/$defs/ControlledReplication"
+    },
+    "StaticConcept": {
+      "$ref": "#/$defs/StaticConcept"
+    },
+    "TemplateModel": {
+      "$ref": "#/$defs/TemplateModel"
+    }
+  },
+  "required": [
+    "Concept",
+    "Template",
+    "ControlledConversion",
+    "GroupedControlledConversion",
+    "GroupedControlledProduction",
+    "ControlledProduction",
+    "NaturalConversion",
+    "MultiConversion",
+    "ReversibleFlux",
+    "NaturalProduction",
+    "NaturalDegradation",
+    "ControlledDegradation",
+    "GroupedControlledDegradation",
+    "NaturalReplication",
+    "ControlledReplication",
+    "StaticConcept",
+    "TemplateModel"
+  ],
+  "type": "object"
 }

--- a/mira/metamodel/schema.py
+++ b/mira/metamodel/schema.py
@@ -6,7 +6,8 @@ import json
 from pathlib import Path
 
 import pydantic
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
+from pydantic.json_schema import model_json_schema
 
 from . import Concept, Template, TemplateModel
 
@@ -15,29 +16,31 @@ SCHEMA_PATH = HERE.joinpath("schema.json")
 
 
 def get_json_schema():
-    """Get the JSON schema for MIRA.
-
-    Returns
-    -------
-    : JSON
-        The JSON schema for MIRA.
-    """
+    """Get the JSON schema for MIRA."""
     rv = {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "$id": "https://raw.githubusercontent.com/indralab/mira/main/mira/metamodel/schema.json",
+        "title": "MIRA Metamodel Template Schema",
+        "description": "MIRA metamodel templates give a high-level abstraction of modeling appropriate for many domains.",
     }
-    rv.update(
-        pydantic.schema.schema(
-            [
-                Concept,
-                Template,
-                *Template.__subclasses__(),
-                TemplateModel,
-            ],
-            title="MIRA Metamodel Template Schema",
-            description="MIRA metamodel templates give a high-level abstraction of modeling appropriate for many domains.",
-        )
+
+    models = [Concept, Template, *Template.__subclasses__(), TemplateModel]
+
+    CombinedModel = create_model(
+        "CombinedModel",
+        **{model.__name__: (model, ...) for model in models}
     )
+
+    schema = model_json_schema(
+        CombinedModel,
+        mode='validation',
+    )
+
+    # Remove the top-level 'title' and 'description' from the generated schema
+    schema.pop('title', None)
+    schema.pop('description', None)
+
+    rv.update(schema)
     return rv
 
 

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -1,3 +1,5 @@
+from pydantic import ConfigDict
+
 __all__ = [
     "Annotations",
     "TemplateModel",
@@ -34,13 +36,11 @@ class Initial(BaseModel):
     expression: SympyExprStr = Field(
         description="The expression for the initial."
     )
-
-    class Config:
-        arbitrary_types_allowed = True
-        json_encoders = {
-            SympyExprStr: lambda e: str(e),
-        }
-        json_decoders = {SympyExprStr: lambda e: sympy.parse_expr(e)}
+    # TODO[pydantic]: The following keys were removed: `json_encoders`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(arbitrary_types_allowed=True, json_encoders={
+        SympyExprStr: lambda e: str(e),
+    }, json_decoders={SympyExprStr: lambda e: sympy.parse_expr(e)})
 
     @classmethod
     def from_json(cls, data: Dict[str, Any], locals_dict=None) -> "Initial":
@@ -131,13 +131,11 @@ class Observable(Concept):
     readout is not defined as a state variable but is rather a function of
     state variables.
     """
-
-    class Config:
-        arbitrary_types_allowed = True
-        json_encoders = {
-            SympyExprStr: lambda e: str(e),
-        }
-        json_decoders = {SympyExprStr: lambda e: safe_parse_expr(e)}
+    # TODO[pydantic]: The following keys were removed: `json_encoders`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(arbitrary_types_allowed=True, json_encoders={
+        SympyExprStr: lambda e: str(e),
+    }, json_decoders={SympyExprStr: lambda e: safe_parse_expr(e)})
 
     expression: SympyExprStr = Field(
         description="The expression for the observable."
@@ -181,7 +179,7 @@ class Time(BaseModel):
     name: str = Field(
         default="t", description="The symbol of the time variable in the model."
     )
-    units: Optional[Unit] = Field(description="The units of the time variable.")
+    units: Optional[Unit] = Field(None, description="The units of the time variable.")
 
 
 class Author(BaseModel):
@@ -199,8 +197,8 @@ class Annotations(BaseModel):
     """
 
     name: Optional[str] = Field(
-        description="A human-readable label for the model",
-        example="SIR model of scenarios of COVID-19 spread in CA and NY",
+        None, description="A human-readable label for the model",
+        examples=["SIR model of scenarios of COVID-19 spread in CA and NY"],
     )
     # identifiers: Dict[str, str] = Field(
     #     description="Structured identifiers corresponding to the model artifact "
@@ -213,8 +211,8 @@ class Annotations(BaseModel):
     #     },
     # )
     description: Optional[str] = Field(
-        description="A description of the model",
-        example="The coronavirus disease 2019 (COVID-19) pandemic has placed "
+        None, description="A description of the model",
+        examples=["The coronavirus disease 2019 (COVID-19) pandemic has placed "
         "epidemic modeling at the forefront of worldwide public policy making. "
         "Nonetheless, modeling and forecasting the spread of COVID-19 remains a "
         "challenge. Here, we detail three regional scale models for forecasting "
@@ -225,48 +223,48 @@ class Annotations(BaseModel):
         "time series data for a particular region. Capable of measuring and "
         "forecasting the impacts of social distancing, these models highlight the "
         "dangers of relaxing nonpharmaceutical public health interventions in the "
-        "absence of a vaccine or antiviral therapies.",
+        "absence of a vaccine or antiviral therapies."],
     )
     license: Optional[str] = Field(
-        description="Information about the licensing of the model artifact. "
+        None, description="Information about the licensing of the model artifact. "
         "Ideally, given as an SPDX identifier like CC0 or CC-BY-4.0. For example, "
         "models from the BioModels databases are all licensed under the CC0 "
         "public attribution license.",
-        example="CC0",
+        examples=["CC0"],
     )
     authors: List[Author] = Field(
         default_factory=list,
         description="A list of authors/creators of the model. This is not the same "
         "as the people who e.g., submitted the model to BioModels",
-        example=[
+        examples=[[
             Author(name="Andrea L Bertozzi"),
             Author(name="Elisa Franco"),
             Author(name="George Mohler"),
             Author(name="Martin B Short"),
             Author(name="Daniel Sledge"),
-        ],
+        ]],
     )
     references: List[str] = Field(
         default_factory=list,
         description="A list of CURIEs (i.e., <prefix>:<identifier>) corresponding "
         "to literature references that describe the model. Do **not** duplicate the "
         "same publication with different CURIEs (e.g., using pubmed, pmc, and doi)",
-        example=["pubmed:32616574"],
+        examples=[["pubmed:32616574"]],
     )
     # TODO agree on how we annotate this one, e.g. with a timedelta
     time_scale: Optional[str] = Field(
-        description="The granularity of the time element of the model, typically on "
+        None, description="The granularity of the time element of the model, typically on "
         "the scale of days, weeks, or months for epidemiology models",
-        example="day",
+        examples=["day"],
     )
     time_start: Optional[datetime.datetime] = Field(
-        description="The start time of the applicability of a model, given as a datetime. "
+        None, description="The start time of the applicability of a model, given as a datetime. "
         "When the time scale is not so granular, leave the less granular fields as default, "
         "i.e., if the time scale is on months, give dates like YYYY-MM-01 00:00",
         # example=datetime.datetime(year=2020, month=3, day=1),
     )
     time_end: Optional[datetime.datetime] = Field(
-        description="Similar to the start time of the applicability of a model, the end time "
+        None, description="Similar to the start time of the applicability of a model, the end time "
         "is given as a datetime. For example, the Bertozzi 2020 model is applicable between "
         "March and August 2020, so this field is annotated with August 1st, 2020.",
         # example=datetime.datetime(year=2020, month=8, day=1),
@@ -278,10 +276,10 @@ class Annotations(BaseModel):
         "has multiple levels of granularity including city/state/country level terms. For example,"
         "the Bertozzi 2020 model was for New York City (geonames:5128581) and California "
         "(geonames:5332921)",
-        example=[
+        examples=[[
             "geonames:5128581",
             "geonames:5332921",
-        ],
+        ]],
     )
     pathogens: List[str] = Field(
         default_factory=list,
@@ -290,9 +288,9 @@ class Annotations(BaseModel):
         "SARS-CoV-2, this is ncbitaxon:2697049. Do not confuse this field with terms for annotating "
         "the disease caused by the pathogen. Note that some models may have multiple pathogens, for "
         "simulating double pandemics such as the interaction with SARS-CoV-2 and the seasonal flu.",
-        example=[
+        examples=[[
             "ncbitaxon:2697049",
-        ],
+        ]],
     )
     diseases: List[str] = Field(
         default_factory=list,
@@ -300,9 +298,9 @@ class Annotations(BaseModel):
         "vocabulary for dieases, such as DOID, EFO, or MONDO. For example, the Bertozzi 2020 model "
         "is about SARS-CoV-2, which causes COVID-19. In the Human Disease Ontology (DOID), this "
         "is referenced by doid:0080600.",
-        example=[
+        examples=[[
             "doid:0080600",
-        ],
+        ]],
     )
     hosts: List[str] = Field(
         default_factory=list,
@@ -311,9 +309,9 @@ class Annotations(BaseModel):
         "human infection by SARS-CoV-2. Therefore, the appropriate annotation for this field "
         "would be ncbitaxon:9606. Note that some models have multiple hosts, such as Malaria "
         "models that consider humans and mosquitos.",
-        example=[
+        examples=[[
             "ncbitaxon:9606",
-        ],
+        ]],
     )
     model_types: List[str] = Field(
         default_factory=list,
@@ -322,10 +320,10 @@ class Annotations(BaseModel):
         " model', 'population model', etc. These should be annotated as CURIEs in the form "
         "of mamo:<local unique identifier>. For example, the Bertozzi 2020 model is a population "
         "model (mamo:0000028) and ordinary differential equation model (mamo:0000046)",
-        example=[
+        examples=[[
             "mamo:0000028",
             "mamo:0000046",
-        ],
+        ]],
     )
 
 
@@ -363,12 +361,11 @@ class TemplateModel(BaseModel):
         description="A structure containing time-related annotations. "
         "Note that all annotations are optional.",
     )
-
-    class Config:
-        json_encoders = {
-            SympyExprStr: lambda e: str(e),
-        }
-        json_decoders = {SympyExprStr: lambda e: safe_parse_expr(e)}
+    # TODO[pydantic]: The following keys were removed: `json_encoders`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(json_encoders={
+        SympyExprStr: lambda e: str(e),
+    }, json_decoders={SympyExprStr: lambda e: safe_parse_expr(e)})
 
     def get_parameters_from_rate_law(self, rate_law) -> Set[str]:
         """Given a rate law, find its elements that are model parameters.

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -196,6 +196,8 @@ class Annotations(BaseModel):
     a well-annotated SIR model in the BioModels database.
     """
 
+    model_config = ConfigDict(protected_namespaces=())
+
     name: Optional[str] = Field(
         None, description="A human-readable label for the model",
         examples=["SIR model of scenarios of COVID-19 spread in CA and NY"],

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -115,11 +115,11 @@ class Parameter(Concept):
     """A Parameter is a special type of Concept that carries a value."""
 
     value: Optional[float] = Field(
-        default_factory=None, description="Value of the parameter."
+        default=None, description="Value of the parameter."
     )
 
     distribution: Optional[Distribution] = Field(
-        default_factory=None,
+        default=None,
         description="A distribution of values for the parameter.",
     )
 

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -353,13 +353,13 @@ class TemplateModel(BaseModel):
     )
 
     annotations: Optional[Annotations] = Field(
-        default_factory=None,
+        default=None,
         description="A structure containing model-level annotations. "
         "Note that all annotations are optional.",
     )
 
     time: Optional[Time] = Field(
-        default_factory=None,
+        default=None,
         description="A structure containing time-related annotations. "
         "Note that all annotations are optional.",
     )

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -112,7 +112,7 @@ class Concept(BaseModel):
     """
 
     name: str = Field(..., description="The name of the concept.")
-    display_name: str = \
+    display_name: Optional[str]= \
         Field(None, description="An optional display name for the concept. "
                                 "If not provided, the name can be used for "
                                 "display purposes.")

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -3,6 +3,9 @@ Data models for metamodel templates.
 
 Regenerate the JSON schema by running ``python -m mira.metamodel.schema``.
 """
+from pydantic import ConfigDict
+from typing import Literal
+
 __all__ = [
     "Concept",
     "Template",
@@ -125,15 +128,13 @@ class Concept(BaseModel):
         None, description="The units of the concept."
     )
     _base_name: str = pydantic.PrivateAttr(None)
-
-    class Config:
-        arbitrary_types_allowed = True
-        json_encoders = {
-            SympyExprStr: lambda e: str(e),
-        }
-        json_decoders = {
-            SympyExprStr: lambda e: sympy.parse_expr(e)
-        }
+    # TODO[pydantic]: The following keys were removed: `json_encoders`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(arbitrary_types_allowed=True, json_encoders={
+        SympyExprStr: lambda e: str(e),
+    }, json_decoders={
+        SympyExprStr: lambda e: sympy.parse_expr(e)
+    })
 
     def with_context(self, do_rename=False, curie_to_name_map=None,
                      inplace=False, **context) -> "Concept":
@@ -387,15 +388,13 @@ class Concept(BaseModel):
 
 class Template(BaseModel):
     """The Template is a parent class for model processes"""
-
-    class Config:
-        arbitrary_types_allowed = True
-        json_encoders = {
-            SympyExprStr: lambda e: str(e),
-        }
-        json_decoders = {
-            SympyExprStr: lambda e: safe_parse_expr(e)
-        }
+    # TODO[pydantic]: The following keys were removed: `json_encoders`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(arbitrary_types_allowed=True, json_encoders={
+        SympyExprStr: lambda e: str(e),
+    }, json_decoders={
+        SympyExprStr: lambda e: safe_parse_expr(e)
+    })
 
     rate_law: Optional[SympyExprStr] = Field(
         default=None, description="The rate law for the template."
@@ -890,7 +889,7 @@ class ControlledConversion(Template):
     """Specifies a process of controlled conversion from subject to outcome,
     controlled by the controller."""
 
-    type: Literal["ControlledConversion"] = Field("ControlledConversion", const=True)
+    type: Literal["ControlledConversion"] = "ControlledConversion"
     controller: Concept = Field(..., description="The controller of the conversion.")
     subject: Concept = Field(..., description="The subject of the conversion.")
     outcome: Concept = Field(..., description="The outcome of the conversion.")
@@ -976,7 +975,7 @@ class ControlledConversion(Template):
 
 
 class GroupedControlledConversion(Template):
-    type: Literal["GroupedControlledConversion"] = Field("GroupedControlledConversion", const=True)
+    type: Literal["GroupedControlledConversion"] = "GroupedControlledConversion"
     controllers: List[Concept] = Field(..., description="The controllers of the conversion.")
     subject: Concept = Field(..., description="The subject of the conversion.")
     outcome: Concept = Field(..., description="The outcome of the conversion.")
@@ -1066,7 +1065,7 @@ class GroupedControlledConversion(Template):
 class GroupedControlledProduction(Template):
     """Specifies a process of production controlled by several controllers"""
 
-    type: Literal["GroupedControlledProduction"] = Field("GroupedControlledProduction", const=True)
+    type: Literal["GroupedControlledProduction"] = "GroupedControlledProduction"
     controllers: List[Concept] = Field(..., description="The controllers of the production.")
     outcome: Concept = Field(..., description="The outcome of the production.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the production.")
@@ -1152,9 +1151,7 @@ class GroupedControlledProduction(Template):
 class ControlledProduction(Template):
     """Specifies a process of production controlled by one controller"""
 
-    type: Literal["ControlledProduction"] = Field(
-        "ControlledProduction", const=True
-    )
+    type: Literal["ControlledProduction"] = "ControlledProduction"
     controller: Concept = Field(
         ..., description="The controller of the production."
     )
@@ -1240,7 +1237,7 @@ class ControlledProduction(Template):
 class NaturalConversion(Template):
     """Specifies a process of natural conversion from subject to outcome"""
 
-    type: Literal["NaturalConversion"] = Field("NaturalConversion", const=True)
+    type: Literal["NaturalConversion"] = "NaturalConversion"
     subject: Concept = Field(..., description="The subject of the conversion.")
     outcome: Concept = Field(..., description="The outcome of the conversion.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the conversion.")
@@ -1278,7 +1275,7 @@ class NaturalConversion(Template):
 class MultiConversion(Template):
     """Specifies a conversion process of multiple subjects and outcomes."""
 
-    type: Literal["MultiConversion"] = Field("MultiConversion", const=True)
+    type: Literal["MultiConversion"] = "MultiConversion"
     subjects: List[Concept] = Field(..., description="The subjects of the conversion.")
     outcomes: List[Concept] = Field(..., description="The outcomes of the conversion.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the conversion.")
@@ -1325,7 +1322,7 @@ class MultiConversion(Template):
 class ReversibleFlux(Template):
     """Specifies a reversible flux between a left and right side."""
 
-    type: Literal["ReversibleFlux"] = Field("ReversibleFlux", const=True)
+    type: Literal["ReversibleFlux"] = "ReversibleFlux"
     left: List[Concept] = Field(..., description="The left hand side of the flux.")
     right: List[Concept] = Field(..., description="The right hand side of the flux.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the flux.")
@@ -1372,7 +1369,7 @@ class ReversibleFlux(Template):
 class NaturalProduction(Template):
     """A template for the production of a species at a constant rate."""
 
-    type: Literal["NaturalProduction"] = Field("NaturalProduction", const=True)
+    type: Literal["NaturalProduction"] = "NaturalProduction"
     outcome: Concept = Field(..., description="The outcome of the production.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the production.")
 
@@ -1406,7 +1403,7 @@ class NaturalProduction(Template):
 class NaturalDegradation(Template):
     """A template for the degradataion of a species at a proportional rate to its amount."""
 
-    type: Literal["NaturalDegradation"] = Field("NaturalDegradation", const=True)
+    type: Literal["NaturalDegradation"] = "NaturalDegradation"
     subject: Concept = Field(..., description="The subject of the degradation.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the degradation.")
 
@@ -1439,7 +1436,7 @@ class NaturalDegradation(Template):
 class ControlledDegradation(Template):
     """Specifies a process of degradation controlled by one controller"""
 
-    type: Literal["ControlledDegradation"] = Field("ControlledDegradation", const=True)
+    type: Literal["ControlledDegradation"] = "ControlledDegradation"
     controller: Concept = Field(..., description="The controller of the degradation.")
     subject: Concept = Field(..., description="The subject of the degradation.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the degradation.")
@@ -1518,7 +1515,7 @@ class ControlledDegradation(Template):
 class GroupedControlledDegradation(Template):
     """Specifies a process of degradation controlled by several controllers"""
 
-    type: Literal["GroupedControlledDegradation"] = Field("GroupedControlledDegradation", const=True)
+    type: Literal["GroupedControlledDegradation"] = "GroupedControlledDegradation"
     controllers: List[Concept] = Field(..., description="The controllers of the degradation.")
     subject: Concept = Field(..., description="The subject of the degradation.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the degradation.")
@@ -1602,7 +1599,7 @@ class GroupedControlledDegradation(Template):
 class NaturalReplication(Template):
     """Specifies a process of natural replication of a subject."""
 
-    type: Literal["NaturalReplication"] = Field("NaturalReplication", const=True)
+    type: Literal["NaturalReplication"] = "NaturalReplication"
     subject: Concept = Field(..., description="The subject of the replication.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the template.")
 
@@ -1635,7 +1632,7 @@ class NaturalReplication(Template):
 class ControlledReplication(Template):
     """Specifies a process of replication controlled by one controller"""
 
-    type: Literal["ControlledReplication"] = Field("ControlledReplication", const=True)
+    type: Literal["ControlledReplication"] = "ControlledReplication"
     controller: Concept = Field(..., description="The controller of the replication.")
     subject: Concept = Field(..., description="The subject of the replication.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance of the replication.")
@@ -1695,7 +1692,7 @@ class ControlledReplication(Template):
 class StaticConcept(Template):
     """Specifies a standalone Concept that is not part of a process."""
 
-    type: Literal["StaticConcept"] = Field("StaticConcept", const=True)
+    type: Literal["StaticConcept"] = "StaticConcept"
     subject: Concept = Field(..., description="The subject.")
     provenance: List[Provenance] = Field(default_factory=list, description="The provenance.")
     concept_keys: ClassVar[List[str]] = ["subject"]

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -121,7 +121,7 @@ class Concept(BaseModel):
     identifiers: Mapping[str, str] = Field(
         default_factory=dict, description="A mapping of namespaces to identifiers."
     )
-    context: Mapping[str, str] = Field(
+    context: Mapping[str, Union[str,int]] = Field(
         default_factory=dict, description="A mapping of context keys to values."
     )
     units: Optional[Unit] = Field(

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -136,6 +136,17 @@ class Concept(BaseModel):
         SympyExprStr: lambda e: sympy.parse_expr(e)
     })
 
+    def __eq__(self, other):
+        if isinstance(other, Concept):
+            return (self.name == other.name and
+                    self.display_name == other.display_name and
+                    self.description == other.description and
+                    self.identifiers == other.identifiers and
+                    self.context == other.context and
+                    self.units == other.units)
+        else:
+            return False
+
     def with_context(self, do_rename=False, curie_to_name_map=None,
                      inplace=False, **context) -> "Concept":
         """Return this concept with extra context.

--- a/mira/metamodel/units.py
+++ b/mira/metamodel/units.py
@@ -1,3 +1,5 @@
+from pydantic import ConfigDict
+
 __all__ = [
     'Unit',
     'person_units',
@@ -32,14 +34,13 @@ UNIT_SYMBOLS = load_units()
 
 class Unit(BaseModel):
     """A unit of measurement."""
-    class Config:
-        arbitrary_types_allowed = True
-        json_encoders = {
-            SympyExprStr: lambda e: str(e),
-        }
-        json_decoders = {
-            SympyExprStr: lambda e: sympy.parse_expr(e)
-        }
+    # TODO[pydantic]: The following keys were removed: `json_encoders`.
+    # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
+    model_config = ConfigDict(arbitrary_types_allowed=True, json_encoders={
+        SympyExprStr: lambda e: str(e),
+    }, json_decoders={
+        SympyExprStr: lambda e: sympy.parse_expr(e)
+    })
 
     expression: SympyExprStr = Field(
         description="The expression for the unit."

--- a/mira/metamodel/units.py
+++ b/mira/metamodel/units.py
@@ -36,11 +36,15 @@ class Unit(BaseModel):
     """A unit of measurement."""
     # TODO[pydantic]: The following keys were removed: `json_encoders`.
     # Check https://docs.pydantic.dev/dev-v2/migration/#changes-to-config for more information.
-    model_config = ConfigDict(arbitrary_types_allowed=True, json_encoders={
-        SympyExprStr: lambda e: str(e),
-    }, json_decoders={
-        SympyExprStr: lambda e: sympy.parse_expr(e)
-    })
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        json_encoders={
+            SympyExprStr: lambda e: str(e),
+        },
+        #json_decoders={
+        #    SympyExprStr: lambda e: sympy.parse_expr(e)
+        #}
+    )
 
     expression: SympyExprStr = Field(
         description="The expression for the unit."
@@ -55,6 +59,12 @@ class Unit(BaseModel):
             data['expression'], str
         )
         return cls(**data)
+
+    @classmethod
+    def model_validate(cls, obj):
+        if isinstance(obj, dict) and 'expression' in obj:
+            obj['expression'] = SympyExprStr(obj['expression'])
+        return super().model_validate(obj)
 
 
 person_units = Unit(expression=sympy.Symbol('person'))

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -39,6 +39,8 @@ def safe_parse_expr(s: str, local_dict=None) -> sympy.Expr:
 
 class SympyExprStr(sympy.Expr):
     @classmethod
+    # TODO[pydantic]: We couldn't refactor `__get_validators__`, please create the `__get_pydantic_core_schema__` manually.
+    # Check https://docs.pydantic.dev/latest/migration/#defining-custom-types for more information.
     def __get_validators__(cls):
         yield cls.validate
 

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -50,10 +50,10 @@ class SympyExprStr(sympy.Expr):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> core_schema.CoreSchema:
-        return core_schema.union_schema([
+        return handler.resolve_ref_schema(core_schema.union_schema([
             core_schema.is_instance_schema(cls),
             core_schema.no_info_plain_validator_function(cls.validate)
-        ])
+        ]))
 
 
     @classmethod
@@ -67,8 +67,11 @@ class SympyExprStr(sympy.Expr):
         return cls(v)
 
     @classmethod
-    def __get_pydantic_json_schema__(cls, field_schema):
-        field_schema.update(type="string", example="2*x")
+    def __get_pydantic_json_schema__(cls, core_schema, handler):
+        json_schema = handler(core_schema)
+        json_schema.update(type="string", format="sympy-expr")
+        return json_schema
+        #field_schema.update(type="string", example="2*x")
 
     def __str__(self):
         return super().__str__()[len(self.__class__.__name__)+1:-1]

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -5,6 +5,10 @@ import sympy
 import re
 import unicodedata
 
+from typing import Any
+from pydantic import GetCoreSchemaHandler
+from pydantic_core import core_schema
+
 
 def get_parseable_expression(s: str) -> str:
     """Return an expression that can be parsed using sympy."""
@@ -39,8 +43,18 @@ def safe_parse_expr(s: str, local_dict=None) -> sympy.Expr:
 
 class SympyExprStr(sympy.Expr):
     @classmethod
-    def __get_pydantic_core_schema__(cls):
+    def __get_validators__(cls):
         yield cls.validate
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        return core_schema.union_schema([
+            core_schema.is_instance_schema(cls),
+            core_schema.no_info_plain_validator_function(cls.validate)
+        ])
+
 
     @classmethod
     def validate(cls, v):

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -39,9 +39,7 @@ def safe_parse_expr(s: str, local_dict=None) -> sympy.Expr:
 
 class SympyExprStr(sympy.Expr):
     @classmethod
-    # TODO[pydantic]: We couldn't refactor `__get_validators__`, please create the `__get_pydantic_core_schema__` manually.
-    # Check https://docs.pydantic.dev/latest/migration/#defining-custom-types for more information.
-    def __get_validators__(cls):
+    def __get_pydantic_core_schema__(cls):
         yield cls.validate
 
     @classmethod

--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -53,7 +53,7 @@ class SympyExprStr(sympy.Expr):
         return cls(v)
 
     @classmethod
-    def __modify_schema__(cls, field_schema):
+    def __get_pydantic_json_schema__(cls, field_schema):
         field_schema.update(type="string", example="2*x")
 
     def __str__(self):

--- a/mira/modeling/acsets/petri.py
+++ b/mira/modeling/acsets/petri.py
@@ -21,7 +21,7 @@ from mira.metamodel.utils import safe_parse_expr
 
 class State(BaseModel):
     sname: str
-    sprop: Optional[Dict]
+    sprop: Optional[Dict] = None
     #mira_ids: str
     #mira_context: str
     #mira_initial_value: Optional[float]
@@ -29,8 +29,8 @@ class State(BaseModel):
 
 class Transition(BaseModel):
     tname: str
-    rate: Optional[float]
-    tprop: Optional[Dict]
+    rate: Optional[float] = None
+    tprop: Optional[Dict] = None
     #template_type: str
     #parameter_name: Optional[str]
     #parameter_value: Optional[str]

--- a/mira/modeling/amr/petrinet.py
+++ b/mira/modeling/amr/petrinet.py
@@ -374,8 +374,8 @@ class Initial(BaseModel):
 
 
 class TransitionProperties(BaseModel):
-    name: Optional[str]
-    grounding: Optional[Dict]
+    name: Optional[str] = None
+    grounding: Optional[Dict] = None
 
 
 class Rate(BaseModel):
@@ -397,7 +397,7 @@ class Units(BaseModel):
 class State(BaseModel):
     id: str
     name: Optional[str] = None
-    grounding: Optional[Dict]
+    grounding: Optional[Dict] = None
     units: Optional[Units] = None
 
 
@@ -405,15 +405,15 @@ class Transition(BaseModel):
     id: str
     input: List[str]
     output: List[str]
-    grounding: Optional[Dict]
-    properties: Optional[TransitionProperties]
+    grounding: Optional[Dict] = None
+    properties: Optional[TransitionProperties] = None
 
 
 class Parameter(BaseModel):
     id: str
     description: Optional[str] = None
     value: Optional[float] = None
-    grounding: Optional[Dict]
+    grounding: Optional[Dict] = None
     distribution: Optional[Distribution] = None
     units: Optional[Units] = None
 
@@ -431,8 +431,8 @@ class Time(BaseModel):
 
 class Observable(BaseModel):
     id: str
-    name: Optional[str]
-    grounding: Optional[Dict]
+    name: Optional[str] = None
+    grounding: Optional[Dict] = None
     expression: str
     expression_mathml: str
 
@@ -446,12 +446,12 @@ class OdeSemantics(BaseModel):
     rates: List[Rate]
     initials: List[Initial]
     parameters: List[Parameter]
-    time: Optional[Time]
+    time: Optional[Time] = None
     observables: List[Observable]
 
 
 class Ode(BaseModel):
-    ode: Optional[OdeSemantics]
+    ode: Optional[OdeSemantics] = None
 
 
 class Header(BaseModel):
@@ -465,7 +465,7 @@ class Header(BaseModel):
 class ModelSpecification(BaseModel):
     """A Pydantic model corresponding to the PetriNet JSON schema."""
     header: Header
-    properties: Optional[Dict]
+    properties: Optional[Dict] = None
     model: PetriModel
-    semantics: Optional[Ode]
-    metadata: Optional[Dict]
+    semantics: Optional[Ode] = None
+    metadata: Optional[Dict] = None

--- a/mira/modeling/amr/regnet.py
+++ b/mira/modeling/amr/regnet.py
@@ -460,9 +460,9 @@ class Initial(BaseModel):
 
 
 class TransitionProperties(BaseModel):
-    name: Optional[str]
-    grounding: Optional[Dict]
-    rate: Optional[Dict]
+    name: Optional[str] = None
+    grounding: Optional[Dict] = None
+    rate: Optional[Dict] = None
 
 
 class Rate(BaseModel):
@@ -485,7 +485,7 @@ class Transition(BaseModel):
     id: str
     input: List[str]
     output: List[str]
-    properties: Optional[TransitionProperties]
+    properties: Optional[TransitionProperties] = None
 
 
 class Parameter(BaseModel):
@@ -517,18 +517,18 @@ class Header(BaseModel):
 
 class OdeSemantics(BaseModel):
     rates: List[Rate]
-    time: Optional[Time]
+    time: Optional[Time] = None
     observables: List[Observable]
 
 
 class Ode(BaseModel):
-    ode: Optional[OdeSemantics]
+    ode: Optional[OdeSemantics] = None
 
 
 class ModelSpecification(BaseModel):
     """A Pydantic model specification of the model."""
     header: Header
-    properties: Optional[Dict]
+    properties: Optional[Dict] = None
     model: RegNetModel
-    semantics: Optional[Ode]
-    metadata: Optional[Dict]
+    semantics: Optional[Ode] = None
+    metadata: Optional[Dict] = None

--- a/mira/sources/acsets/stockflow.py
+++ b/mira/sources/acsets/stockflow.py
@@ -107,8 +107,9 @@ def template_model_from_stockflow_ascet_json(model_json) -> TemplateModel:
         outputs = []
 
         # flow_id or flow_name for template name?
-        flow_id = flow["_id"]  # required
-        flow_name = flow.get("fname")
+        flow_id = flow["_id"] # required
+        flow_name = str(flow_id)
+        flow_display_name = flow.get("fname")
 
         inputs.append(input)
         outputs.append(output)
@@ -135,8 +136,8 @@ def template_model_from_stockflow_ascet_json(model_json) -> TemplateModel:
                 output_concepts,
                 controller_concepts,
                 expression_sympy,
-                flow_id,
                 flow_name,
+                flow_display_name,
             )
         )
 
@@ -162,7 +163,7 @@ def stock_to_concept(stock) -> Concept:
     :
         The concept created from the stock
     """
-    name = stock["_id"]
+    name = str(stock["_id"])
     display_name = stock.get("sname")
     grounding = stock.get("grounding", {})
     identifiers = grounding.get("identifiers", {})

--- a/mira/sources/sbml/qual_processor.py
+++ b/mira/sources/sbml/qual_processor.py
@@ -66,7 +66,8 @@ class SbmlQualProcessor:
         for transition_id, transition in enumerate(
             self.qual_model_plugin.transitions
         ):
-            transition_name = transition.id
+            transition_name = str(transition.id)
+            transition_display_name = transition.id
 
             input_names = [
                 qual_species.qualitative_species
@@ -108,16 +109,16 @@ class SbmlQualProcessor:
                     templates.append(
                         NaturalDegradation(
                             subject=input_concepts[0],
-                            name=transition_id,
-                            display_name=transition_name,
+                            name=transition_name,
+                            display_name=transition_display_name,
                         )
                     )
                 elif len(input_concepts) == 0 and len(output_concepts) == 1:
                     templates.append(
                         NaturalProduction(
                             outcome=output_concepts[0],
-                            name=transition_id,
-                            display_name=transition_name,
+                            name=transition_name,
+                            display_name=transition_display_name,
                         )
                     )
                 elif len(input_concepts) == 1 and len(output_concepts) == 1:
@@ -125,8 +126,8 @@ class SbmlQualProcessor:
                         NaturalConversion(
                             subject=input_concepts[0],
                             outcome=output_concepts[0],
-                            name=transition_id,
-                            display_name=transition_name,
+                            name=transition_name,
+                            display_name=transition_display_name,
                         )
                     )
             else:
@@ -139,8 +140,8 @@ class SbmlQualProcessor:
                             ControlledProduction(
                                 controller=positive_controller_concepts[0],
                                 outcome=output_concepts[0],
-                                name=transition_id,
-                                display_name=transition_name,
+                                name=transition_name,
+                                display_name=transition_display_name,
                             )
                         )
                     else:
@@ -148,8 +149,8 @@ class SbmlQualProcessor:
                             GroupedControlledProduction(
                                 controllers=positive_controller_concepts,
                                 outcome=output_concepts[0],
-                                name=transition_id,
-                                display_name=transition_name,
+                                name=transition_name,
+                                display_name=transition_display_name,
                             )
                         )
                 elif (
@@ -161,8 +162,8 @@ class SbmlQualProcessor:
                             ControlledDegradation(
                                 controller=negative_controller_concepts[0],
                                 subject=input_concepts[0],
-                                name=transition_id,
-                                display_name=transition_name,
+                                name=transition_name,
+                                display_name=transition_display_name,
                             )
                         )
                     else:
@@ -170,8 +171,8 @@ class SbmlQualProcessor:
                             GroupedControlledDegradation(
                                 controllers=negative_controller_concepts,
                                 subject=input_concepts[0],
-                                name=transition_id,
-                                display_name=transition_name,
+                                name=transition_name,
+                                display_name=transition_display_name,
                             )
                         )
                 elif (
@@ -183,8 +184,8 @@ class SbmlQualProcessor:
                             controllers=positive_controller_concepts
                             + negative_controller_concepts,
                             outcome=output_concepts[0],
-                            name=transition_id,
-                            display_name=transition_name,
+                            name=transition_name,
+                            display_name=transition_display_name,
                         )
                     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,6 @@ tests =
     pandas
     matplotlib
     matplotlib_venn
-    httpx 
 dkg-client =
     neo4j
     networkx

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,7 +68,7 @@ metaregistry =
     bioregistry[web]
     more_click
 web =
-    fastapi<0.87.0
+    fastapi>=0.100.0
     flask
     flasgger
     bootstrap-flask

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ tests =
     pandas
     matplotlib
     matplotlib_venn
+    httpx 
 dkg-client =
     neo4j
     networkx

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ license_files =
 
 [options]
 install_requires =
-    pydantic>=1.10,<2.0.0
+    pydantic>=2.0.0
     sympy
     typing_extensions
     networkx

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ metaregistry =
     more_click
 web =
     fastapi>=0.100.0
+    httpx
     flask
     flasgger
     bootstrap-flask

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -1,241 +1,241 @@
-# """Tests for the domain knowledge graph app."""
-#
-# import inspect
-# import os
-# import unittest
-# from typing import ClassVar
-#
-# import fastapi.params
-# import pystow
-# from fastapi.testclient import TestClient
-# from gilda.grounder import Grounder
-#
-# from mira.dkg.api import get_relations
-# from mira.dkg.client import AskemEntity, Entity, METAREGISTRY_BASE
-# from mira.dkg.utils import MiraState
-# from mira.dkg.viz import draw_relations
-#
-# MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
-#
-# @unittest.skipIf(not MIRA_NEO4J_URL, reason="Missing neo4j connection configuration")
-# class TestDKG(unittest.TestCase):
-#     """Test the DKG."""
-#
-#     client: ClassVar[TestClient]
-#
-#     @classmethod
-#     def setUp(cls) -> None:
-#         """Set up the test case."""
-#         from mira.dkg.wsgi import app
-#
-#         cls.client = TestClient(app)
-#         cls.client.__enter__()
-#
-#     @classmethod
-#     def tearDownClass(cls) -> None:
-#         """Clean up the test case."""
-#         cls.client.__exit__()
-#
-#     def test_state(self):
-#         """Test the app is filled up with MIRA goodness."""
-#         self.assertIsInstance(self.client.app.state, MiraState)
-#         self.assertIsInstance(self.client.app.state.grounder, Grounder)
-#
-#     def test_grounding_get(self):
-#         """Test grounding with a get request."""
-#         response = self.client.get("/api/ground/vaccine")
-#         self.assertEqual(200, response.status_code, msg=response.content)
-#         self.assertTrue(
-#             any(
-#                 r["prefix"] == "vo" and r["identifier"] == "0000001"
-#                 for r in response.json()["results"]
-#             )
-#         )
-#
-#     def test_grounding_post(self):
-#         """Test grounding with a post request."""
-#         response = self.client.post("/api/ground", json={"text": "vaccine"})
-#         self.assertEqual(200, response.status_code, msg=response.content)
-#         self.assertTrue(
-#             any(
-#                 r["prefix"] == "vo" and r["identifier"] == "0000001"
-#                 for r in response.json()["results"]
-#             )
-#         )
-#
-#     def test_get_transitive_closure(self):
-#         """Test getting a transitive closure"""
-#         # NOTE: takes ~45 s to run with local Neo4j deployment
-#         response = self.client.get(
-#             "/api/transitive_closure",
-#             params={"relation_types": "subclassof"},
-#         )
-#         self.assertEqual(
-#             response.status_code, 200, msg=f"Got status {response.status_code}"
-#         )
-#         res_json = response.json()
-#         self.assertIsInstance(res_json, list)
-#         self.assertEqual(len(res_json[0]), 2)
-#         self.assertTrue(any(t[0].split(":")[0] == "go" for t in res_json))
-#
-#     def test_get_relations(self):
-#         """Test getting relations."""
-#         spec = inspect.signature(get_relations)
-#         relation_query_default = spec.parameters["relation_query"].default
-#         self.assertIsInstance(relation_query_default, fastapi.params.Body)
-#         for key, data in relation_query_default.examples.items():
-#             with self.subTest(key=key):
-#                 response = self.client.post("/api/relations", json=data["value"])
-#                 self.assertEqual(200, response.status_code, msg=response.content)
-#
-#     def test_get_relations_graph(self):
-#         """Test getting graph output of relations."""
-#         spec = inspect.signature(get_relations)
-#         relation_query_default = spec.parameters["relation_query"].default
-#         self.assertIsInstance(relation_query_default, fastapi.params.Body)
-#         for key, data in relation_query_default.examples.items():
-#             with self.subTest(key=key):
-#                 response = self.client.post("/api/relations", json=data["value"])
-#                 is_full = data['value'].get('full', False)
-#                 draw_relations(response.json(), f"test_{key}.png",
-#                                is_full=is_full)
-#
-#     def test_search(self):
-#         """Test search functionality."""
-#         res1 = self.client.get("/api/search", params={
-#             "q": "infect", "limit": 25, "offset": 0
-#         })
-#         self.assertEqual(200, res1.status_code, msg=res1.content)
-#         e1 = [Entity(**e) for e in res1.json()]
-#
-#         res2 = self.client.get("/api/search", params={
-#             "q": "infect", "limit": 20, "offset": 5
-#         })
-#         self.assertEqual(200, res2.status_code, msg=res2.content)
-#         e2 = [Entity(**e) for e in res2.json()]
-#         self.assertEqual(e1[5:], e2)
-#
-#         res3 = self.client.get("/api/search", params={
-#             "q": "count", "limit": 20, "offset": 5, "labels": "unit"
-#         })
-#         self.assertEqual(200, res3.status_code, msg=res3.content)
-#         e3 = [Entity(**e) for e in res3.json()]
-#         self.assertTrue(all(
-#             "unit" in e.labels
-#             for e in e3
-#         ))
-#
-#         res4 = self.client.get("/api/search", params={
-#             "q": "count", "limit": 20, "offset": 5, "prefixes": "wikidata"
-#         })
-#         self.assertEqual(200, res3.status_code, msg=res4.content)
-#         e4 = [Entity(**e) for e in res3.json()]
-#         self.assertTrue(all(
-#             "wikidata" == e.prefix
-#             for e in e4
-#         ))
-#
-#         # Test not returning restricted prefixes
-#         res5 = self.client.get("/api/search", params={"q": "hasdbxref"})
-#         self.assertEqual(0, len(res5.json()))
-#
-#         # Test entries with synonyms but no name, such as fbbt:00000008
-#         res6 = self.client.get("/api/search", params={"q": "clypeo-labrum"})
-#         e6 = [Entity(**e) for e in res6.json()]
-#         self.assertTrue(all(
-#             e.id != "fbbt:00000008"
-#             for e in e6
-#         ))
-#
-#     def test_entity(self):
-#         """Test getting entities."""
-#         res = self.client.get("/api/entity/ido:0000463")
-#         e = Entity(**res.json())
-#         self.assertIsInstance(e, Entity)
-#         self.assertFalse(hasattr(e, "physical_min"))
-#
-#         res = self.client.get("/api/entity/askemo:0000008")
-#         e = AskemEntity(**res.json())
-#         self.assertLessEqual(1, len(e.synonyms))
-#         self.assertTrue(
-#             any(
-#                 s.value == "infectivity" and s.type == "oboInOwl:hasExactSynonym"
-#                 for s in e.synonyms
-#             )
-#         )
-#         self.assertTrue(
-#             any(
-#                 xref.id == "ido:0000463" and xref.type == "skos:exactMatch"
-#                 for xref in e.xrefs
-#             )
-#         )
-#         self.assertEqual("float", e.suggested_data_type)
-#         self.assertEqual("unitless", e.suggested_unit)
-#
-#         res = self.client.get("/api/entity/askemo:0000010")
-#         self.assertIn("link", res.json())
-#         e = AskemEntity(**res.json())
-#         self.assertTrue(hasattr(e, "physical_min"))
-#         self.assertIsInstance(e.physical_min, float)
-#         self.assertEqual(0.0, e.physical_min)
-#
-#     def test_entities(self):
-#         """Test getting multiple entities."""
-#         res = self.client.get("/api/entities/ido:0000463,askemo:0000008")
-#         entities = [Entity.from_data(**record) for record in res.json()]
-#         self.assertEqual("ido:0000463", entities[0].id)
-#         self.assertEqual(f"{METAREGISTRY_BASE}/ido:0000463", entities[0].link)
-#         self.assertEqual("askemo:0000008", entities[1].id)
-#
-#     def test_entity_missing(self):
-#         """Test what happens when an entity is requested that's not in the DKG."""
-#         # Scenario 1: invalid prefix
-#         res = self.client.get("/api/entity/nope:0000008")
-#         self.assertEqual(404, res.status_code)
-#
-#         # Scenario 2: invalid identifier
-#         res = self.client.get("/api/entity/askemo:ABCDE")
-#         self.assertEqual(404, res.status_code)
-#
-#         # Scenario 3: just not in the DKG
-#         res = self.client.get("/api/entity/askemo:1000008")
-#         self.assertEqual(404, res.status_code)
-#
-#     def test_search_wikidata_fallback(self):
-#         # first, check that without fallback, no results are returned
-#         res = self.client.get("/api/search", params={
-#             "q": "charles tapley hoyt", "wikidata_fallback": False,
-#         })
-#         self.assertEqual(200, res.status_code)
-#         entities = [Entity(**e) for e in res.json()]
-#         self.assertEqual([], entities)
-#
-#         # now, turn on fallback
-#         res = self.client.get("/api/search", params={
-#             "q": "charles tapley hoyt", "wikidata_fallback": True,
-#         })
-#         self.assertEqual(200, res.status_code)
-#         entities = [Entity(**e) for e in res.json()]
-#         self.assertTrue(any(
-#             e.id == "wikidata:Q47475003"
-#             for e in entities
-#         ))
-#         self.assertEqual([], entities)
-#
-#     def test_parent_query(self):
-#         """Test parent query."""
-#         res = self.client.post(
-#             "/api/common_parent",
-#             json={"curie1": "ido:0000566",
-#                   "curie2": "ido:0000567"}
-#         )
-#         self.assertEqual(200, res.status_code)
-#
-#         # Try to parse the json to an Entity object
-#         entities = [Entity(**r) for r in res.json()]
-#
-#         # Check that the parent is correct
-#         assert len(entities) == 1
-#         entity = entities[0]
-#         assert entity.id == "ido:0000504"
-#         assert not entity.obsolete
+"""Tests for the domain knowledge graph app."""
+
+import inspect
+import os
+import unittest
+from typing import ClassVar
+
+import fastapi.params
+import pystow
+from fastapi.testclient import TestClient
+from gilda.grounder import Grounder
+
+from mira.dkg.api import get_relations
+from mira.dkg.client import AskemEntity, Entity, METAREGISTRY_BASE
+from mira.dkg.utils import MiraState
+from mira.dkg.viz import draw_relations
+
+MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
+
+@unittest.skipIf(not MIRA_NEO4J_URL, reason="Missing neo4j connection configuration")
+class TestDKG(unittest.TestCase):
+    """Test the DKG."""
+
+    client: ClassVar[TestClient]
+
+    @classmethod
+    def setUp(cls) -> None:
+        """Set up the test case."""
+        from mira.dkg.wsgi import app
+
+        cls.client = TestClient(app)
+        cls.client.__enter__()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """Clean up the test case."""
+        cls.client.__exit__()
+
+    def test_state(self):
+        """Test the app is filled up with MIRA goodness."""
+        self.assertIsInstance(self.client.app.state, MiraState)
+        self.assertIsInstance(self.client.app.state.grounder, Grounder)
+
+    def test_grounding_get(self):
+        """Test grounding with a get request."""
+        response = self.client.get("/api/ground/vaccine")
+        self.assertEqual(200, response.status_code, msg=response.content)
+        self.assertTrue(
+            any(
+                r["prefix"] == "vo" and r["identifier"] == "0000001"
+                for r in response.json()["results"]
+            )
+        )
+
+    def test_grounding_post(self):
+        """Test grounding with a post request."""
+        response = self.client.post("/api/ground", json={"text": "vaccine"})
+        self.assertEqual(200, response.status_code, msg=response.content)
+        self.assertTrue(
+            any(
+                r["prefix"] == "vo" and r["identifier"] == "0000001"
+                for r in response.json()["results"]
+            )
+        )
+
+    def test_get_transitive_closure(self):
+        """Test getting a transitive closure"""
+        # NOTE: takes ~45 s to run with local Neo4j deployment
+        response = self.client.get(
+            "/api/transitive_closure",
+            params={"relation_types": "subclassof"},
+        )
+        self.assertEqual(
+            response.status_code, 200, msg=f"Got status {response.status_code}"
+        )
+        res_json = response.json()
+        self.assertIsInstance(res_json, list)
+        self.assertEqual(len(res_json[0]), 2)
+        self.assertTrue(any(t[0].split(":")[0] == "go" for t in res_json))
+
+    def test_get_relations(self):
+        """Test getting relations."""
+        spec = inspect.signature(get_relations)
+        relation_query_default = spec.parameters["relation_query"].default
+        self.assertIsInstance(relation_query_default, fastapi.params.Body)
+        for key, data in relation_query_default.examples.items():
+            with self.subTest(key=key):
+                response = self.client.post("/api/relations", json=data["value"])
+                self.assertEqual(200, response.status_code, msg=response.content)
+
+    def test_get_relations_graph(self):
+        """Test getting graph output of relations."""
+        spec = inspect.signature(get_relations)
+        relation_query_default = spec.parameters["relation_query"].default
+        self.assertIsInstance(relation_query_default, fastapi.params.Body)
+        for key, data in relation_query_default.examples.items():
+            with self.subTest(key=key):
+                response = self.client.post("/api/relations", json=data["value"])
+                is_full = data['value'].get('full', False)
+                draw_relations(response.json(), f"test_{key}.png",
+                               is_full=is_full)
+
+    def test_search(self):
+        """Test search functionality."""
+        res1 = self.client.get("/api/search", params={
+            "q": "infect", "limit": 25, "offset": 0
+        })
+        self.assertEqual(200, res1.status_code, msg=res1.content)
+        e1 = [Entity(**e) for e in res1.json()]
+
+        res2 = self.client.get("/api/search", params={
+            "q": "infect", "limit": 20, "offset": 5
+        })
+        self.assertEqual(200, res2.status_code, msg=res2.content)
+        e2 = [Entity(**e) for e in res2.json()]
+        self.assertEqual(e1[5:], e2)
+
+        res3 = self.client.get("/api/search", params={
+            "q": "count", "limit": 20, "offset": 5, "labels": "unit"
+        })
+        self.assertEqual(200, res3.status_code, msg=res3.content)
+        e3 = [Entity(**e) for e in res3.json()]
+        self.assertTrue(all(
+            "unit" in e.labels
+            for e in e3
+        ))
+
+        res4 = self.client.get("/api/search", params={
+            "q": "count", "limit": 20, "offset": 5, "prefixes": "wikidata"
+        })
+        self.assertEqual(200, res3.status_code, msg=res4.content)
+        e4 = [Entity(**e) for e in res3.json()]
+        self.assertTrue(all(
+            "wikidata" == e.prefix
+            for e in e4
+        ))
+
+        # Test not returning restricted prefixes
+        res5 = self.client.get("/api/search", params={"q": "hasdbxref"})
+        self.assertEqual(0, len(res5.json()))
+
+        # Test entries with synonyms but no name, such as fbbt:00000008
+        res6 = self.client.get("/api/search", params={"q": "clypeo-labrum"})
+        e6 = [Entity(**e) for e in res6.json()]
+        self.assertTrue(all(
+            e.id != "fbbt:00000008"
+            for e in e6
+        ))
+
+    def test_entity(self):
+        """Test getting entities."""
+        res = self.client.get("/api/entity/ido:0000463")
+        e = Entity(**res.json())
+        self.assertIsInstance(e, Entity)
+        self.assertFalse(hasattr(e, "physical_min"))
+
+        res = self.client.get("/api/entity/askemo:0000008")
+        e = AskemEntity(**res.json())
+        self.assertLessEqual(1, len(e.synonyms))
+        self.assertTrue(
+            any(
+                s.value == "infectivity" and s.type == "oboInOwl:hasExactSynonym"
+                for s in e.synonyms
+            )
+        )
+        self.assertTrue(
+            any(
+                xref.id == "ido:0000463" and xref.type == "skos:exactMatch"
+                for xref in e.xrefs
+            )
+        )
+        self.assertEqual("float", e.suggested_data_type)
+        self.assertEqual("unitless", e.suggested_unit)
+
+        res = self.client.get("/api/entity/askemo:0000010")
+        self.assertIn("link", res.json())
+        e = AskemEntity(**res.json())
+        self.assertTrue(hasattr(e, "physical_min"))
+        self.assertIsInstance(e.physical_min, float)
+        self.assertEqual(0.0, e.physical_min)
+
+    def test_entities(self):
+        """Test getting multiple entities."""
+        res = self.client.get("/api/entities/ido:0000463,askemo:0000008")
+        entities = [Entity.from_data(**record) for record in res.json()]
+        self.assertEqual("ido:0000463", entities[0].id)
+        self.assertEqual(f"{METAREGISTRY_BASE}/ido:0000463", entities[0].link)
+        self.assertEqual("askemo:0000008", entities[1].id)
+
+    def test_entity_missing(self):
+        """Test what happens when an entity is requested that's not in the DKG."""
+        # Scenario 1: invalid prefix
+        res = self.client.get("/api/entity/nope:0000008")
+        self.assertEqual(404, res.status_code)
+
+        # Scenario 2: invalid identifier
+        res = self.client.get("/api/entity/askemo:ABCDE")
+        self.assertEqual(404, res.status_code)
+
+        # Scenario 3: just not in the DKG
+        res = self.client.get("/api/entity/askemo:1000008")
+        self.assertEqual(404, res.status_code)
+
+    def test_search_wikidata_fallback(self):
+        # first, check that without fallback, no results are returned
+        res = self.client.get("/api/search", params={
+            "q": "charles tapley hoyt", "wikidata_fallback": False,
+        })
+        self.assertEqual(200, res.status_code)
+        entities = [Entity(**e) for e in res.json()]
+        self.assertEqual([], entities)
+
+        # now, turn on fallback
+        res = self.client.get("/api/search", params={
+            "q": "charles tapley hoyt", "wikidata_fallback": True,
+        })
+        self.assertEqual(200, res.status_code)
+        entities = [Entity(**e) for e in res.json()]
+        self.assertTrue(any(
+            e.id == "wikidata:Q47475003"
+            for e in entities
+        ))
+        self.assertEqual([], entities)
+
+    def test_parent_query(self):
+        """Test parent query."""
+        res = self.client.post(
+            "/api/common_parent",
+            json={"curie1": "ido:0000566",
+                  "curie2": "ido:0000567"}
+        )
+        self.assertEqual(200, res.status_code)
+
+        # Try to parse the json to an Entity object
+        entities = [Entity(**r) for r in res.json()]
+
+        # Check that the parent is correct
+        assert len(entities) == 1
+        entity = entities[0]
+        assert entity.id == "ido:0000504"
+        assert not entity.obsolete

--- a/tests/test_dkg.py
+++ b/tests/test_dkg.py
@@ -1,241 +1,241 @@
-"""Tests for the domain knowledge graph app."""
-
-import inspect
-import os
-import unittest
-from typing import ClassVar
-
-import fastapi.params
-import pystow
-from fastapi.testclient import TestClient
-from gilda.grounder import Grounder
-
-from mira.dkg.api import get_relations
-from mira.dkg.client import AskemEntity, Entity, METAREGISTRY_BASE
-from mira.dkg.utils import MiraState
-from mira.dkg.viz import draw_relations
-
-MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
-
-@unittest.skipIf(not MIRA_NEO4J_URL, reason="Missing neo4j connection configuration")
-class TestDKG(unittest.TestCase):
-    """Test the DKG."""
-
-    client: ClassVar[TestClient]
-
-    @classmethod
-    def setUp(cls) -> None:
-        """Set up the test case."""
-        from mira.dkg.wsgi import app
-
-        cls.client = TestClient(app)
-        cls.client.__enter__()
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        """Clean up the test case."""
-        cls.client.__exit__()
-
-    def test_state(self):
-        """Test the app is filled up with MIRA goodness."""
-        self.assertIsInstance(self.client.app.state, MiraState)
-        self.assertIsInstance(self.client.app.state.grounder, Grounder)
-
-    def test_grounding_get(self):
-        """Test grounding with a get request."""
-        response = self.client.get("/api/ground/vaccine")
-        self.assertEqual(200, response.status_code, msg=response.content)
-        self.assertTrue(
-            any(
-                r["prefix"] == "vo" and r["identifier"] == "0000001"
-                for r in response.json()["results"]
-            )
-        )
-
-    def test_grounding_post(self):
-        """Test grounding with a post request."""
-        response = self.client.post("/api/ground", json={"text": "vaccine"})
-        self.assertEqual(200, response.status_code, msg=response.content)
-        self.assertTrue(
-            any(
-                r["prefix"] == "vo" and r["identifier"] == "0000001"
-                for r in response.json()["results"]
-            )
-        )
-
-    def test_get_transitive_closure(self):
-        """Test getting a transitive closure"""
-        # NOTE: takes ~45 s to run with local Neo4j deployment
-        response = self.client.get(
-            "/api/transitive_closure",
-            params={"relation_types": "subclassof"},
-        )
-        self.assertEqual(
-            response.status_code, 200, msg=f"Got status {response.status_code}"
-        )
-        res_json = response.json()
-        self.assertIsInstance(res_json, list)
-        self.assertEqual(len(res_json[0]), 2)
-        self.assertTrue(any(t[0].split(":")[0] == "go" for t in res_json))
-
-    def test_get_relations(self):
-        """Test getting relations."""
-        spec = inspect.signature(get_relations)
-        relation_query_default = spec.parameters["relation_query"].default
-        self.assertIsInstance(relation_query_default, fastapi.params.Body)
-        for key, data in relation_query_default.examples.items():
-            with self.subTest(key=key):
-                response = self.client.post("/api/relations", json=data["value"])
-                self.assertEqual(200, response.status_code, msg=response.content)
-
-    def test_get_relations_graph(self):
-        """Test getting graph output of relations."""
-        spec = inspect.signature(get_relations)
-        relation_query_default = spec.parameters["relation_query"].default
-        self.assertIsInstance(relation_query_default, fastapi.params.Body)
-        for key, data in relation_query_default.examples.items():
-            with self.subTest(key=key):
-                response = self.client.post("/api/relations", json=data["value"])
-                is_full = data['value'].get('full', False)
-                draw_relations(response.json(), f"test_{key}.png",
-                               is_full=is_full)
-
-    def test_search(self):
-        """Test search functionality."""
-        res1 = self.client.get("/api/search", params={
-            "q": "infect", "limit": 25, "offset": 0
-        })
-        self.assertEqual(200, res1.status_code, msg=res1.content)
-        e1 = [Entity(**e) for e in res1.json()]
-
-        res2 = self.client.get("/api/search", params={
-            "q": "infect", "limit": 20, "offset": 5
-        })
-        self.assertEqual(200, res2.status_code, msg=res2.content)
-        e2 = [Entity(**e) for e in res2.json()]
-        self.assertEqual(e1[5:], e2)
-
-        res3 = self.client.get("/api/search", params={
-            "q": "count", "limit": 20, "offset": 5, "labels": "unit"
-        })
-        self.assertEqual(200, res3.status_code, msg=res3.content)
-        e3 = [Entity(**e) for e in res3.json()]
-        self.assertTrue(all(
-            "unit" in e.labels
-            for e in e3
-        ))
-
-        res4 = self.client.get("/api/search", params={
-            "q": "count", "limit": 20, "offset": 5, "prefixes": "wikidata"
-        })
-        self.assertEqual(200, res3.status_code, msg=res4.content)
-        e4 = [Entity(**e) for e in res3.json()]
-        self.assertTrue(all(
-            "wikidata" == e.prefix
-            for e in e4
-        ))
-
-        # Test not returning restricted prefixes
-        res5 = self.client.get("/api/search", params={"q": "hasdbxref"})
-        self.assertEqual(0, len(res5.json()))
-
-        # Test entries with synonyms but no name, such as fbbt:00000008
-        res6 = self.client.get("/api/search", params={"q": "clypeo-labrum"})
-        e6 = [Entity(**e) for e in res6.json()]
-        self.assertTrue(all(
-            e.id != "fbbt:00000008"
-            for e in e6
-        ))
-
-    def test_entity(self):
-        """Test getting entities."""
-        res = self.client.get("/api/entity/ido:0000463")
-        e = Entity(**res.json())
-        self.assertIsInstance(e, Entity)
-        self.assertFalse(hasattr(e, "physical_min"))
-
-        res = self.client.get("/api/entity/askemo:0000008")
-        e = AskemEntity(**res.json())
-        self.assertLessEqual(1, len(e.synonyms))
-        self.assertTrue(
-            any(
-                s.value == "infectivity" and s.type == "oboInOwl:hasExactSynonym"
-                for s in e.synonyms
-            )
-        )
-        self.assertTrue(
-            any(
-                xref.id == "ido:0000463" and xref.type == "skos:exactMatch"
-                for xref in e.xrefs
-            )
-        )
-        self.assertEqual("float", e.suggested_data_type)
-        self.assertEqual("unitless", e.suggested_unit)
-
-        res = self.client.get("/api/entity/askemo:0000010")
-        self.assertIn("link", res.json())
-        e = AskemEntity(**res.json())
-        self.assertTrue(hasattr(e, "physical_min"))
-        self.assertIsInstance(e.physical_min, float)
-        self.assertEqual(0.0, e.physical_min)
-
-    def test_entities(self):
-        """Test getting multiple entities."""
-        res = self.client.get("/api/entities/ido:0000463,askemo:0000008")
-        entities = [Entity.from_data(**record) for record in res.json()]
-        self.assertEqual("ido:0000463", entities[0].id)
-        self.assertEqual(f"{METAREGISTRY_BASE}/ido:0000463", entities[0].link)
-        self.assertEqual("askemo:0000008", entities[1].id)
-
-    def test_entity_missing(self):
-        """Test what happens when an entity is requested that's not in the DKG."""
-        # Scenario 1: invalid prefix
-        res = self.client.get("/api/entity/nope:0000008")
-        self.assertEqual(404, res.status_code)
-
-        # Scenario 2: invalid identifier
-        res = self.client.get("/api/entity/askemo:ABCDE")
-        self.assertEqual(404, res.status_code)
-
-        # Scenario 3: just not in the DKG
-        res = self.client.get("/api/entity/askemo:1000008")
-        self.assertEqual(404, res.status_code)
-
-    def test_search_wikidata_fallback(self):
-        # first, check that without fallback, no results are returned
-        res = self.client.get("/api/search", params={
-            "q": "charles tapley hoyt", "wikidata_fallback": False,
-        })
-        self.assertEqual(200, res.status_code)
-        entities = [Entity(**e) for e in res.json()]
-        self.assertEqual([], entities)
-
-        # now, turn on fallback
-        res = self.client.get("/api/search", params={
-            "q": "charles tapley hoyt", "wikidata_fallback": True,
-        })
-        self.assertEqual(200, res.status_code)
-        entities = [Entity(**e) for e in res.json()]
-        self.assertTrue(any(
-            e.id == "wikidata:Q47475003"
-            for e in entities
-        ))
-        self.assertEqual([], entities)
-
-    def test_parent_query(self):
-        """Test parent query."""
-        res = self.client.post(
-            "/api/common_parent",
-            json={"curie1": "ido:0000566",
-                  "curie2": "ido:0000567"}
-        )
-        self.assertEqual(200, res.status_code)
-
-        # Try to parse the json to an Entity object
-        entities = [Entity(**r) for r in res.json()]
-
-        # Check that the parent is correct
-        assert len(entities) == 1
-        entity = entities[0]
-        assert entity.id == "ido:0000504"
-        assert not entity.obsolete
+# """Tests for the domain knowledge graph app."""
+#
+# import inspect
+# import os
+# import unittest
+# from typing import ClassVar
+#
+# import fastapi.params
+# import pystow
+# from fastapi.testclient import TestClient
+# from gilda.grounder import Grounder
+#
+# from mira.dkg.api import get_relations
+# from mira.dkg.client import AskemEntity, Entity, METAREGISTRY_BASE
+# from mira.dkg.utils import MiraState
+# from mira.dkg.viz import draw_relations
+#
+# MIRA_NEO4J_URL = pystow.get_config("mira", "neo4j_url") or os.getenv("MIRA_NEO4J_URL")
+#
+# @unittest.skipIf(not MIRA_NEO4J_URL, reason="Missing neo4j connection configuration")
+# class TestDKG(unittest.TestCase):
+#     """Test the DKG."""
+#
+#     client: ClassVar[TestClient]
+#
+#     @classmethod
+#     def setUp(cls) -> None:
+#         """Set up the test case."""
+#         from mira.dkg.wsgi import app
+#
+#         cls.client = TestClient(app)
+#         cls.client.__enter__()
+#
+#     @classmethod
+#     def tearDownClass(cls) -> None:
+#         """Clean up the test case."""
+#         cls.client.__exit__()
+#
+#     def test_state(self):
+#         """Test the app is filled up with MIRA goodness."""
+#         self.assertIsInstance(self.client.app.state, MiraState)
+#         self.assertIsInstance(self.client.app.state.grounder, Grounder)
+#
+#     def test_grounding_get(self):
+#         """Test grounding with a get request."""
+#         response = self.client.get("/api/ground/vaccine")
+#         self.assertEqual(200, response.status_code, msg=response.content)
+#         self.assertTrue(
+#             any(
+#                 r["prefix"] == "vo" and r["identifier"] == "0000001"
+#                 for r in response.json()["results"]
+#             )
+#         )
+#
+#     def test_grounding_post(self):
+#         """Test grounding with a post request."""
+#         response = self.client.post("/api/ground", json={"text": "vaccine"})
+#         self.assertEqual(200, response.status_code, msg=response.content)
+#         self.assertTrue(
+#             any(
+#                 r["prefix"] == "vo" and r["identifier"] == "0000001"
+#                 for r in response.json()["results"]
+#             )
+#         )
+#
+#     def test_get_transitive_closure(self):
+#         """Test getting a transitive closure"""
+#         # NOTE: takes ~45 s to run with local Neo4j deployment
+#         response = self.client.get(
+#             "/api/transitive_closure",
+#             params={"relation_types": "subclassof"},
+#         )
+#         self.assertEqual(
+#             response.status_code, 200, msg=f"Got status {response.status_code}"
+#         )
+#         res_json = response.json()
+#         self.assertIsInstance(res_json, list)
+#         self.assertEqual(len(res_json[0]), 2)
+#         self.assertTrue(any(t[0].split(":")[0] == "go" for t in res_json))
+#
+#     def test_get_relations(self):
+#         """Test getting relations."""
+#         spec = inspect.signature(get_relations)
+#         relation_query_default = spec.parameters["relation_query"].default
+#         self.assertIsInstance(relation_query_default, fastapi.params.Body)
+#         for key, data in relation_query_default.examples.items():
+#             with self.subTest(key=key):
+#                 response = self.client.post("/api/relations", json=data["value"])
+#                 self.assertEqual(200, response.status_code, msg=response.content)
+#
+#     def test_get_relations_graph(self):
+#         """Test getting graph output of relations."""
+#         spec = inspect.signature(get_relations)
+#         relation_query_default = spec.parameters["relation_query"].default
+#         self.assertIsInstance(relation_query_default, fastapi.params.Body)
+#         for key, data in relation_query_default.examples.items():
+#             with self.subTest(key=key):
+#                 response = self.client.post("/api/relations", json=data["value"])
+#                 is_full = data['value'].get('full', False)
+#                 draw_relations(response.json(), f"test_{key}.png",
+#                                is_full=is_full)
+#
+#     def test_search(self):
+#         """Test search functionality."""
+#         res1 = self.client.get("/api/search", params={
+#             "q": "infect", "limit": 25, "offset": 0
+#         })
+#         self.assertEqual(200, res1.status_code, msg=res1.content)
+#         e1 = [Entity(**e) for e in res1.json()]
+#
+#         res2 = self.client.get("/api/search", params={
+#             "q": "infect", "limit": 20, "offset": 5
+#         })
+#         self.assertEqual(200, res2.status_code, msg=res2.content)
+#         e2 = [Entity(**e) for e in res2.json()]
+#         self.assertEqual(e1[5:], e2)
+#
+#         res3 = self.client.get("/api/search", params={
+#             "q": "count", "limit": 20, "offset": 5, "labels": "unit"
+#         })
+#         self.assertEqual(200, res3.status_code, msg=res3.content)
+#         e3 = [Entity(**e) for e in res3.json()]
+#         self.assertTrue(all(
+#             "unit" in e.labels
+#             for e in e3
+#         ))
+#
+#         res4 = self.client.get("/api/search", params={
+#             "q": "count", "limit": 20, "offset": 5, "prefixes": "wikidata"
+#         })
+#         self.assertEqual(200, res3.status_code, msg=res4.content)
+#         e4 = [Entity(**e) for e in res3.json()]
+#         self.assertTrue(all(
+#             "wikidata" == e.prefix
+#             for e in e4
+#         ))
+#
+#         # Test not returning restricted prefixes
+#         res5 = self.client.get("/api/search", params={"q": "hasdbxref"})
+#         self.assertEqual(0, len(res5.json()))
+#
+#         # Test entries with synonyms but no name, such as fbbt:00000008
+#         res6 = self.client.get("/api/search", params={"q": "clypeo-labrum"})
+#         e6 = [Entity(**e) for e in res6.json()]
+#         self.assertTrue(all(
+#             e.id != "fbbt:00000008"
+#             for e in e6
+#         ))
+#
+#     def test_entity(self):
+#         """Test getting entities."""
+#         res = self.client.get("/api/entity/ido:0000463")
+#         e = Entity(**res.json())
+#         self.assertIsInstance(e, Entity)
+#         self.assertFalse(hasattr(e, "physical_min"))
+#
+#         res = self.client.get("/api/entity/askemo:0000008")
+#         e = AskemEntity(**res.json())
+#         self.assertLessEqual(1, len(e.synonyms))
+#         self.assertTrue(
+#             any(
+#                 s.value == "infectivity" and s.type == "oboInOwl:hasExactSynonym"
+#                 for s in e.synonyms
+#             )
+#         )
+#         self.assertTrue(
+#             any(
+#                 xref.id == "ido:0000463" and xref.type == "skos:exactMatch"
+#                 for xref in e.xrefs
+#             )
+#         )
+#         self.assertEqual("float", e.suggested_data_type)
+#         self.assertEqual("unitless", e.suggested_unit)
+#
+#         res = self.client.get("/api/entity/askemo:0000010")
+#         self.assertIn("link", res.json())
+#         e = AskemEntity(**res.json())
+#         self.assertTrue(hasattr(e, "physical_min"))
+#         self.assertIsInstance(e.physical_min, float)
+#         self.assertEqual(0.0, e.physical_min)
+#
+#     def test_entities(self):
+#         """Test getting multiple entities."""
+#         res = self.client.get("/api/entities/ido:0000463,askemo:0000008")
+#         entities = [Entity.from_data(**record) for record in res.json()]
+#         self.assertEqual("ido:0000463", entities[0].id)
+#         self.assertEqual(f"{METAREGISTRY_BASE}/ido:0000463", entities[0].link)
+#         self.assertEqual("askemo:0000008", entities[1].id)
+#
+#     def test_entity_missing(self):
+#         """Test what happens when an entity is requested that's not in the DKG."""
+#         # Scenario 1: invalid prefix
+#         res = self.client.get("/api/entity/nope:0000008")
+#         self.assertEqual(404, res.status_code)
+#
+#         # Scenario 2: invalid identifier
+#         res = self.client.get("/api/entity/askemo:ABCDE")
+#         self.assertEqual(404, res.status_code)
+#
+#         # Scenario 3: just not in the DKG
+#         res = self.client.get("/api/entity/askemo:1000008")
+#         self.assertEqual(404, res.status_code)
+#
+#     def test_search_wikidata_fallback(self):
+#         # first, check that without fallback, no results are returned
+#         res = self.client.get("/api/search", params={
+#             "q": "charles tapley hoyt", "wikidata_fallback": False,
+#         })
+#         self.assertEqual(200, res.status_code)
+#         entities = [Entity(**e) for e in res.json()]
+#         self.assertEqual([], entities)
+#
+#         # now, turn on fallback
+#         res = self.client.get("/api/search", params={
+#             "q": "charles tapley hoyt", "wikidata_fallback": True,
+#         })
+#         self.assertEqual(200, res.status_code)
+#         entities = [Entity(**e) for e in res.json()]
+#         self.assertTrue(any(
+#             e.id == "wikidata:Q47475003"
+#             for e in entities
+#         ))
+#         self.assertEqual([], entities)
+#
+#     def test_parent_query(self):
+#         """Test parent query."""
+#         res = self.client.post(
+#             "/api/common_parent",
+#             json={"curie1": "ido:0000566",
+#                   "curie2": "ido:0000567"}
+#         )
+#         self.assertEqual(200, res.status_code)
+#
+#         # Try to parse the json to an Entity object
+#         entities = [Entity(**r) for r in res.json()]
+#
+#         # Check that the parent is correct
+#         assert len(entities) == 1
+#         entity = entities[0]
+#         assert entity.id == "ido:0000504"
+#         assert not entity.obsolete

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -1,129 +1,129 @@
-from itertools import product, chain
-
-from mira.examples.sir import sir
-from mira.metamodel import TemplateModel, Concept
-from mira.metamodel.comparison import TemplateModelComparison
-from mira.dkg.web_client import is_ontological_child_web
-
-
-def test_template_model_comp_graph_export():
-    # Check counts
-    # Check identifications
-    # check expected edges
-
-    # This will create a copy SIR model with context -> should have a
-    # refinement edge between each corresponding pair of nodes in the graph
-    sir_w_context = TemplateModel(
-        templates=[
-            t.with_context(location="geonames:4930956") for t in sir.templates
-        ],
-        parameters=sir.parameters,
-        initials=sir.initials,
-    )
-    tmc = TemplateModelComparison(
-        template_models=[sir, sir_w_context],
-        refinement_func=is_ontological_child_web,
-    )
-
-    # Check that the graph export is correct
-    graph_data = tmc.model_comparison
-
-    # Check that model ids are integers and non-negative
-    assert len(graph_data.concept_nodes.values()) > 0
-    # {model_id: {node_id: Concept|Template}}
-    assert isinstance(list(graph_data.template_nodes.values())[0], dict)
-    assert isinstance(list(list(graph_data.concept_nodes.values())[0].values())[0],
-                      Concept)
-    assert list(list(graph_data.concept_nodes.values())[0].keys())[0] >= 0
-    assert all(isinstance(k, int) for k in graph_data.template_models.keys())
-    assert all(k >= 0 for k in graph_data.template_models.keys())
-    model_id_refs = {k for k in graph_data.template_models.keys()}
-
-    model_id_refs_nodes = {model_id for model_id in graph_data.concept_nodes.keys()}
-    assert model_id_refs == model_id_refs_nodes
-
-    # One node per template per TemplateModel + one node per concept per
-    # template per TemplateModel
-    template_node_count = len(sir.templates) + len(sir_w_context.templates)
-    assert template_node_count == 4
-
-    concept_keys = set()
-    for t in chain(sir.templates, sir_w_context.templates):
-        for c in t.get_concepts():
-            concept_keys.add(c.get_key())
-
-    concept_node_count = len(concept_keys)
-    assert concept_node_count == 6
-    assert 10 == template_node_count + concept_node_count
-
-    # Check that all models are represented in the node lookup
-    assert len(graph_data.template_nodes) == len(graph_data.template_models)
-
-    # Check that the total count of nodes is as expected
-    total_count = 0
-    for nodes in graph_data.template_nodes.values():
-        total_count += len(nodes)
-    assert total_count == template_node_count
-
-    total_count = 0
-    for nodes in graph_data.concept_nodes.values():
-        total_count += len(nodes)
-    assert total_count == concept_node_count
-
-    # One intra edge per concept per template per TemplateModel
-    assert len(graph_data.intra_model_edges) == concept_node_count + template_node_count
-
-    # (One inter edge per refinement + one inter edge per equality) per TemplateModel
-    concept_equal_edges = 0
-    template_equal_edges = 0
-    concept_refinement_edges = 0
-    template_refinement_edges = 0
-    seen_concept_pairs = set()
-    for t1, t2 in product(sir.templates, sir_w_context.templates):
-        if t1.is_equal_to(t2, with_context=True):
-            template_equal_edges += 1
-        if t1.refinement_of(
-            t2, refinement_func=is_ontological_child_web, with_context=True
-        ):
-            template_refinement_edges += 1
-        if t2.refinement_of(
-            t1, refinement_func=is_ontological_child_web, with_context=True
-        ):
-            template_refinement_edges += 1
-        for c1, c2 in product(t1.get_concepts(), t2.get_concepts()):
-            if (c1.get_key(), c2.get_key()) in seen_concept_pairs:
-                continue
-            if c1.is_equal_to(c2, with_context=True):
-                concept_equal_edges += 1
-            if c1.refinement_of(
-                c2, refinement_func=is_ontological_child_web, with_context=True
-            ):
-                concept_refinement_edges += 1
-            if c2.refinement_of(
-                c1, refinement_func=is_ontological_child_web, with_context=True
-            ):
-                concept_refinement_edges += 1
-            seen_concept_pairs.add((c1.get_key(), c2.get_key()))
-
-    # Check that the counts are as expected
-    assert template_equal_edges == 0
-    assert template_refinement_edges == 2
-    assert concept_equal_edges == 0
-    assert concept_refinement_edges == 3
-
-    # check that the total number of inter edges is as expected and
-    # corresponds to what's in the graph data
-    inter_edge_count = (
-        template_equal_edges
-        + template_refinement_edges
-        + concept_refinement_edges
-        + concept_equal_edges
-    )
-    assert inter_edge_count == 5
-    assert len(graph_data.inter_model_edges) == inter_edge_count
-
-    # Score should be 0.5*number of refinement edges + 1*number of equal edges
-    sim_score = graph_data.get_similarity_score(0, 1)
-    assert sim_score == (0.5 * concept_refinement_edges +
-                         concept_equal_edges) / 3
-    assert sim_score == 1.5 / 3
+# from itertools import product, chain
+#
+# from mira.examples.sir import sir
+# from mira.metamodel import TemplateModel, Concept
+# from mira.metamodel.comparison import TemplateModelComparison
+# from mira.dkg.web_client import is_ontological_child_web
+#
+#
+# def test_template_model_comp_graph_export():
+#     # Check counts
+#     # Check identifications
+#     # check expected edges
+#
+#     # This will create a copy SIR model with context -> should have a
+#     # refinement edge between each corresponding pair of nodes in the graph
+#     sir_w_context = TemplateModel(
+#         templates=[
+#             t.with_context(location="geonames:4930956") for t in sir.templates
+#         ],
+#         parameters=sir.parameters,
+#         initials=sir.initials,
+#     )
+#     tmc = TemplateModelComparison(
+#         template_models=[sir, sir_w_context],
+#         refinement_func=is_ontological_child_web,
+#     )
+#
+#     # Check that the graph export is correct
+#     graph_data = tmc.model_comparison
+#
+#     # Check that model ids are integers and non-negative
+#     assert len(graph_data.concept_nodes.values()) > 0
+#     # {model_id: {node_id: Concept|Template}}
+#     assert isinstance(list(graph_data.template_nodes.values())[0], dict)
+#     assert isinstance(list(list(graph_data.concept_nodes.values())[0].values())[0],
+#                       Concept)
+#     assert list(list(graph_data.concept_nodes.values())[0].keys())[0] >= 0
+#     assert all(isinstance(k, int) for k in graph_data.template_models.keys())
+#     assert all(k >= 0 for k in graph_data.template_models.keys())
+#     model_id_refs = {k for k in graph_data.template_models.keys()}
+#
+#     model_id_refs_nodes = {model_id for model_id in graph_data.concept_nodes.keys()}
+#     assert model_id_refs == model_id_refs_nodes
+#
+#     # One node per template per TemplateModel + one node per concept per
+#     # template per TemplateModel
+#     template_node_count = len(sir.templates) + len(sir_w_context.templates)
+#     assert template_node_count == 4
+#
+#     concept_keys = set()
+#     for t in chain(sir.templates, sir_w_context.templates):
+#         for c in t.get_concepts():
+#             concept_keys.add(c.get_key())
+#
+#     concept_node_count = len(concept_keys)
+#     assert concept_node_count == 6
+#     assert 10 == template_node_count + concept_node_count
+#
+#     # Check that all models are represented in the node lookup
+#     assert len(graph_data.template_nodes) == len(graph_data.template_models)
+#
+#     # Check that the total count of nodes is as expected
+#     total_count = 0
+#     for nodes in graph_data.template_nodes.values():
+#         total_count += len(nodes)
+#     assert total_count == template_node_count
+#
+#     total_count = 0
+#     for nodes in graph_data.concept_nodes.values():
+#         total_count += len(nodes)
+#     assert total_count == concept_node_count
+#
+#     # One intra edge per concept per template per TemplateModel
+#     assert len(graph_data.intra_model_edges) == concept_node_count + template_node_count
+#
+#     # (One inter edge per refinement + one inter edge per equality) per TemplateModel
+#     concept_equal_edges = 0
+#     template_equal_edges = 0
+#     concept_refinement_edges = 0
+#     template_refinement_edges = 0
+#     seen_concept_pairs = set()
+#     for t1, t2 in product(sir.templates, sir_w_context.templates):
+#         if t1.is_equal_to(t2, with_context=True):
+#             template_equal_edges += 1
+#         if t1.refinement_of(
+#             t2, refinement_func=is_ontological_child_web, with_context=True
+#         ):
+#             template_refinement_edges += 1
+#         if t2.refinement_of(
+#             t1, refinement_func=is_ontological_child_web, with_context=True
+#         ):
+#             template_refinement_edges += 1
+#         for c1, c2 in product(t1.get_concepts(), t2.get_concepts()):
+#             if (c1.get_key(), c2.get_key()) in seen_concept_pairs:
+#                 continue
+#             if c1.is_equal_to(c2, with_context=True):
+#                 concept_equal_edges += 1
+#             if c1.refinement_of(
+#                 c2, refinement_func=is_ontological_child_web, with_context=True
+#             ):
+#                 concept_refinement_edges += 1
+#             if c2.refinement_of(
+#                 c1, refinement_func=is_ontological_child_web, with_context=True
+#             ):
+#                 concept_refinement_edges += 1
+#             seen_concept_pairs.add((c1.get_key(), c2.get_key()))
+#
+#     # Check that the counts are as expected
+#     assert template_equal_edges == 0
+#     assert template_refinement_edges == 2
+#     assert concept_equal_edges == 0
+#     assert concept_refinement_edges == 3
+#
+#     # check that the total number of inter edges is as expected and
+#     # corresponds to what's in the graph data
+#     inter_edge_count = (
+#         template_equal_edges
+#         + template_refinement_edges
+#         + concept_refinement_edges
+#         + concept_equal_edges
+#     )
+#     assert inter_edge_count == 5
+#     assert len(graph_data.inter_model_edges) == inter_edge_count
+#
+#     # Score should be 0.5*number of refinement edges + 1*number of equal edges
+#     sim_score = graph_data.get_similarity_score(0, 1)
+#     assert sim_score == (0.5 * concept_refinement_edges +
+#                          concept_equal_edges) / 3
+#     assert sim_score == 1.5 / 3

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -1,129 +1,129 @@
-# from itertools import product, chain
-#
-# from mira.examples.sir import sir
-# from mira.metamodel import TemplateModel, Concept
-# from mira.metamodel.comparison import TemplateModelComparison
-# from mira.dkg.web_client import is_ontological_child_web
-#
-#
-# def test_template_model_comp_graph_export():
-#     # Check counts
-#     # Check identifications
-#     # check expected edges
-#
-#     # This will create a copy SIR model with context -> should have a
-#     # refinement edge between each corresponding pair of nodes in the graph
-#     sir_w_context = TemplateModel(
-#         templates=[
-#             t.with_context(location="geonames:4930956") for t in sir.templates
-#         ],
-#         parameters=sir.parameters,
-#         initials=sir.initials,
-#     )
-#     tmc = TemplateModelComparison(
-#         template_models=[sir, sir_w_context],
-#         refinement_func=is_ontological_child_web,
-#     )
-#
-#     # Check that the graph export is correct
-#     graph_data = tmc.model_comparison
-#
-#     # Check that model ids are integers and non-negative
-#     assert len(graph_data.concept_nodes.values()) > 0
-#     # {model_id: {node_id: Concept|Template}}
-#     assert isinstance(list(graph_data.template_nodes.values())[0], dict)
-#     assert isinstance(list(list(graph_data.concept_nodes.values())[0].values())[0],
-#                       Concept)
-#     assert list(list(graph_data.concept_nodes.values())[0].keys())[0] >= 0
-#     assert all(isinstance(k, int) for k in graph_data.template_models.keys())
-#     assert all(k >= 0 for k in graph_data.template_models.keys())
-#     model_id_refs = {k for k in graph_data.template_models.keys()}
-#
-#     model_id_refs_nodes = {model_id for model_id in graph_data.concept_nodes.keys()}
-#     assert model_id_refs == model_id_refs_nodes
-#
-#     # One node per template per TemplateModel + one node per concept per
-#     # template per TemplateModel
-#     template_node_count = len(sir.templates) + len(sir_w_context.templates)
-#     assert template_node_count == 4
-#
-#     concept_keys = set()
-#     for t in chain(sir.templates, sir_w_context.templates):
-#         for c in t.get_concepts():
-#             concept_keys.add(c.get_key())
-#
-#     concept_node_count = len(concept_keys)
-#     assert concept_node_count == 6
-#     assert 10 == template_node_count + concept_node_count
-#
-#     # Check that all models are represented in the node lookup
-#     assert len(graph_data.template_nodes) == len(graph_data.template_models)
-#
-#     # Check that the total count of nodes is as expected
-#     total_count = 0
-#     for nodes in graph_data.template_nodes.values():
-#         total_count += len(nodes)
-#     assert total_count == template_node_count
-#
-#     total_count = 0
-#     for nodes in graph_data.concept_nodes.values():
-#         total_count += len(nodes)
-#     assert total_count == concept_node_count
-#
-#     # One intra edge per concept per template per TemplateModel
-#     assert len(graph_data.intra_model_edges) == concept_node_count + template_node_count
-#
-#     # (One inter edge per refinement + one inter edge per equality) per TemplateModel
-#     concept_equal_edges = 0
-#     template_equal_edges = 0
-#     concept_refinement_edges = 0
-#     template_refinement_edges = 0
-#     seen_concept_pairs = set()
-#     for t1, t2 in product(sir.templates, sir_w_context.templates):
-#         if t1.is_equal_to(t2, with_context=True):
-#             template_equal_edges += 1
-#         if t1.refinement_of(
-#             t2, refinement_func=is_ontological_child_web, with_context=True
-#         ):
-#             template_refinement_edges += 1
-#         if t2.refinement_of(
-#             t1, refinement_func=is_ontological_child_web, with_context=True
-#         ):
-#             template_refinement_edges += 1
-#         for c1, c2 in product(t1.get_concepts(), t2.get_concepts()):
-#             if (c1.get_key(), c2.get_key()) in seen_concept_pairs:
-#                 continue
-#             if c1.is_equal_to(c2, with_context=True):
-#                 concept_equal_edges += 1
-#             if c1.refinement_of(
-#                 c2, refinement_func=is_ontological_child_web, with_context=True
-#             ):
-#                 concept_refinement_edges += 1
-#             if c2.refinement_of(
-#                 c1, refinement_func=is_ontological_child_web, with_context=True
-#             ):
-#                 concept_refinement_edges += 1
-#             seen_concept_pairs.add((c1.get_key(), c2.get_key()))
-#
-#     # Check that the counts are as expected
-#     assert template_equal_edges == 0
-#     assert template_refinement_edges == 2
-#     assert concept_equal_edges == 0
-#     assert concept_refinement_edges == 3
-#
-#     # check that the total number of inter edges is as expected and
-#     # corresponds to what's in the graph data
-#     inter_edge_count = (
-#         template_equal_edges
-#         + template_refinement_edges
-#         + concept_refinement_edges
-#         + concept_equal_edges
-#     )
-#     assert inter_edge_count == 5
-#     assert len(graph_data.inter_model_edges) == inter_edge_count
-#
-#     # Score should be 0.5*number of refinement edges + 1*number of equal edges
-#     sim_score = graph_data.get_similarity_score(0, 1)
-#     assert sim_score == (0.5 * concept_refinement_edges +
-#                          concept_equal_edges) / 3
-#     assert sim_score == 1.5 / 3
+from itertools import product, chain
+
+from mira.examples.sir import sir
+from mira.metamodel import TemplateModel, Concept
+from mira.metamodel.comparison import TemplateModelComparison
+from mira.dkg.web_client import is_ontological_child_web
+
+
+def test_template_model_comp_graph_export():
+    # Check counts
+    # Check identifications
+    # check expected edges
+
+    # This will create a copy SIR model with context -> should have a
+    # refinement edge between each corresponding pair of nodes in the graph
+    sir_w_context = TemplateModel(
+        templates=[
+            t.with_context(location="geonames:4930956") for t in sir.templates
+        ],
+        parameters=sir.parameters,
+        initials=sir.initials,
+    )
+    tmc = TemplateModelComparison(
+        template_models=[sir, sir_w_context],
+        refinement_func=is_ontological_child_web,
+    )
+
+    # Check that the graph export is correct
+    graph_data = tmc.model_comparison
+
+    # Check that model ids are integers and non-negative
+    assert len(graph_data.concept_nodes.values()) > 0
+    # {model_id: {node_id: Concept|Template}}
+    assert isinstance(list(graph_data.template_nodes.values())[0], dict)
+    assert isinstance(list(list(graph_data.concept_nodes.values())[0].values())[0],
+                      Concept)
+    assert list(list(graph_data.concept_nodes.values())[0].keys())[0] >= 0
+    assert all(isinstance(k, int) for k in graph_data.template_models.keys())
+    assert all(k >= 0 for k in graph_data.template_models.keys())
+    model_id_refs = {k for k in graph_data.template_models.keys()}
+
+    model_id_refs_nodes = {model_id for model_id in graph_data.concept_nodes.keys()}
+    assert model_id_refs == model_id_refs_nodes
+
+    # One node per template per TemplateModel + one node per concept per
+    # template per TemplateModel
+    template_node_count = len(sir.templates) + len(sir_w_context.templates)
+    assert template_node_count == 4
+
+    concept_keys = set()
+    for t in chain(sir.templates, sir_w_context.templates):
+        for c in t.get_concepts():
+            concept_keys.add(c.get_key())
+
+    concept_node_count = len(concept_keys)
+    assert concept_node_count == 6
+    assert 10 == template_node_count + concept_node_count
+
+    # Check that all models are represented in the node lookup
+    assert len(graph_data.template_nodes) == len(graph_data.template_models)
+
+    # Check that the total count of nodes is as expected
+    total_count = 0
+    for nodes in graph_data.template_nodes.values():
+        total_count += len(nodes)
+    assert total_count == template_node_count
+
+    total_count = 0
+    for nodes in graph_data.concept_nodes.values():
+        total_count += len(nodes)
+    assert total_count == concept_node_count
+
+    # One intra edge per concept per template per TemplateModel
+    assert len(graph_data.intra_model_edges) == concept_node_count + template_node_count
+
+    # (One inter edge per refinement + one inter edge per equality) per TemplateModel
+    concept_equal_edges = 0
+    template_equal_edges = 0
+    concept_refinement_edges = 0
+    template_refinement_edges = 0
+    seen_concept_pairs = set()
+    for t1, t2 in product(sir.templates, sir_w_context.templates):
+        if t1.is_equal_to(t2, with_context=True):
+            template_equal_edges += 1
+        if t1.refinement_of(
+            t2, refinement_func=is_ontological_child_web, with_context=True
+        ):
+            template_refinement_edges += 1
+        if t2.refinement_of(
+            t1, refinement_func=is_ontological_child_web, with_context=True
+        ):
+            template_refinement_edges += 1
+        for c1, c2 in product(t1.get_concepts(), t2.get_concepts()):
+            if (c1.get_key(), c2.get_key()) in seen_concept_pairs:
+                continue
+            if c1.is_equal_to(c2, with_context=True):
+                concept_equal_edges += 1
+            if c1.refinement_of(
+                c2, refinement_func=is_ontological_child_web, with_context=True
+            ):
+                concept_refinement_edges += 1
+            if c2.refinement_of(
+                c1, refinement_func=is_ontological_child_web, with_context=True
+            ):
+                concept_refinement_edges += 1
+            seen_concept_pairs.add((c1.get_key(), c2.get_key()))
+
+    # Check that the counts are as expected
+    assert template_equal_edges == 0
+    assert template_refinement_edges == 2
+    assert concept_equal_edges == 0
+    assert concept_refinement_edges == 3
+
+    # check that the total number of inter edges is as expected and
+    # corresponds to what's in the graph data
+    inter_edge_count = (
+        template_equal_edges
+        + template_refinement_edges
+        + concept_refinement_edges
+        + concept_equal_edges
+    )
+    assert inter_edge_count == 5
+    assert len(graph_data.inter_model_edges) == inter_edge_count
+
+    # Score should be 0.5*number of refinement edges + 1*number of equal edges
+    sim_score = graph_data.get_similarity_score(0, 1)
+    assert sim_score == (0.5 * concept_refinement_edges +
+                         concept_equal_edges) / 3
+    assert sim_score == 1.5 / 3

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -582,12 +582,13 @@ class TestModelApi(unittest.TestCase):
             "exclude_defaults": True,
             "exclude_unset": True,
             "exclude_none": True,
-            "skip_defaults": True,
+            # "skip_defaults": True,
         }
         # Compare the ModelComparisonResponse models
         assert local_response == resp_model  # If assertion fails the diff is printed
         local_sorted_str = sorted_json_str(
-            json.loads(local_response.json(**dict_options)), skip_empty=True
+            json.loads(local_response.model_dump_json(**dict_options)),
+            skip_empty=True
         )
         resp_sorted_str = sorted_json_str(
             json.loads(resp_model.json(**dict_options)), skip_empty=True

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -587,7 +587,7 @@ class TestModelApi(unittest.TestCase):
         # Compare the ModelComparisonResponse models
         assert local_response == resp_model  # If assertion fails the diff is printed
         local_sorted_str = sorted_json_str(
-            json.loads(local_response.model_dump_json(**dict_options)),
+            json.loads(local_response.json(**dict_options)),
             skip_empty=True
         )
         resp_sorted_str = sorted_json_str(


### PR DESCRIPTION
This PR updates the code in various places to make it compatible with Pydantic2's stricter type enforcement. Additionally, Pydantic2 generates a more detailed but not meaningfully different schema compared to the schema generated from Pydantic1.

The `MIRA_REST_URL` for the Github workflows testing configuration has been updated as well to reflect migrated MIRA services. `Pydantic>=2.0.0`, `fastapi>=0.100.0`, and `httpx` are the new dependency updates.  

