### PR TITLE
Extend SBML distribution processing

### DIFF
--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -805,6 +805,7 @@ def _extract_all_copasi_attrib(
 
 
 def get_distribution(obj):
+    """Return a Distribution oextracted from an SBML object if available."""
     distr_tag = obj.getPlugin("distrib")
     if distr_tag:
         # We import only if needed
@@ -821,13 +822,13 @@ def get_distribution(obj):
                     original_params, (probonto_type, probonto_params) = \
                         distribution_map[expr.func.name]
                     # We collect the parameters from the expression
-                    probonto_params = {}
+                    mapped_params = {}
                     for idx, (orig_param, probonto_param) in \
                             enumerate(zip(original_params, probonto_params)):
-                        probonto_params[probonto_param] = expr.args[idx]
+                        mapped_params[probonto_param] = expr.args[idx]
                     # Finally, construct the Distribution
                     distr = Distribution(type=probonto_type,
-                                         parameters=probonto_params)
+                                         parameters=mapped_params)
                     return distr
     return None
 

--- a/mira/sources/sbml/processor.py
+++ b/mira/sources/sbml/processor.py
@@ -812,14 +812,35 @@ def get_distribution(obj):
             for param_uncertainty in uncertainty.getListOfUncertParameters():
                 mathml_str = libsbml.writeMathMLToString(param_uncertainty.getMath())
                 expr = SBMLMathMLParser().parse_str(mathml_str)
-                if expr.func.name == 'uniform':
-                    distr = Distribution(
-                        type='Uniform1',
-                        parameters={
-                            'minimum': expr.args[0],
-                            'maximum': expr.args[1],
-                        }
 
+                # Check if the distribution function exists in the map
+                if expr.func.name in distribution_map:
+                    original_params, (probonto_type, probonto_params) = \
+                        distribution_map[expr.func.name]
+                    probonto_params = {}
+                    for idx, (orig_param, probonto_param) in \
+                            enumerate(zip(original_params, probonto_params)):
+                        probonto_params[probonto_param] = expr.args[idx]
+                    distr = Distribution(
+                        type=probonto_type,
+                        parameters=probonto_params
                     )
                     return distr
     return None
+
+
+distribution_map = {
+    'normal': (['mean', 'stdev'], ('Normal1', ['mean', 'stdev'])),
+    'uniform': (['min', 'max'], ('Uniform1', ['minimum', 'maximum'])),
+    'bernoulli': (['prob'], ('Bernoulli1', ['probability'])),
+    'binomial': (['nTrials', 'probabilityOfSuccess'],
+                 ('Binomial1', ['numberOfTrials', 'probability'])),
+    'cauchy': (['location', 'scale'], ('Cauchy1', ['location', 'scale'])),
+    'chisquare': (['degreesOfFreedom'], ('ChiSquare1', ['degreesOfFreedom'])),
+    'exponential': (['rate'], ('Exponential1', ['rate'])),
+    'gamma': (['shape', 'scale'], ('Gamma1', ['shape', 'scale'])),
+    'laplace': (['location', 'scale'], ('Laplace1', ['location', 'scale'])),
+    'lognormal': (['mean', 'stdev'], ('LogNormal1', ['meanLog', 'stdevLog'])),
+    'poisson': (['rate'], ('Poisson1', ['rate'])),
+    'rayleigh': (['scale'], ('Rayleigh1', ['scale'])),
+}

--- a/tests/ABCD_model.xml
+++ b/tests/ABCD_model.xml
@@ -26,9 +26,9 @@
             <distrib:uncertParameter distrib:type="distribution">
               <math xmlns="http://www.w3.org/1998/Math/MathML">
                 <apply>
-                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
-                  <cn type="integer"> 0 </cn>
-                  <cn type="integer"> 10 </cn>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/normal"> normal </csymbol>
+                  <cn type="real"> 2.7 </cn>
+                  <cn type="real"> 10.5 </cn>
                 </apply>
               </math>
             </distrib:uncertParameter>
@@ -41,9 +41,8 @@
             <distrib:uncertParameter distrib:type="distribution">
               <math xmlns="http://www.w3.org/1998/Math/MathML">
                 <apply>
-                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
-                  <cn type="integer"> 0 </cn>
-                  <cn type="integer"> 10 </cn>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/poisson"> poisson </csymbol>
+                  <cn type="real"> 0.1 </cn>
                 </apply>
               </math>
             </distrib:uncertParameter>
@@ -56,9 +55,9 @@
             <distrib:uncertParameter distrib:type="distribution">
               <math xmlns="http://www.w3.org/1998/Math/MathML">
                 <apply>
-                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/uniform"> uniform </csymbol>
-                  <cn type="integer"> 0 </cn>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/binomial"> binomial </csymbol>
                   <cn type="integer"> 10 </cn>
+                  <cn type="real"> 0.1 </cn>
                 </apply>
               </math>
             </distrib:uncertParameter>

--- a/tests/test_sbml.py
+++ b/tests/test_sbml.py
@@ -41,8 +41,30 @@ def test_distr_processing():
     model_file = os.path.join(HERE, 'ABCD_model.xml')
     tm = template_model_from_sbml_file(model_file)
 
+    lambda x: float(x.args[0])
+
+    # GeneA_init should be uniform 0 10
+    assert tm.parameters['GeneA_init'].distribution.type == 'Uniform1'
+    assert tm.parameters['GeneA_init'].distribution.parameters['minimum'].args[0] == 0
+    assert tm.parameters['GeneA_init'].distribution.parameters['maximum'].args[0] == 10
+
+    # GeneB init should be normal 2.7 10.5
+    assert tm.parameters['GeneB_init'].distribution.type == 'Normal1'
+    assert float(tm.parameters['GeneB_init'].distribution.parameters['mean'].args[0]) == 2.7
+    assert float(tm.parameters['GeneB_init'].distribution.parameters['stdev'].args[0]) == 10.5
+
+    # GeneC_init should be poisson 0.1
+    assert tm.parameters['GeneC_init'].distribution.type == 'Poisson1'
+    assert float(tm.parameters['GeneC_init'].distribution.parameters['rate'].args[0]) == 0.1
+
+    # GeneD_init should be binomial 10 0.1
+    assert tm.parameters['GeneD_init'].distribution.type == 'Binomial1'
+    assert tm.parameters['GeneD_init'].distribution.parameters['numberOfTrials'].args[0] == 10
+    assert float(tm.parameters['GeneD_init'].distribution.parameters['probability'].args[0]) == 0.1
+
     for p, v in tm.parameters.items():
-        if 'compartment' in p:
+        if 'compartment' in p or 'init' in p:
             continue
         assert v.distribution is not None
         assert v.distribution.type == 'Uniform1'
+        assert v.distribution.parameters


### PR DESCRIPTION
This PR makes the distribution processing from SBML more general by using a general mapping data structure from SBML distributions to ProbOnto which can be easily extended, if needed, though it covers all distributions in the specification. Resolves #394 