### PR TITLE
Propagate concept descriptions

### DIFF
--- a/mira/modeling/amr/petrinet.py
+++ b/mira/modeling/amr/petrinet.py
@@ -79,8 +79,7 @@ class AMRPetriNetModel:
                                     var.concept.identifiers.items()
                                     if k != 'biomodels.species'},
                     'modifiers': var.concept.context,
-                },
-
+                }
             if var.concept.units:
                 states_dict['units'] = {
                     'expression': str(var.concept.units.expression),
@@ -408,6 +407,7 @@ class Units(BaseModel):
 class State(BaseModel):
     id: str
     name: Optional[str] = None
+    description: Optional[str] = None
     grounding: Optional[Dict] = None
     units: Optional[Units] = None
 

--- a/mira/modeling/amr/petrinet.py
+++ b/mira/modeling/amr/petrinet.py
@@ -61,6 +61,7 @@ class AMRPetriNetModel:
             # on the key otherwise
             vmap[key] = name = var.concept.name or str(key)
             display_name = var.concept.display_name or name
+            description = var.concept.description
             # State structure
             # {
             #   'id': str,
@@ -69,14 +70,17 @@ class AMRPetriNetModel:
             # }
             states_dict = {
                 'id': name,
-                'name': display_name,
-                'grounding': {
+                'name': display_name
+            }
+            if description:
+                states_dict['description'] = description
+            states_dict['grounding'] =  {
                     'identifiers': {k: v for k, v in
                                     var.concept.identifiers.items()
                                     if k != 'biomodels.species'},
                     'modifiers': var.concept.context,
                 },
-            }
+
             if var.concept.units:
                 states_dict['units'] = {
                     'expression': str(var.concept.units.expression),

--- a/mira/modeling/amr/stockflow.py
+++ b/mira/modeling/amr/stockflow.py
@@ -72,16 +72,19 @@ class AMRStockFlowModel:
         for key, var in model.variables.items():
             vmap[key] = name = var.concept.name or str(key)
             display_name = var.concept.display_name or name
+            description = var.concept.description
             stocks_dict = {
                 'id': name,
-                'name': display_name,
-                'grounding': {
+                'name': display_name
+            }
+            if description:
+                stocks_dict['description'] = description
+            stocks_dict['grounding'] = {
                     'identifiers': {k: v for k, v in
                                     var.concept.identifiers.items()
                                     if k != 'biomodels.species'},
-                    'modifiers': var.concept.context,
-                },
-            }
+                    'modifiers': var.concept.context
+                }
             if var.concept.units:
                 stocks_dict['units'] = {
                     'expression': str(var.concept.units.expression),

--- a/mira/sources/amr/petrinet.py
+++ b/mira/sources/amr/petrinet.py
@@ -257,6 +257,7 @@ def state_to_concept(state):
     # names
     name = state['id']
     display_name = state.get('name')
+    description = state.get("description")
     grounding = state.get('grounding', {})
     identifiers = grounding.get('identifiers', {})
     context = grounding.get('modifiers', {})
@@ -265,6 +266,7 @@ def state_to_concept(state):
     units_obj = Unit(expression=units_expr) if units_expr else None
     return Concept(name=name,
                    display_name=display_name,
+                   description=description,
                    identifiers=identifiers,
                    context=context,
                    units=units_obj)

--- a/mira/sources/amr/stockflow.py
+++ b/mira/sources/amr/stockflow.py
@@ -2,7 +2,7 @@
 https://github.com/DARPA-ASKEM/Model-Representations/tree/main/stockflow.
 """
 __all__ = ["template_model_from_amr_json",
-           "stock_to_concept"]
+           "stock_to_concept", "model_from_url"]
 
 import sympy
 import requests


### PR DESCRIPTION
This PR addresses issue #389 where concept descriptions are not propagated when ingesting a petrinet amr and exporting a petrinet/stockflow amr. 