### PR TITLE
Add explicit file path to sphinx configuration file in readthedocs.yml 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,8 @@
 # See: https://docs.readthedocs.io/en/latest/config-file/v2.html
 
 version: 2
+sphinx:
+  configuration: docs/source/conf.py
 
 # Set the OS, Python version and other tools you might need
 build:


### PR DESCRIPTION
This PR allows for explicit sphinx configuration in the readthedocs.yml file to avoid deprecation as noted in this blog post: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/. 

This addresses #417. 