### PR TITLE
Generalize SBML initial condition extraction

### DIFF
--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -345,8 +345,10 @@ class SbmlProcessor:
             # initial_concentration is still a float value (even if not
             # defined in the XML) with value 0.0. So we have to do a more complex
             # check here.
-            init_amount_falsy = not species.initial_amount
-            init_conc_falsy = not species.initial_concentration
+            init_amount_falsy = (not species.initial_amount) \
+                or math.isnan(species.initial_amount)
+            init_conc_falsy = (not species.initial_concentration) \
+                or math.isnan(species.initial_concentration)
             if init_conc_falsy and not init_amount_falsy:
                 init_value = species.initial_amount
             elif not init_conc_falsy:

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -564,9 +564,10 @@ def variables_from_ast(ast_node):
 
 
 def _extract_concept(species, units=None, model_id=None):
+    # Generally, species have an ID and a name
     species_id = species.getId()
-    species_name = species.getName()
-    display_name = species_name if species_name else species_id
+    # If the name is missing, we revert to the ID as the name
+    species_name = species.getName() or species_id
     if "(" in species_name or not species_name:
         species_name = species_id
 
@@ -576,7 +577,7 @@ def _extract_concept(species, units=None, model_id=None):
         mapped_ids, mapped_context = grounding_map[(model_id, species_name)]
         concept = Concept(
             name=species_name,
-            display_name=display_name,
+            display_name=species_name,
             identifiers=copy.deepcopy(mapped_ids),
             context=copy.deepcopy(mapped_context),
             units=units,
@@ -597,7 +598,7 @@ def _extract_concept(species, units=None, model_id=None):
         logger.debug(f"[{model_id} species:{species_id}] had no annotations")
         concept = Concept(
             name=species_name,
-            display_name=display_name,
+            display_name=species_name,
             identifiers={},
             context={},
             units=units,
@@ -709,7 +710,7 @@ def _extract_concept(species, units=None, model_id=None):
         identifiers["biomodels.species"] = f"{model_id}:{species_id}"
     concept = Concept(
         name=species_name or species_id,
-        display_name=display_name,
+        display_name=species_name,
         identifiers=identifiers,
         # TODO how to handle multiple properties? can we extend context to allow lists?
         context=context,


### PR DESCRIPTION
This PR handles a corner case when a species is missing a name, and generalizes initial value extraction to cases where an initial amount is given instead of an initial concentration.

Fixes #374 