### PR TITLE
Fix sbml amr export

### DIFF
--- a/mira/modeling/__init__.py
+++ b/mira/modeling/__init__.py
@@ -284,6 +284,7 @@ class Model:
                                            self.template_model.initials)
                     for participant in template.left
                 )
+                consumed_key = tuple(c.key for c in consumed)
             else:
                 consumed, consumed_key = tuple(), None
 
@@ -333,6 +334,7 @@ class Model:
                                            self.template_model.initials)
                     for participant in template.right
                 )
+                produced_key = tuple(p.key for p in produced)
             elif not is_replication(template):
                 produced, produced_key = tuple(), None
 

--- a/tests/test_metamodel.py
+++ b/tests/test_metamodel.py
@@ -263,3 +263,17 @@ def test_initial_expression_float():
     init = Initial(concept=Concept(name='x'), expression=1)
     assert isinstance(init.expression, SympyExprStr)
     assert isinstance(init.expression.args[0], sympy.Expr)
+
+
+def test_reversible_flux():
+    from mira.modeling import Model
+    from mira.modeling.amr.petrinet import template_model_to_petrinet_json
+    t = ReversibleFlux(
+        left=[Concept(name='x')],
+        right=[Concept(name='y')],
+    )
+    # Make sure we can export to AMR
+    tm = TemplateModel(templates=[t])
+    model = Model(tm)
+    amr = template_model_to_petrinet_json(tm)
+


### PR DESCRIPTION
This PR addresses issue #366 by making sure we define a `consumed_key` and `produced_key` tuple when an sbml template is reversible. 