### PR TITLE
Update Docker build, pin pyobo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     add-apt-repository "deb https://debian.neo4j.com stable 4.4" && \
     apt-get install -y neo4j && \
     apt-get install -y git zip unzip bzip2 gcc graphviz graphviz-dev \
-        pkg-config python3 python3-pip && \
+        pkg-config python3-dev python3-pip && \
     # purge blinker here to avoid pip uninstall error below
     apt-get purge -y python3-blinker && \
     ln -s /usr/bin/python3 /usr/bin/python

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 WORKDIR /sw
 
@@ -9,10 +9,9 @@ RUN apt-get update && \
     add-apt-repository "deb https://debian.neo4j.com stable 4.4" && \
     apt-get install -y neo4j && \
     apt-get install -y git zip unzip bzip2 gcc graphviz graphviz-dev \
-        pkg-config python3-dev python3-pip && \
+        pkg-config python3.9-dev python3-pip && \
     # purge blinker here to avoid pip uninstall error below
-    apt-get purge -y python3-blinker && \
-    ln -s /usr/bin/python3 /usr/bin/python
+    apt-get purge -y python3-blinker
 
 ARG version=2024-09-30
 ARG domain=epi
@@ -30,16 +29,16 @@ RUN wget -O /sw/nodes.tsv.gz https://askem-mira.s3.amazonaws.com/dkg/$domain/bui
     neo4j-admin import --delimiter='TAB' --skip-duplicate-nodes=true --skip-bad-relationships=true --nodes /sw/nodes.tsv.gz --relationships /sw/edges.tsv.gz
 
 # Python packages
-RUN python -m pip install --upgrade pip && \
-    python -m pip install git+https://github.com/gyorilab/mira.git@main#egg=mira[web,uvicorn,dkg-client,dkg-construct] && \
-    python -m pip uninstall -y flask_bootstrap && \
-    python -m pip uninstall -y bootstrap_flask && \
-    python -m pip install bootstrap_flask && \
-    python -m pip install --no-dependencies pint && \
-    python -m pip install --no-dependencies "lxml>=4.6.4" && \
-    python -m pip install --no-dependencies sbmlmath
+RUN python3.9 -m pip install --upgrade pip && \
+    python3.9 -m pip install git+https://github.com/gyorilab/mira.git@docker-build#egg=mira[web,uvicorn,dkg-client,dkg-construct] && \
+    python3.9 -m pip uninstall -y flask_bootstrap && \
+    python3.9 -m pip uninstall -y bootstrap_flask && \
+    python3.9 -m pip install bootstrap_flask && \
+    python3.9 -m pip install --no-dependencies pint && \
+    python3.9 -m pip install --no-dependencies "lxml>=4.6.4" && \
+    python3.9 -m pip install --no-dependencies --ignore-requires-python sbmlmath
 
-RUN python -m mira.dkg.generate_obo_graphs
+RUN python3.9 -m mira.dkg.generate_obo_graphs
 
 # Copy the example json for reconstructing the ode semantics
 RUN wget -O /sw/sir_flux_span.json https://raw.githubusercontent.com/gyorilab/mira/main/tests/sir_flux_span.json

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ RUN python -m pip install --upgrade pip && \
     python -m pip install bootstrap_flask && \
     python -m pip install --no-dependencies pint && \
     python -m pip install --no-dependencies "lxml>=4.6.4" && \
-    python -m pip install --no-dependencies --ignore-requires-python sbmlmath
+    python -m pip install --no-dependencies sbmlmath
 
 RUN python -m mira.dkg.generate_obo_graphs
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:22.04
 
 WORKDIR /sw
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && \
     apt-get purge -y python3-blinker && \
     ln -s /usr/bin/python3 /usr/bin/python
 
-ARG version=2023-10-19
-ARG domain=climate
+ARG version=2024-09-30
+ARG domain=epi
 ARG embeddings_path=/sw/embeddings.tsv.gz
 # This latter is used in the code
 ENV MIRA_DOMAIN=${domain}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && \
     # purge blinker here to avoid pip uninstall error below
     apt-get purge -y python3-blinker
 
+RUN ln -s /usr/bin/python3.9 /usr/bin/python
+
 ARG version=2024-09-30
 ARG domain=epi
 ARG embeddings_path=/sw/embeddings.tsv.gz
