### PR TITLE
Stratify initial expressions and corresponding parameters

### DIFF
--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -258,21 +258,35 @@ def stratify(
                         all_param_mappings[old_param].add(new_param)
                     templates.append(stratified_template)
 
-    # Create new initial values for each of the strata
-    # of the original compartments, copied from the initial
-    # values of the original compartments
+    # Handle initial values and expressions depending on different
+    # criteria
     initials = {}
     for initial_key, initial in template_model.initials.items():
-        if initial.concept.name in exclude_concepts:
-            initials[initial.concept.name] = deepcopy(initial)
-            continue
+        # We need to keep track of whether we stratified any parameters in
+        # the expression for this initial and if the parameter is being
+        # replaced by multiple stratified parameters
         any_param_stratified = False
+        param_replacements = defaultdict(set)
+
         for stratum_idx, stratum in enumerate(strata):
-            new_concept = initial.concept.with_context(
-                do_rename=modify_names,
-                curie_to_name_map=strata_curie_to_name,
-                **{key: stratum},
-            )
+            # Figure out if the concept for this initial is one that we
+            # need to stratify or not
+            if (exclude_concepts and initial.concept.name in exclude_concepts) or \
+                    (concepts_to_preserve and initial.concept.name in concepts_to_preserve):
+                # Just make a copy of the original initial concept
+                new_concept = deepcopy(initial.concept)
+                concept_stratified = False
+            else:
+                # We create a new concept for the given stratum
+                new_concept = initial.concept.with_context(
+                    do_rename=modify_names,
+                    curie_to_name_map=strata_curie_to_name,
+                    **{key: stratum},
+                )
+                concept_stratified = True
+            # Now we may have to rewrite the expression so that we can
+            # update for stratified parameters so we make a copy and figure
+            # out what parameters are in the expression
             new_expression = deepcopy(initial.expression)
             init_expr_params = template_model.get_parameters_from_expression(
                 new_expression.args[0]
@@ -292,16 +306,41 @@ def stratify(
                 # where nothing was said about parameter stratification or the
                 # parameter was listed explicitly to be stratified
                 else:
+                    # We create a new parameter symbol for the given stratum
                     param_suffix = '_'.join([str(s) for s in template_strata])
                     new_param = f'{parameter}_{param_suffix}'
+                    # If the concept is not stratified then we have to replace
+                    # the original parameter with the sum of stratified ones
+                    # so we just keep track of that in a set
+                    any_param_stratified = True
+                    if not concept_stratified:
+                        param_replacements[parameter].add(new_param)
+                        continue
+                    # Otherwise we have to rewrite the expression to use the
+                    # new parameter as replacement for the original one
                     all_param_mappings[parameter].add(new_param)
                     new_expression = new_expression.subs(parameter,
                                                          sympy.Symbol(new_param))
-                    any_param_stratified = True
-            if not any_param_stratified:
-                new_initial = SympyExprStr(new_expression.args[0] / len(strata))
-            else:
+
+            # If we stratified any parameters in the expression then we have
+            # to update the initial value expression to reflect that
+            if any_param_stratified:
+                if param_replacements:
+                    for orig_param, new_params in param_replacements.items():
+                        new_expression = new_expression.subs(
+                            orig_param,
+                            sympy.Add(*[sympy.Symbol(np) for np in new_params])
+                        )
                 new_initial = new_expression
+            # Otherwise we can just use the original expression, except if the
+            # concept was stratified, then we have to divide the initial
+            # expression into as many parts as there are strata
+            else:
+                if concept_stratified:
+                    new_initial = SympyExprStr(new_expression.args[0] / len(strata))
+                else:
+                    new_initial = new_expression
+
             initials[new_concept.name] = \
                 Initial(concept=new_concept, expression=new_initial)
 

--- a/mira/metamodel/template_model.py
+++ b/mira/metamodel/template_model.py
@@ -373,6 +373,22 @@ class TemplateModel(BaseModel):
     )
 
     def get_parameters_from_expression(self, expression) -> Set[str]:
+        """Given a symbolic expression, find its elements that are model parameters.
+
+        Expressions such as rate laws consist of some combination of participants,
+        rate parameters and potentially other factors. This function finds those
+        elements of expressions that are rate parameters.
+
+        Parameters
+        ----------
+        expression : sympy.Symbol | sympy.Expr
+            A sympy expression or symbol, whose parameters are extracted.
+
+        Returns
+        -------
+        :
+            A set of parameter names (as strings).
+        """
         if expression is None:
             return set()
         params = set()
@@ -401,7 +417,7 @@ class TemplateModel(BaseModel):
         Parameters
         ----------
         rate_law : sympy.Symbol | sympy.Expr
-            A sympy expression or symbol, whose names are extracted.
+            A sympy expression or symbol, whose parameters are extracted.
 
         Returns
         -------

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -636,3 +636,20 @@ def test_add_observable_pattern():
     assert 'young' in tm.observables
     obs = tm.observables['young']
     assert obs.expression.args[0] == sympy.Symbol('A_young') + sympy.Symbol('B_young')
+
+
+def test_stratify_initials_parameters():
+    s = Concept(name='S')
+    t = NaturalDegradation(subject=s, rate_law=sympy.Symbol('alpha') *
+                                               sympy.Symbol(s.name))
+    S0 = Initial(concept=s, expression=sympy.Symbol('S0'))
+    tm = TemplateModel(templates=[t],
+                       parameters={'alpha': Parameter(name='alpha', value=0.1),
+                                   'S0': Parameter(name='S0', value=1000)},
+                       initials={'S': S0})
+    tm = stratify(tm, key='age', strata=['young', 'old'], structure=[],
+                  param_renaming_uses_strata_names=True)
+    assert 'S_young' in tm.initials
+    assert tm.initials['S_young'].expression.args[0] == sympy.Symbol('S0_young')
+    assert 'S_old' in tm.initials
+    assert tm.initials['S_old'].expression.args[0] == sympy.Symbol('S0_old')

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -647,9 +647,24 @@ def test_stratify_initials_parameters():
                        parameters={'alpha': Parameter(name='alpha', value=0.1),
                                    'S0': Parameter(name='S0', value=1000)},
                        initials={'S': S0})
-    tm = stratify(tm, key='age', strata=['young', 'old'], structure=[],
-                  param_renaming_uses_strata_names=True)
-    assert 'S_young' in tm.initials
-    assert tm.initials['S_young'].expression.args[0] == sympy.Symbol('S0_young')
-    assert 'S_old' in tm.initials
-    assert tm.initials['S_old'].expression.args[0] == sympy.Symbol('S0_old')
+    tm1 = stratify(tm, key='age', strata=['young', 'old'], structure=[],
+                   param_renaming_uses_strata_names=True)
+    assert 'S_young' in tm1.initials
+    assert tm1.initials['S_young'].expression.args[0] == sympy.Symbol('S0_young')
+    assert 'S_old' in tm1.initials
+    assert tm1.initials['S_old'].expression.args[0] == sympy.Symbol('S0_old')
+
+    tm2 = stratify(tm, key='age', strata=['young', 'old'], structure=[],
+                   param_renaming_uses_strata_names=True,
+                   params_to_preserve={'S0'})
+    assert 'S_young' in tm2.initials
+    assert tm2.initials['S_young'].expression.args[0] == sympy.Symbol('S0') / 2
+    assert 'S_old' in tm2.initials
+    assert tm2.initials['S_old'].expression.args[0] == sympy.Symbol('S0') / 2
+
+    tm3 = stratify(tm, key='age', strata=['young', 'old'], structure=[],
+                   param_renaming_uses_strata_names=True,
+                   concepts_to_preserve={'S'})
+    assert set(tm3.initials) == {'S'}
+    assert tm3.initials['S'].expression.args[0] == \
+        sympy.Symbol('S0_old') + sympy.Symbol('S0_young')

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -653,6 +653,10 @@ def test_stratify_initials_parameters():
     assert tm1.initials['S_young'].expression.args[0] == sympy.Symbol('S0_young')
     assert 'S_old' in tm1.initials
     assert tm1.initials['S_old'].expression.args[0] == sympy.Symbol('S0_old')
+    assert 'S0_young' in tm1.parameters
+    assert tm1.parameters['S0_young'].value == 500
+    assert 'S0_old' in tm1.parameters
+    assert tm1.parameters['S0_old'].value == 500
 
     tm2 = stratify(tm, key='age', strata=['young', 'old'], structure=[],
                    param_renaming_uses_strata_names=True,
@@ -661,6 +665,8 @@ def test_stratify_initials_parameters():
     assert tm2.initials['S_young'].expression.args[0] == sympy.Symbol('S0') / 2
     assert 'S_old' in tm2.initials
     assert tm2.initials['S_old'].expression.args[0] == sympy.Symbol('S0') / 2
+    assert 'S0' in tm2.parameters
+    assert tm2.parameters['S0'].value == 1000
 
     tm3 = stratify(tm, key='age', strata=['young', 'old'], structure=[],
                    param_renaming_uses_strata_names=True,
@@ -668,3 +674,6 @@ def test_stratify_initials_parameters():
     assert set(tm3.initials) == {'S'}
     assert tm3.initials['S'].expression.args[0] == \
         sympy.Symbol('S0_old') + sympy.Symbol('S0_young')
+    assert set(tm3.parameters) == {'alpha', 'S0_old', 'S0_young'}
+    assert tm3.parameters['S0_old'].value == 500
+    assert tm3.parameters['S0_young'].value == 500


### PR DESCRIPTION
This PR implements a new feature to extend stratification to non-trivial initial expressions that can contain parameters. Cases supported include all possible combinations of stratification or preservation of the concept whose initial is being defined as well as each parameter appearing in initial expressions. 

Resolves #408 