### PR TITLE
Reimplement ODE processing using a hypergraph

### DIFF
--- a/mira/sources/sympy_ode/__init__.py
+++ b/mira/sources/sympy_ode/__init__.py
@@ -1,5 +1,6 @@
 __all__ = ['template_model_from_sympy_odes']
 
+import itertools
 
 import sympy
 from sympy import Function, Derivative, Eq, Expr
@@ -15,6 +16,45 @@ def make_concept(name, data=None):
 def make_param(name, data=None):
     param_data = data.get(name, {}) if data else {}
     return Parameter(name=name, **param_data)
+
+
+class Hyperedge:
+    def __init__(self, sources, targets, data):
+        self.sources = sources if sources else set()
+        self.targets = targets if targets else set()
+        self.data = data
+
+    def __str__(self):
+        return '({%s}, {%s})' % (sorted(set(self.sources)),
+                                 sorted(set(self.targets)))
+
+    def __repr__(self):
+        return str(self)
+
+
+class Hypergraph:
+    def __init__(self, nodes=None, edges=None):
+        self.nodes = nodes if nodes else {}
+        self.edges = edges if edges else {}
+
+    def add_node(self, key, data):
+        self.nodes[key] = data
+
+    def add_edge(self, key, sources, targets, data=None):
+        self.edges[key] = Hyperedge(sources, targets, data)
+        for node in sources | targets:
+            if node not in self.nodes:
+                self.nodes[node] = {}
+
+    def get_connected_nodes(self):
+        connected_nodes = set()
+        for edge in self.edges.values():
+            connected_nodes |= edge.sources
+            connected_nodes |= edge.targets
+        return connected_nodes
+
+    def get_unconnected_nodes(self):
+        return set(self.nodes) - self.get_connected_nodes()
 
 
 def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
@@ -71,17 +111,17 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
         variables.append(variable_name)
 
     # Step 3: Interpret RHS equations
-    consumes = {}
-    produces = {}
     parameters = set()
     terms_by_key = {}
     term_effects = {}
+    all_terms = []
+    G = Hypergraph()
     for lhs_variable, eq in zip(variables, odes):
         # Access the RHS
         rhs = eq.rhs
         # Break up the RHS into a sum of terms
         terms = rhs.as_ordered_terms()
-        for term in terms:
+        for term_idx, term in enumerate(terms):
             neg = is_negative(term, time_variable)
             term_parameters = term.free_symbols - {time_variable}
             parameters |= term_parameters
@@ -95,98 +135,106 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
             key = (tuple(sorted([s.name for s in term.free_symbols])),
                    tuple(sorted([f.name for f in term.atoms(Function)])),
                    abs_diff_key(term))
-            if key not in term_effects:
-                term_effects[key] = {'consumes': [], 'produces': [],
-                                     'potential_controllers': set()}
-            if key not in terms_by_key or not neg:
-                terms_by_key[key] = term
-            if neg:
-                consumes[lhs_variable] = key
-                term_effects[key]['consumes'].append(lhs_variable)
-            else:
-                produces[lhs_variable] = key
-                term_effects[key]['produces'].append(lhs_variable)
+            all_terms.append((term, key, neg, lhs_variable))
             potential_controllers = {f.name for f in funcs} - {lhs_variable}
-            term_effects[key]['potential_controllers'] |= potential_controllers
+            G.add_node((lhs_variable, term_idx),
+                       {'key': key, 'neg': neg, 'term': term,
+                        'lhs_var': lhs_variable,
+                        'potential_controllers': potential_controllers})
 
-    params = {
-        p.name: make_param(name=p.name, data=param_data) for p in parameters
-    }
+    edge_idx = 0
+    for n1, n2 in itertools.combinations(G.nodes, 2):
+        if sympy.simplify(G.nodes[n1]['term'] + G.nodes[n2]['term']) == 0:
+            sources = {n1 if G.nodes[n1]['neg'] else n2}
+            targets = {n1, n2} - sources
+            G.add_edge(edge_idx, sources, targets)
+            edge_idx += 1
 
