### PR TITLE
Fix duplication of adding some templates in ODE processing

### DIFF
--- a/mira/sources/sympy_ode/__init__.py
+++ b/mira/sources/sympy_ode/__init__.py
@@ -176,7 +176,6 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
                 template = GroupedControlledDegradation(
                     subject=concept, controllers=controller_concepts,
                     rate_law=rate_law)
-            templates.append(template)
         else:
             if not controllers:
                 template = NaturalProduction(outcome=concept,
@@ -192,7 +191,6 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
                 template = GroupedControlledProduction(
                     outcome=concept, controllers=controller_concepts,
                     rate_law=rate_law)
-            templates.append(template)
         templates.append(template)
 
     # Next, we look at edges in the graph and construct conversion

--- a/tests/test_sympy_odes.py
+++ b/tests/test_sympy_odes.py
@@ -1,4 +1,5 @@
 import sympy
+from sympy import Function, symbols, Eq
 
 from mira.sources.sympy_ode import template_model_from_sympy_odes
 
@@ -145,3 +146,26 @@ def test_branching_implicit():
     assert vtransition.subject.name == 'I'
     assert sympy_eq(vtransition.rate_law.args[0],
            (1 - sympy.Symbol('k')) * sympy.Symbol('g') * sympy.Symbol('I'))
+
+
+def test_no_duplicate_templates():
+    # Define time variable
+    t = symbols("t")
+
+    # Define time-dependent variables
+    S, E, I, R, D, C = symbols("S E I R D C", cls=Function)
+
+    # Define constant parameters
+    beta, sigma, gamma, alpha, lambda_, N = symbols("beta sigma gamma alpha lambda N")
+
+    # Define the equations
+    equation_output = [
+        Eq(S(t).diff(t), (-beta * S(t) / N * I(t)).expand()),
+        Eq(E(t).diff(t), (beta * S(t) / N * I(t) - sigma * E(t)).expand()),
+        Eq(I(t).diff(t), (sigma * E(t) - gamma * I(t)).expand()),
+        Eq(R(t).diff(t), ((1 - alpha) * gamma * I(t)).expand()),
+        Eq(D(t).diff(t), (alpha * gamma * I(t)).expand()),
+        Eq(C(t).diff(t), (lambda_ * gamma * I(t)).expand())
+    ]
+    tm = template_model_from_sympy_odes(equation_output)
+    assert sum('lambda' in str(t.rate_law) for t in tm.templates) == 1


### PR DESCRIPTION
This PR fixes a small issue in which under certain conditions, a template is added twice when processing ODEs into Template Models.