### PR TITLE
Process distributions from SBML models

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           sudo apt-get install graphviz libgraphviz-dev
           pip install --upgrade pip setuptools wheel
+          pip install --ignore-requires-python sbmlmath
           pip install "tox<4.0.0"
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,6 @@ jobs:
         run: |
           sudo apt-get install graphviz libgraphviz-dev
           pip install --upgrade pip setuptools wheel
-          pip install --ignore-requires-python sbmlmath
           pip install "tox<4.0.0"
       - name: Test with pytest
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.10" ]
+        python-version: [ "3.9", "3.12" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -8,7 +8,6 @@ Alternate XPath queries for COPASI data:
 import copy
 import math
 import libsbml
-from sbmlmath import SBMLMathMLParser
 from typing import Dict, Iterable, List, Mapping, Tuple
 
 from mira.sources.sbml.utils import *
@@ -808,6 +807,7 @@ def _extract_all_copasi_attrib(
 def get_distribution(obj):
     distr_tag = obj.getPlugin("distrib")
     if distr_tag:
+        from sbmlmath import SBMLMathMLParser
         for uncertainty in distr_tag.getListOfUncertainties():
             for param_uncertainty in uncertainty.getListOfUncertParameters():
                 mathml_str = libsbml.writeMathMLToString(param_uncertainty.getMath())

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -63,7 +63,7 @@ class SbmlProcessor:
                 and "cumulative" not in species_id
             ]
 
-        # Iterate thorugh all reactions and piecewise convert to templates
+        # Iterate through all reactions and piecewise convert to templates
         templates: List[Template] = []
         # see docs on reactions
         # https://sbml.org/software/libsbml/5.18.0/docs/formatted/python-api/

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
 
 zip_safe = false
 include_package_data = True
-python_requires = >=3.8
+python_requires = >=3.9
 
 # Where is my code
 packages = find:

--- a/tests/ABCD_model.xml
+++ b/tests/ABCD_model.xml
@@ -1,0 +1,312 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" level="3" version="2" distrib:required="true">
+  <model metaid="grn_model" id="grn_model">
+    <listOfCompartments>
+      <compartment sboTerm="SBO:0000410" id="default_compartment" spatialDimensions="3" size="1" constant="true"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species id="GeneA" name="GeneA" compartment="default_compartment" initialConcentration="10" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn type="integer"> 0 </cn>
+                  <cn type="integer"> 10 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </species>
+      <species id="GeneB" name="GeneB" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn type="integer"> 0 </cn>
+                  <cn type="integer"> 10 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </species>
+      <species id="GeneC" name="GeneC" compartment="default_compartment" initialConcentration="10" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn type="integer"> 0 </cn>
+                  <cn type="integer"> 10 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </species>
+      <species id="GeneD" name="GeneD" compartment="default_compartment" initialConcentration="0" hasOnlySubstanceUnits="false" boundaryCondition="false" constant="false">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn type="integer"> 0 </cn>
+                  <cn type="integer"> 10 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="n_GeneA_to_GeneB" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="K_GeneA_to_GeneB" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="beta_GeneA_to_GeneB" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="n_GeneB_to_GeneD" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="K_GeneB_to_GeneD" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="beta_GeneB_to_GeneD" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="n_GeneC_to_GeneB" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="beta_GeneC_to_GeneB" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+      <parameter id="K_GeneC_to_GeneB" value="1" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:type="distribution">
+              <math xmlns="http://www.w3.org/1998/Math/MathML">
+                <apply>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
+                  <cn> 0.1 </cn>
+                  <cn type="integer"> 3 </cn>
+                </apply>
+              </math>
+            </distrib:uncertParameter>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="J_GeneA_to_GeneB" reversible="false">
+        <listOfReactants>
+          <speciesReference species="GeneA" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="GeneB" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <power/>
+                  <ci> GeneA </ci>
+                  <ci> n_GeneA_to_GeneB </ci>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <apply>
+                  <power/>
+                  <ci> K_GeneA_to_GeneB </ci>
+                  <ci> n_GeneA_to_GeneB </ci>
+                </apply>
+                <apply>
+                  <power/>
+                  <ci> GeneA </ci>
+                  <ci> n_GeneA_to_GeneB </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="J_GeneB_to_GeneD" reversible="false">
+        <listOfReactants>
+          <speciesReference species="GeneB" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="GeneD" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <power/>
+                  <ci> GeneB </ci>
+                  <ci> n_GeneB_to_GeneD </ci>
+                </apply>
+              </apply>
+              <apply>
+                <plus/>
+                <apply>
+                  <power/>
+                  <ci> K_GeneB_to_GeneD </ci>
+                  <ci> n_GeneB_to_GeneD </ci>
+                </apply>
+                <apply>
+                  <power/>
+                  <ci> GeneB </ci>
+                  <ci> n_GeneB_to_GeneD </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+      <reaction id="J_GeneC_to_GeneB" reversible="false">
+        <listOfReactants>
+          <speciesReference species="GeneC" stoichiometry="1" constant="true"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference species="GeneB" stoichiometry="1" constant="true"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <cn type="integer"> 1 </cn>
+              <apply>
+                <plus/>
+                <cn type="integer"> 1 </cn>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <power/>
+                    <ci> GeneC </ci>
+                    <ci> n_GeneC_to_GeneB </ci>
+                  </apply>
+                  <cn type="integer"> 1 </cn>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/tests/test_sbml.py
+++ b/tests/test_sbml.py
@@ -1,7 +1,9 @@
+import os
 import sympy
 
 from mira.sources.sbml.processor import parse_assignment_rule, \
     process_unit_definition
+from mira.sources.sbml import template_model_from_sbml_file
 
 
 def test_parse_expr():
@@ -32,3 +34,13 @@ def test_unit_processing():
     person = MockUnit(12, 1, -1, 0)
     res = process_unit_definition(MockUnitDefinition([day, person]))
     assert res == 1 / (sympy.Symbol('day') * sympy.Symbol('person'))
+
+
+def test_distr_processing():
+    HERE = os.path.dirname(os.path.abspath(__file__))
+    model_file = os.path.join(HERE, 'ABCD_model.xml')
+    tm = template_model_from_sbml_file(model_file)
+
+    for p, v in tm.parameters.items():
+        assert v.distribution is not None
+        assert v.distribution.type == 'Uniform1'

--- a/tests/test_sbml.py
+++ b/tests/test_sbml.py
@@ -42,5 +42,7 @@ def test_distr_processing():
     tm = template_model_from_sbml_file(model_file)
 
     for p, v in tm.parameters.items():
+        if 'compartment' in p:
+            continue
         assert v.distribution is not None
         assert v.distribution.type == 'Uniform1'

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,9 @@ commands =
     coverage run -p -m pytest --durations=20 {posargs:tests} -m "not slow"
 ;    coverage combine
 ;    coverage xml
+commands_pre =
+    pip install --ignore-requires-python .
+
 [testenv:docs]
 extras =
     docs

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,12 @@ extras =
     dkg-construct
 deps = 
     anyio<4
-    sbmlmath
 commands =
     coverage run -p -m pytest --durations=20 {posargs:tests} -m "not slow"
 ;    coverage combine
 ;    coverage xml
 commands_pre =
-    pip install --ignore-requires-python .
+    pip install --ignore-requires-python sbmlmath
 
 [testenv:docs]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ extras =
     dkg-construct
 deps = 
     anyio<4
+    sbmlmath
 commands =
     coverage run -p -m pytest --durations=20 {posargs:tests} -m "not slow"
 ;    coverage combine


### PR DESCRIPTION
This PR extends the SBML processor to extract distributions from SBML models. Since distributions are not explicitly encoded in SBML, only as MathML expressions, we first convert MathML to SymPy and then map the name of the function representing the distribution and its arguments to ProbOnto. Generalization to a broader class of distributions can be done on a later PR. Distributions associated both with rate parameters and initial condition parameters are recognized.

The PR also adjusts Python versions for testing from 3.8-3.10 to 3.9-3.12. sbmlmath is nominally Python 3.10+ and works in practice on 3.9+, though not on 3.8 hence the version shift.

Fixes #361 