### PR TITLE
Add all geonames admin2 regions 

### DIFF
--- a/mira/dkg/resources/geonames.py
+++ b/mira/dkg/resources/geonames.py
@@ -133,11 +133,6 @@ def get_cities(code_to_country, code_to_admin1, code_to_admin2, *, minimum_popul
 
         terms[admin1_term.identifier] = admin1_term
 
-        # We skip cities that don't meet the minimum population requirement
-        if int(population) < minimum_population:
-            continue
-        terms[identifier] = term = Term.from_triple("geonames", identifier,
-                                                    name)
         if pd.notna(admin2):
             admin2_full = f"{country}.{admin1}.{admin2}"
             admin2_term = code_to_admin2.get(admin2_full)
@@ -152,4 +147,9 @@ def get_cities(code_to_country, code_to_admin1, code_to_admin2, *, minimum_popul
             # If there's no admin 2, just annotate directly onto admin 1
             term.append_relationship(part_of, admin1_term)
 
+        # We skip cities that don't meet the minimum population requirement
+        if int(population) < minimum_population:
+            continue
+        terms[identifier] = term = Term.from_triple("geonames", identifier,
+                                                    name)
     return terms


### PR DESCRIPTION
This PR performs the minimum city population check of geonames cities only after all administrative 1 and 2 regions have been processed from geonames. Previously before any changes to geonames processing, we had 9,700 geonames terms. After making sure we add all admin1 regions we have 10,900 terms, and after masking sure we add all admin2 regions we have roughly 17,900 terms. 