### PR TITLE
Add model parameters to safe parse of distribution parameters

### DIFF
--- a/mira/sources/util.py
+++ b/mira/sources/util.py
@@ -190,7 +190,7 @@ def parameter_to_mira(parameter, param_symbols=None) -> Parameter:
                 processed_distr_parameters[param_key] = float(param_value)
             elif isinstance(param_value, str):
                 processed_distr_parameters[param_key] = \
-                    safe_parse_expr(param_value)
+                    safe_parse_expr(param_value, local_dict=param_symbols)
             else:
                 raise ValueError(f"Parameter {param_key} is neither a float, "
                                  f"int, or str")


### PR DESCRIPTION
Sympy expressions of distribution parameters may contain model parameters as free variables.

Therefore, this line:

https://github.com/gyorilab/mira/blob/e559f4664abb3f59c019d86c9f3bc112420f6cdf/mira/sources/util.py#L191-L193

should be:


```python
            elif isinstance(param_value, str):
                processed_distr_parameters[param_key] = \
                    safe_parse_expr(param_value, local_dict=param_symbols)
```

This PR passes  `param_symbols` to the safe parse of distribution parameter expressions.  This will support the representation of multi-level models.