@@ -29,16 +31,16 @@ RUN wget -O /sw/nodes.tsv.gz https://askem-mira.s3.amazonaws.com/dkg/$domain/bui
     neo4j-admin import --delimiter='TAB' --skip-duplicate-nodes=true --skip-bad-relationships=true --nodes /sw/nodes.tsv.gz --relationships /sw/edges.tsv.gz
 
 # Python packages
-RUN python3.9 -m pip install --upgrade pip && \
-    python3.9 -m pip install git+https://github.com/gyorilab/mira.git@docker-build#egg=mira[web,uvicorn,dkg-client,dkg-construct] && \
-    python3.9 -m pip uninstall -y flask_bootstrap && \
-    python3.9 -m pip uninstall -y bootstrap_flask && \
-    python3.9 -m pip install bootstrap_flask && \
-    python3.9 -m pip install --no-dependencies pint && \
-    python3.9 -m pip install --no-dependencies "lxml>=4.6.4" && \
-    python3.9 -m pip install --no-dependencies --ignore-requires-python sbmlmath
+RUN python -m pip install --upgrade pip && \
+    python -m pip install git+https://github.com/gyorilab/mira.git@main#egg=mira[web,uvicorn,dkg-client,dkg-construct] && \
+    python -m pip uninstall -y flask_bootstrap && \
+    python -m pip uninstall -y bootstrap_flask && \
+    python -m pip install bootstrap_flask && \
+    python -m pip install --no-dependencies pint && \
+    python -m pip install --no-dependencies "lxml>=4.6.4" && \
+    python -m pip install --no-dependencies --ignore-requires-python sbmlmath
 
-RUN python3.9 -m mira.dkg.generate_obo_graphs
+RUN python -m mira.dkg.generate_obo_graphs
 
 # Copy the example json for reconstructing the ode semantics
 RUN wget -O /sw/sir_flux_span.json https://raw.githubusercontent.com/gyorilab/mira/main/tests/sir_flux_span.json

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
+
+set -eoxu pipefail
+
+echo "Starting database"
 neo4j start
-sleep 100
+
+echo "Waiting for database"
+until [ \
+  "$(curl -s -w '%{http_code}' -o /dev/null "http://localhost:7474")" \
+  -eq 200 ]
+do
+  sleep 5
+done
+
 neo4j status
 
 # Index nodes on id property

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -18,6 +18,9 @@ neo4j status
 # Index nodes on id property
 python -m mira.dkg.indexing --exist-ok
 
+# Set ROOT_PATH to empty string if it is not set in the environment
+ROOT_PATH="${ROOT_PATH:-}"
+
 # Start the service
 
 if [ "${ROOT_PATH}" ]; then

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dkg-client =
     tqdm
 dkg-construct =
     bioontologies>=0.3.1
-    pyobo>=0.9.1,<0.11
+    pyobo>=0.9.1,<0.10.3
     bioregistry>=0.6.13
     click
     pystow
@@ -101,7 +101,7 @@ docs =
     autodoc-pydantic
     m2r2
     pygraphviz
-    pyobo<0.11
+    pyobo<0.10.3
     mock
     wget
 sbml =

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dkg-client =
     tqdm
 dkg-construct =
     bioontologies>=0.3.1
-    pyobo>=0.9.1,<0.10.3
+    pyobo>=0.9.1,<0.11
     bioregistry>=0.6.13
     click
     pystow
@@ -101,7 +101,7 @@ docs =
     autodoc-pydantic
     m2r2
     pygraphviz
-    pyobo<0.10.3
+    pyobo<0.11
     mock
     wget
 sbml =

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ dkg-client =
     tqdm
 dkg-construct =
     bioontologies>=0.3.1
-    pyobo>=0.9.1
+    pyobo>=0.9.1,<0.11
     bioregistry>=0.6.13
     click
     pystow
@@ -101,7 +101,7 @@ docs =
     autodoc-pydantic
     m2r2
     pygraphviz
-    pyobo
+    pyobo<0.11
     mock
     wget
 sbml =


### PR DESCRIPTION
This PR pins the pyobo to an earlier, stable release that works with out codebase in mira. Additionally, the following changes are made to the Dockerfile and the startup script:

- ~Build docker from ubuntu 22 instead of 20, allowing python 3.10 to be used. Ubuntu 20 used python 3.8 which has [reached EOL](https://endoflife.date/python) in October 2024.~ _Build from 20.04 but install and use python 3.9._
- Probe the neo4j instance on port 7474 during startup instead of waiting 100 s, since it usually takes a lot less than 100 s to start.