### PR TITLE
Update utils.py

### DIFF
--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -14,6 +14,8 @@ def get_parseable_expression(s: str) -> str:
     """Return an expression that can be parsed using sympy."""
     # Handle lambda which cannot be parsed by sympy
     s = s.replace('lambda', 'XXlambdaXX')
+    # Handle gamma which interprets this as the Gamma function
+    s = s.replace('gamma', 'XXgammaXX')
     # Handle dots which also cannot be parsed
     s = re.sub(r'\.(?=\D)', 'XX_XX', s)
     # Handle superscripts which are not allowed in sympy


### PR DESCRIPTION
It turns out that `Symbol('gamma')` is interpreted as the $\Gamma$ function in sympy

```python
beta_mean = Parameter(name='beta_mean',
                    distribution=Distribution(type="Beta1",
                    parameters={'alpha': sympy.Integer(10)*sympy.Symbol("gamma"),
                                'beta': sympy.Integer(10)}))
```

results in this error:

```python
ValueError: Error from parse_expr with transformed code: 'Integer (10 )*gamma '
TypeError: unsupported operand type(s) for *: 'Integer' and 'FunctionClass
```

I think the solution is just to treat `gamma` as a reserved word in sympy.