### PR TITLE
Fix unit processing for model ingestion 

### DIFF
--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -1,3 +1,5 @@
+import copy
+
 from pydantic import ConfigDict
 
 __all__ = [
@@ -473,6 +475,8 @@ class TemplateModel(BaseModel):
         :
             Returns the newly created template model.
         """
+        # Do a copy just to make sure we don't modify the original data
+        data = copy.deepcopy(data)
         local_symbols = {p: sympy.Symbol(p) for p in data.get("parameters", [])}
         for template_dict in data.get("templates", []):
             # We need to figure out the template class based on the type

--- a/mira/metamodel/templates.py
+++ b/mira/metamodel/templates.py
@@ -3,6 +3,8 @@ Data models for metamodel templates.
 
 Regenerate the JSON schema by running ``python -m mira.metamodel.schema``.
 """
+import copy
+
 from pydantic import ConfigDict
 from typing import Literal
 
@@ -376,6 +378,8 @@ class Concept(BaseModel):
         if isinstance(data, Concept):
             return data
         elif data.get('units'):
+            # Copy so we don't update the input
+            data = copy.deepcopy(data)
             data['units'] = Unit.from_json(data['units'])
 
         return cls(**data)
@@ -413,6 +417,8 @@ class Template(BaseModel):
         :
             A Template object
         """
+        # Make a copy to make sure we don't update the input
+        data = copy.deepcopy(data)
         # We make sure to use data such that it's not modified in place,
         # e.g., we don't use pop or overwrite items, otherwise this function
         # would have unintended side effects.

--- a/mira/metamodel/units.py
+++ b/mira/metamodel/units.py
@@ -42,8 +42,8 @@ class Unit(BaseModel):
 
     @classmethod
     def from_json(cls, data: Dict[str, Any]) -> "Unit":
-        # Use get_sympy from amr.petrinet, but avoid circular import
-        from mira.sources.amr.petrinet import get_sympy
+        # Use get_sympy from sources, but avoid circular import
+        from mira.sources.util import get_sympy
         new_data = data.copy()
         new_data["expression"] = get_sympy(data, local_dict=UNIT_SYMBOLS)
         assert (new_data.get('expression') is None or

--- a/mira/metamodel/units.py
+++ b/mira/metamodel/units.py
@@ -44,11 +44,12 @@ class Unit(BaseModel):
     def from_json(cls, data: Dict[str, Any]) -> "Unit":
         # Use get_sympy from amr.petrinet, but avoid circular import
         from mira.sources.amr.petrinet import get_sympy
-        data["expression"] = get_sympy(data, local_dict=UNIT_SYMBOLS)
-        assert data.get('expression') is None or not isinstance(
-            data['expression'], str
-        )
-        return cls(**data)
+        new_data = data.copy()
+        new_data["expression"] = get_sympy(data, local_dict=UNIT_SYMBOLS)
+        assert (new_data.get('expression') is None or
+                not isinstance(new_data.get('expression'), str))
+
+        return cls(**new_data)
 
     @classmethod
     def model_validate(cls, obj):

--- a/tests/test_modeling/test_amr_ops.py
+++ b/tests/test_modeling/test_amr_ops.py
@@ -1,8 +1,10 @@
 import unittest
 import requests
 from copy import deepcopy as _d
+
 from mira.modeling.amr.ops import *
 from mira.metamodel.io import mathml_to_expression
+from mira.metamodel import safe_parse_expr
 
 try:
     import sbmlmath
@@ -270,8 +272,9 @@ class TestAskenetOperations(unittest.TestCase):
 
         self.assertEqual(old_param_dict[old_id]['value'], new_param_dict[new_id]['value'])
         self.assertEqual(old_param_dict[old_id]['distribution'], new_param_dict[new_id]['distribution'])
-        self.assertEqual(str(old_param_dict[old_id]['units']['expression']),
-                         new_param_dict[new_id]['units']['expression'])
+        self.assertEqual(safe_parse_expr(old_param_dict[old_id]['units']['expression']),
+                         safe_parse_expr(new_param_dict[new_id]['units'][
+                                             'expression']))
         self.assertEqual(mathml_to_expression(old_param_dict[old_id]['units']['expression_mathml']),
                          mathml_to_expression(new_param_dict[new_id]['units']['expression_mathml']))
 


### PR DESCRIPTION
This PR creates a copy of the unit dictionary when processing units for model ingestion. This ensures that the expression field for a unit remains a string and can be serialized back into json format. 