-    # Step 4: Create templates from the detected term effects
+    for n1, n2, n3 in itertools.combinations(G.get_unconnected_nodes(), 3):
+        nodes = {n1, n2, n3}
+        if sympy.simplify(G.nodes[n1]['term'] + G.nodes[n2]['term'] +
+                          G.nodes[n3]['term']) == 0:
+            sources = {n for n in nodes if G.nodes[n]['neg']}
+            targets = nodes - sources
+            G.add_edge(edge_idx, sources, targets)
+
     templates = []
-    for key, effects in term_effects.items():
-        controllers = effects['potential_controllers'] - set(effects['consumes'])
-        term = terms_by_key[key]
+    for node in G.get_unconnected_nodes():
+        data = G.nodes[node]
+        term = data['term']
         rate_law = term.subs({f: sympy.Symbol(f.name)
                               for f in term.atoms(Function)})
-        if not effects['produces']:
-            if len(effects['consumes']) == 1:
-                cons = effects['consumes'][0]
-                rate_law = -rate_law
-                if not controllers:
-                    template = NaturalDegradation(subject=make_concept(cons, concept_data),
-                                                  rate_law=rate_law)
-                    templates.append(template)
-                elif len(controllers) == 1:
-                    contr_concept = make_concept(controllers.pop(), concept_data)
-                    template = ControlledDegradation(subject=make_concept(cons, concept_data),
-                                                     controller=contr_concept,
-                                                     rate_law=rate_law)
-                    templates.append(template)
-                else:
-                    controller_concepts = [make_concept(c, concept_data) for c in controllers]
-                    template = GroupedControlledDegradation(subject=make_concept(cons, concept_data),
-                                                            controllers=controller_concepts,
-                                                            rate_law=rate_law)
-                    templates.append(template)
-        elif not effects['consumes']:
-            if len(effects['produces']) == 1:
-                prod = effects['produces'][0]
-                if not controllers:
-                    template = NaturalProduction(outcome=make_concept(prod, concept_data),
+        concept = make_concept(data['lhs_var'], concept_data)
+        controllers = data['potential_controllers'] - {data['lhs_var']}
+        if data['neg']:
+            if not controllers:
+                template = NaturalDegradation(subject=concept,
+                                              rate_law=rate_law)
+            elif len(controllers) == 1:
+                contr_concept = make_concept(controllers.pop(), concept_data)
+                template = ControlledDegradation(subject=concept,
+                                                 controller=contr_concept,
                                                  rate_law=rate_law)
-                    templates.append(template)
-                elif len(controllers) == 1:
-                    contr_concept = make_concept(controllers.pop(), concept_data)
-                    template = ControlledProduction(outcome=make_concept(prod, concept_data),
-                                                    controller=contr_concept,
-                                                    rate_law=rate_law)
-                    templates.append(template)
-                else:
-                    controller_concepts = [make_concept(c, concept_data) for c in controllers]
-                    template = GroupedControlledProduction(outcome=make_concept(prod,
-                                                                                concept_data),
-                                                           controllers=controller_concepts,
-                                                           rate_law=rate_law)
-                    templates.append(template)
-        elif len(effects['consumes']) == 1 and len(effects['produces']) == 1:
-            cons = effects['consumes'][0]
-            prod = effects['produces'][0]
-            if cons != prod:
-                cons_concept = make_concept(cons, concept_data)
-                prod_concept = make_concept(prod, concept_data)
-                if not controllers:
-                    template = NaturalConversion(subject=cons_concept,
-                                                 outcome=prod_concept,
-                                                 rate_law=rate_law)
-                    templates.append(template)
-                elif len(controllers) == 1:
-                    contr_concept = make_concept(controllers.pop(),
-                                                 concept_data)
-                    template = ControlledConversion(subject=cons_concept,
-                                                    controller=contr_concept,
-                                                    outcome=prod_concept,
-                                                    rate_law=rate_law)
-                    templates.append(template)
-                else:
-                    controller_concepts = [make_concept(c, concept_data) for c in controllers]
-                    template = \
-                        GroupedControlledConversion(subject=cons_concept,
-                                                    controllers=controller_concepts,
-                                                    outcome=prod_concept,
-                                                    rate_law=rate_law)
-                    templates.append(template)
+            else:
+                controller_concepts = [make_concept(c, concept_data)
+                                       for c in controllers]
+                template = GroupedControlledDegradation(
+                    subject=concept, controllers=controller_concepts,
+                    rate_law=rate_law)
+            templates.append(template)
+        else:
+            if not controllers:
+                template = NaturalProduction(outcome=concept,
+                                             rate_law=rate_law)
+            elif len(controllers) == 1:
+                contr_concept = make_concept(controllers.pop(), concept_data)
+                template = ControlledProduction(outcome=concept,
+                                                controller=contr_concept,
+                                                rate_law=rate_law)
+            else:
+                controller_concepts = [make_concept(c, concept_data)
+                                       for c in controllers]
+                template = GroupedControlledProduction(
+                    outcome=concept, controllers=controller_concepts,
+                    rate_law=rate_law)
+            templates.append(template)
+        templates.append(template)
+
+    for edge in G.edges.values():
+        all_potential_controllers = set()
+        for node in edge.sources | edge.targets:
+            all_potential_controllers |= G.nodes[node]['potential_controllers']
+        controllers = all_potential_controllers - \
+            {G.nodes[s]['lhs_var'] for s in edge.sources}
+        controller_concepts = [make_concept(c, concept_data)
+                               for c in controllers]
+        # Sources are consumed
+        source_concepts = {s: make_concept(G.nodes[s]['lhs_var'], concept_data)
+                           for s in edge.sources}
+        target_concepts = {t: make_concept(G.nodes[t]['lhs_var'], concept_data)
+                           for t in edge.targets}
+        for source, target in itertools.product(edge.sources, edge.targets):
+            source_concept = source_concepts[source]
+            target_concept = target_concepts[target]
+            term = G.nodes[target]['term']
+            rate_law = (term.subs({f: sympy.Symbol(f.name)
+                        for f in term.atoms(Function)}))
+            if not controllers:
+                template = NaturalConversion(subject=source_concept, outcome=target_concept,
+                                             rate_law=rate_law)
+            elif len(controllers) == 1:
+                template = ControlledConversion(subject=source_concept, outcome=target_concept,
+                                                controller=list(controller_concepts)[0],
+                                                rate_law=rate_law)
+            else:
+                template = GroupedControlledConversion(
+                    subject=source_concept, outcome=target_concept,
+                    controllers=controller_concepts,
+                    rate_law=rate_law)
+            templates.append(template)
+
+    params = {p.name: make_param(name=p.name, data=param_data)
+              for p in parameters}
 
     time = Time(name=time_variable.name)
     tm = TemplateModel(templates=templates, parameters=params,

--- a/tests/test_sympy_odes.py
+++ b/tests/test_sympy_odes.py
@@ -3,6 +3,13 @@ import sympy
 from mira.sources.sympy_ode import template_model_from_sympy_odes
 
 
+def sympy_eq(expr1, expr2):
+    if sympy.expand(expr1 - expr2) == 0:
+        return True
+    else:
+        return False
+
+
 def test_seir():
     # Define time variable
     t = sympy.symbols(r"t")
@@ -68,7 +75,7 @@ def test_branching():
     assert recovery.rate_law.args[0] == (1 - a) * b * sympy.Symbol('H')
 
 
-def test_merged_terms():
+def test_branching_explicit_parentheses():
     # Define time variable
     t = sympy.symbols(r"t")
 
@@ -94,3 +101,47 @@ def test_merged_terms():
     # H to D
     hd = [t for t in tm.templates if t.outcome.name == 'D'][0]
     assert hd.subject.name == 'H'
+
+
+def test_branching_implicit():
+    # Define time variable
+    t = sympy.symbols(r"t")
+
+    # Define the time-dependent variables
+    S, I, R, V = sympy.symbols(r"S I R V", cls=sympy.Function)
+
+    # Define the parameters
+    b, k, g = sympy.symbols(r"b k g")
+
+    sympy_equations = [
+        sympy.Eq(S(t).diff(t), -b*I(t)*S(t)),
+        sympy.Eq(I(t).diff(t), b*(I(t)*S(t)) - g*I(t)),
+        sympy.Eq(R(t).diff(t), k*(g*I(t))),
+        sympy.Eq(V(t).diff(t), (g*I(t))*(1 - k)),
+    ]
+
+    tm = template_model_from_sympy_odes(sympy_equations)
+
+    assert len(tm.templates) == 3
+
+    infection = [t for t in tm.templates
+                 if t.type == 'ControlledConversion'][0]
+    assert infection.subject.name == 'S'
+    assert infection.outcome.name == 'I'
+    assert infection.controller.name == 'I'
+    assert sympy_eq(infection.rate_law.args[0],
+        sympy.Symbol('b') * sympy.Symbol('S') * sympy.Symbol('I'))
+
+    recovery = [t for t in tm.templates
+                if t.type == 'NaturalConversion'
+                and t.outcome.name == 'R'][0]
+    assert recovery.subject.name == 'I'
+    assert sympy_eq(recovery.rate_law.args[0],
+        sympy.Symbol('k') * sympy.Symbol('g') * sympy.Symbol('I'))
+
+    vtransition = [t for t in tm.templates
+                   if t.type == 'NaturalConversion'
+                   and t.outcome.name == 'V'][0]
+    assert vtransition.subject.name == 'I'
+    assert sympy_eq(vtransition.rate_law.args[0],
+           (1 - sympy.Symbol('k')) * sympy.Symbol('g') * sympy.Symbol('I'))

--- a/tests/test_sympy_odes.py
+++ b/tests/test_sympy_odes.py
@@ -86,20 +86,11 @@ def test_merged_terms():
 
     tm = template_model_from_sympy_odes(sympy_equations)
     assert set(tm.parameters) == {'a', 'b'}
-    assert len(tm.templates) == 3
-    # H naturaldegradation
-    h_deg = tm.templates[0]
-    assert h_deg.type == 'NaturalDegradation'
-    assert h_deg.subject.name == 'H'
-    # D controlledproduction
-    d_prod = tm.templates[1]
-    assert d_prod.type == 'ControlledProduction'
-    assert d_prod.outcome.name == 'D'
-    assert d_prod.controller.name == 'H'
-    # R controlledproduction
-    r_prod = tm.templates[2]
-    assert r_prod.type == 'ControlledProduction'
-    assert r_prod.outcome.name == 'R'
-    assert r_prod.controller.name == 'H'
-
-
+    assert len(tm.templates) == 2
+    assert {t.type for t in tm.templates} == {'NaturalConversion'}
+    # H to R
+    hr = [t for t in tm.templates if t.outcome.name == 'R'][0]
+    assert hr.subject.name == 'H'
+    # H to D
+    hd = [t for t in tm.templates if t.outcome.name == 'D'][0]
+    assert hd.subject.name == 'H'


### PR DESCRIPTION
This PR implements a new algorithm for turning sympy equation representations of ODEs into TemplateModels, using a hypergraph data structure. This allows for inferring conversion between sets of terms consisting of more than two elements that aren't individually matching pairwise.

Example 1
----------

Here, we have explicit branching from H to D and R, represented in a way that the right-hand-side terms don't trivially match. It's explicit because `a` and `b` appear separately on the right hand side of H.

```python
sympy_equations = [
    sympy.Eq(H(t).diff(t), - (a + b) * H(t)),
    sympy.Eq(D(t).diff(t), a * H(t)),
    sympy.Eq(R(t).diff(t), b * H(t)),
]

model = template_model_from_sympy_odes(odes_sympy)
```

used to be interpreted as the Degradation of H and the ControlledProductions of D and R. In the new implementation, we reconstruct two NaturalConversions from H to D and H to R.

Example 2
----------

Here, we have an implicit branching where I branches into R and V in a way that the right hand side of I doesn't mention `k` which controls the branching.

```python
from sympy.parsing import latex

odes_latex = [
    "\\frac{d S(t)}{d t} = -b S(t) I(t)",
    "\\frac{d I(t)}{d t} = b S(t) I(t) - g I(t)",
    "\\frac{d R(t)}{d t} = k g I(t)",
    "\\frac{d V(t)}{d t} = (1 - k) g I(t)"
]
    
odes_sympy = [latex.parse_latex(ode) for ode in odes_latex]
model = template_model_from_sympy_odes(odes_sympy)
```

Again, in the old implementation, this was reconstructed as a set of degradations and productions. In the new implementation, we recognize a NaturalConversion from I to R and I to V.