### PR TITLE
Only filter cities by minimum population

### DIFF
--- a/mira/dkg/resources/geonames.py
+++ b/mira/dkg/resources/geonames.py
@@ -109,16 +109,14 @@ def get_cities(code_to_country, code_to_admin1, code_to_admin2, *, minimum_popul
         ),
     )
 
-    cities_df = cities_df[cities_df.population.astype(int) > minimum_population]
     cities_df.synonyms = cities_df.synonyms.str.split(",")
 
     terms = {}
     for term in code_to_country.values():
         terms[term.identifier] = term
-
-    cols = ["geonames_id", "name", "synonyms", "country_code", "admin1", "admin2"]
-    for identifier, name, synonyms, country, admin1, admin2 in cities_df[cols].values:
-        terms[identifier] = term = Term.from_triple("geonames", identifier, name)
+    cols = ["geonames_id", "name", "synonyms", "country_code", "admin1",
+            "admin2", "population"]
+    for identifier, name, synonyms, country, admin1, admin2, population in (cities_df[cols].values):
         if synonyms and not isinstance(synonyms, float):
             for synoynm in synonyms:
                 term.append_synonym(synoynm)
@@ -135,6 +133,11 @@ def get_cities(code_to_country, code_to_admin1, code_to_admin2, *, minimum_popul
 
         terms[admin1_term.identifier] = admin1_term
 
+        # We skip cities that don't meet the minimum population requirement
+        if int(population) < minimum_population:
+            continue
+        terms[identifier] = term = Term.from_triple("geonames", identifier,
+                                                    name)
         if pd.notna(admin2):
             admin2_full = f"{country}.{admin1}.{admin2}"
             admin2_term = code_to_admin2.get(admin2_full)


### PR DESCRIPTION
This PR addresses #370 by only removing cities with population under the minimum threshold after their related first order adminsitrative divisions have been added when we get geoname terms. After using the `add_resource` endpoint and adding geoname terms to the dkg, we can confirm the precense of the missing geoname nodes mentioned in the linked issue. The new set of geoname terms is a superset of the old set and around 1,200 more geoname terms have been added.

- `[
  {
    "id": "geonames:4142224",
    "name": "Delaware",
    "type": "individual",
    "obsolete": false,
    "synonyms": [],
    "xrefs": [],
    "labels": [],
    "properties": {
      "code": [
        "US.DE"
      ]
    }
  }
]`

- `
  {
    "id": "geonames:5843591",
    "name": "Wyoming",
    "type": "individual",
    "obsolete": false,
    "synonyms": [],
    "xrefs": [],
    "labels": [],
    "properties": {
      "code": [
        "US.WY"
      ]
    }
  }
]`

- `[
  {
    "id": "geonames:4971068",
    "name": "Maine",
    "type": "individual",
    "obsolete": false,
    "synonyms": [],
    "xrefs": [],
    "labels": [],
    "properties": {
      "code": [
        "US.ME"
      ]
    }
  }
]`

- `[
  {
    "id": "geonames:4826850",
    "name": "West Virginia",
    "type": "individual",
    "obsolete": false,
    "synonyms": [],
    "xrefs": [],
    "labels": [],
    "properties": {
      "code": [
        "US.WV"
      ]
    }
  }
]`

- `[
  {
    "id": "geonames:5242283",
    "name": "Vermont",
    "type": "individual",
    "obsolete": false,
    "synonyms": [],
    "xrefs": [],
    "labels": [],
    "properties": {
      "code": [
        "US.VT"
      ]
    }
  }
]`