### PR TITLE
Add "rdfs:subclassof" as a refinement relation 

### DIFF
--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -72,7 +72,7 @@ PREFIXES = [
 ]
 
 #: A list of all relation types that are considered refinement relations
-DKG_REFINER_RELS = ["subclassof", "part_of"]
+DKG_REFINER_RELS = ["rdfs:subclassof", "subclassof", "part_of"]
 
 #: The root path of the MIRA app when running in a container
 DOCKER_FILES_ROOT = Path("/sw")

--- a/mira/dkg/utils.py
+++ b/mira/dkg/utils.py
@@ -72,7 +72,8 @@ PREFIXES = [
 ]
 
 #: A list of all relation types that are considered refinement relations
-DKG_REFINER_RELS = ["rdfs:subclassof", "subclassof", "part_of"]
+#  Must enclose relation types with ":" with backtick (`) 
+DKG_REFINER_RELS = ["`rdfs:subclassof`", "subclassof", "part_of"]
 
 #: The root path of the MIRA app when running in a container
 DOCKER_FILES_ROOT = Path("/sw")


### PR DESCRIPTION
This PR adds the `rdf:subclassof` relation as a refinement relation when testing if a curie is an ontological child of another curie. We add this relation because the dkg construction pipeline now classifies subclass relation types as `rdf:subclassof` instead of `subclassof` in the neo4j graph. 

This has been tested locally with a local version of the REST API and `tests/test_template/test_concept_refinement_grounding` now passes when making a request to the local version of the REST API. 