### PR TITLE
Update util.py

### DIFF
--- a/mira/sources/util.py
+++ b/mira/sources/util.py
@@ -192,7 +192,7 @@ def parameter_to_mira(parameter, param_symbols=None) -> Parameter:
                 processed_distr_parameters[param_key] = \
                     safe_parse_expr(param_value)
             else:
-                raise ValueError(f"{param_value} is neither a float, int, or str")
+                raise ValueError(f"Parameter {param_key} of type {type(param_value)} has value {param_value} that is neither a float, int, or str")
         distr = Distribution(
             type=distr_type,
             parameters=processed_distr_parameters,

--- a/mira/sources/util.py
+++ b/mira/sources/util.py
@@ -186,7 +186,7 @@ def parameter_to_mira(parameter, param_symbols=None) -> Parameter:
         # We need to check for symbolic expressions in parameters
         processed_distr_parameters = {}
         for param_key, param_value in distr_json.get("parameters", {}).items():
-            if isinstance(param_value, float):
+            if isinstance(param_value, float) or isinstance(param_value, int):
                 processed_distr_parameters[param_key] = param_value
             else:
                 processed_distr_parameters[param_key] = \

--- a/mira/sources/util.py
+++ b/mira/sources/util.py
@@ -187,7 +187,7 @@ def parameter_to_mira(parameter, param_symbols=None) -> Parameter:
         processed_distr_parameters = {}
         for param_key, param_value in distr_json.get("parameters", {}).items():
             if isinstance(param_value, float) or isinstance(param_value, int):
-                processed_distr_parameters[param_key] = param_value
+                processed_distr_parameters[param_key] = float(param_value)
             elif isinstance(param_value, str):
                 processed_distr_parameters[param_key] = \
                     safe_parse_expr(param_value)

--- a/mira/sources/util.py
+++ b/mira/sources/util.py
@@ -192,7 +192,8 @@ def parameter_to_mira(parameter, param_symbols=None) -> Parameter:
                 processed_distr_parameters[param_key] = \
                     safe_parse_expr(param_value)
             else:
-                raise ValueError(f"Parameter {param_key} of type {type(param_value)} has value {param_value} that is neither a float, int, or str")
+                raise ValueError(f"Parameter {param_key} is neither a float, "
+                                 f"int, or str")
         distr = Distribution(
             type=distr_type,
             parameters=processed_distr_parameters,

--- a/mira/sources/util.py
+++ b/mira/sources/util.py
@@ -188,9 +188,11 @@ def parameter_to_mira(parameter, param_symbols=None) -> Parameter:
         for param_key, param_value in distr_json.get("parameters", {}).items():
             if isinstance(param_value, float) or isinstance(param_value, int):
                 processed_distr_parameters[param_key] = param_value
-            else:
+            elif isinstance(param_value, str):
                 processed_distr_parameters[param_key] = \
                     safe_parse_expr(param_value)
+            else:
+                raise ValueError(f"{param_value} is neither a float, int, or str")
         distr = Distribution(
             type=distr_type,
             parameters=processed_distr_parameters,


### PR DESCRIPTION
If the parameter is a float **or an int** assign the parameter value.   Should also put a check to see if the value is a string before passing the value to `safe_parse`, and raise an error if it isn't.