### PR TITLE
Remove ambiguous edges in ODE hypergraph

### DIFF
--- a/mira/__init__.py
+++ b/mira/__init__.py
@@ -1,1 +1,10 @@
+import logging
+
 __version__ = "0.10.1"
+
+
+logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'
+                            ' - %(message)s'),
+                    level=logging.INFO, datefmt='%Y-%m-%d %H:%M:%S')
+
+logger = logging.getLogger('mira')

--- a/mira/sources/sympy_ode/__init__.py
+++ b/mira/sources/sympy_ode/__init__.py
@@ -1,12 +1,16 @@
 __all__ = ['template_model_from_sympy_odes']
 
 import itertools
+import logging
 
 import tqdm
 import sympy
 from sympy import Function, Derivative, Eq, Expr
 
 from mira.metamodel import *
+
+
+logger = logging.getLogger(__name__)
 
 
 def make_concept(name, data=None):
@@ -131,6 +135,7 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
             G.add_node((lhs_variable, term_idx),
                        {'neg': neg, 'term': term, 'lhs_var': lhs_variable,
                         'potential_controllers': potential_controllers})
+    logger.info("Constructed hypergraph with %d nodes", len(G.nodes))
 
     # First, we look at all pairs of terms and check if the terms are
     # compatible, in which case we add a hyperedge between them

--- a/mira/sources/sympy_ode/__init__.py
+++ b/mira/sources/sympy_ode/__init__.py
@@ -2,6 +2,7 @@ __all__ = ['template_model_from_sympy_odes']
 
 import itertools
 
+import tqdm
 import sympy
 from sympy import Function, Derivative, Eq, Expr
 
@@ -134,7 +135,7 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
     # First, we look at all pairs of terms and check if the terms are
     # compatible, in which case we add a hyperedge between them
     edge_idx = 0
-    for n1, n2 in itertools.combinations(G.nodes, 2):
+    for n1, n2 in tqdm.tqdm(itertools.combinations(G.nodes, 2)):
         if sympy.simplify(G.nodes[n1]['term'] + G.nodes[n2]['term']) == 0:
             sources = {n1 if G.nodes[n1]['neg'] else n2}
             targets = {n1, n2} - sources
@@ -143,7 +144,7 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
 
     # Next we look at all 3-sets of terms and see if they form an equation
     # in which case we add a hyperedge between the two sides
-    for n1, n2, n3 in itertools.combinations(G.get_unconnected_nodes(), 3):
+    for n1, n2, n3 in tqdm.tqdm(itertools.combinations(G.get_unconnected_nodes(), 3)):
         nodes = {n1, n2, n3}
         if sympy.simplify(G.nodes[n1]['term'] + G.nodes[n2]['term'] +
                           G.nodes[n3]['term']) == 0:

--- a/tests/test_sympy_odes.py
+++ b/tests/test_sympy_odes.py
@@ -187,3 +187,69 @@ def test_negative_term():
     ]
     tm = template_model_from_sympy_odes(equation_output)
     assert tm.templates[0].rate_law.args[0] == Symbol('mu') * Symbol('S')
+
+
+def test_large_model():
+    import sympy
+
+    # Define time variable
+    t = sympy.symbols("t")
+
+    # Define time-dependent variables
+    S, V_c, E_c, A_c, I_c, H_c, R_c = sympy.symbols("S V_c E_c A_c I_c H_c R_c", cls=sympy.Function)
+    V_f, E_f, I_f, R_f = sympy.symbols("V_f E_f I_f R_f", cls=sympy.Function)
+    V_c_f, E_c_f, I_c_f, R_c_f = sympy.symbols("V_c_f E_c_f I_c_f R_c_f", cls=sympy.Function)
+
+    # Define constant parameters
+    pi, kappa_c, kappa_f, kappa_c_f = sympy.symbols("pi kappa_c kappa_f kappa_c_f")
+    omega_c, omega_f, omega_c_f = sympy.symbols("omega_c omega_f omega_c_f")
+    nu, mu, lambd = sympy.symbols("nu_c mu lambda")
+    epsilon_c, epsilon_f, epsilon_c_f = sympy.symbols("epsilon_c epsilon_f epsilon_c_f")
+    sigma_c, psi_s, psi_a = sympy.symbols("sigma_c psi_s psi_a")
+    delta_c, theta_c, phi_f = sympy.symbols("delta_c theta_c phi_f")
+    tau_c, gamma_c = sympy.symbols("tau_c gamma_c")
+    kappa_c, kappa_f, kappa_c_f = sympy.symbols("kappa_c kappa_f kappa_c_f")
+    nu_c, nu_f, nu_c_f = sympy.symbols("nu_c nu_f nu_c_f")
+    sigma_f, gamma_f, delta_f, phi_c = sympy.symbols("sigma_f gamma_f delta_f phi_c")
+    sigma_c_f, gamma_c_f, delta_c_f = sympy.symbols("sigma_c_f gamma_c_f delta_c_f")
+    N = sympy.symbols("N")
+
+    beta_c, eta_A, eta_H, beta_f, beta_c_f, beta_f_c = sympy.symbols("beta_c eta_A eta_H beta_f beta_c_f beta_f_c")
+
+    # Define lambda terms
+    lambda_c = (beta_c * eta_A * A_c(t) + eta_H * H_c(t) + I_c(t)) / N
+    lambda_f = (beta_f * I_f(t)) / N
+    lambda_c_f = (beta_c_f * I_c_f(t)) / N
+    lambda_f_c = (beta_f_c * I_c_f(t)) / N
+
+    # Define system of equations
+    equations = [
+        sympy.Eq(S(t).diff(t), (
+                pi + kappa_c * R_c(t) + kappa_f * R_f(t) + kappa_c_f * R_c_f(t) + omega_c * V_c(t) + omega_f * V_f(
+            t) + omega_c_f * V_c_f(t) - (nu + mu + lambd) * S(t)).expand()),
+        sympy.Eq(V_c(t).diff(t), (nu_c * S(t) - epsilon_c * lambd * V_c(t) - (omega_c + mu) * V_c(t)).expand()),
+        sympy.Eq(E_c(t).diff(t), (
+                (lambda_c + lambda_c_f) * S(t) + epsilon_c * (lambda_c + lambda_c_f) * V_c(t) + epsilon_f * (
+                lambda_c + lambda_c_f) * V_f(t) - (sigma_c * psi_s + sigma_c * psi_a + mu) * E_c(t)).expand()),
+        sympy.Eq(A_c(t).diff(t),
+                 (sigma_c * psi_a * E_c(t) - (mu + delta_c + theta_c + phi_f * lambda_f) * A_c(t)).expand()),
+        sympy.Eq(I_c(t).diff(t),
+                 (sigma_c * psi_s * E_c(t) - tau_c * I_c(t) - (mu + delta_c + phi_f * lambda_f) * I_c(t)).expand()),
+        sympy.Eq(H_c(t).diff(t), (tau_c * I_c(t) - (mu + delta_c + gamma_c + phi_f * lambda_f) * H_c(t)).expand()),
+        sympy.Eq(R_c(t).diff(t), (theta_c * A_c(t) + gamma_c * H_c(t) - (kappa_c + mu) * R_c(t)).expand()),
+        sympy.Eq(V_f(t).diff(t), (nu_f * S(t) - epsilon_f * lambd * V_f(t) - (omega_f + mu) * V_f(t)).expand()),
+        sympy.Eq(E_f(t).diff(t), (
+                (lambda_f + lambda_f_c) * S(t) + epsilon_f * (lambda_f + lambda_f_c) * V_f(t) + epsilon_c * (
+                lambda_f + lambda_f_c) * V_c(t) - (sigma_f + mu) * E_f(t)).expand()),
+        sympy.Eq(I_f(t).diff(t), (sigma_f * E_f(t) - (gamma_f + mu + delta_f + phi_c * lambda_c) * I_f(t)).expand()),
+        sympy.Eq(R_f(t).diff(t), (gamma_f * I_f(t) - (kappa_f + mu) * R_f(t)).expand()),
+        sympy.Eq(V_c_f(t).diff(t),
+                 (nu_c_f * S(t) - epsilon_c_f * lambd * V_c_f(t) - (omega_c_f + mu) * V_c_f(t)).expand()),
+        sympy.Eq(E_c_f(t).diff(t), ((A_c(t) + I_c(t) + H_c(t)) * phi_f * lambda_f + phi_c * lambda_c * I_f(t) - (
+                sigma_c_f + mu) * E_c_f(t)).expand()),
+        sympy.Eq(I_c_f(t).diff(t), (sigma_c_f * E_c_f(t) - (gamma_c_f + mu + delta_c_f) * I_c_f(t)).expand()),
+        sympy.Eq(R_c_f(t).diff(t), (gamma_c_f * I_c_f(t) - (kappa_c_f + mu) * R_c_f(t)).expand())
+    ]
+    tm = template_model_from_sympy_odes(equations)
+    for t in tm.templates:
+        print(t.rate_law)

--- a/tests/test_sympy_odes.py
+++ b/tests/test_sympy_odes.py
@@ -196,60 +196,20 @@ def test_large_model():
     t = sympy.symbols("t")
 
     # Define time-dependent variables
-    S, V_c, E_c, A_c, I_c, H_c, R_c = sympy.symbols("S V_c E_c A_c I_c H_c R_c", cls=sympy.Function)
-    V_f, E_f, I_f, R_f = sympy.symbols("V_f E_f I_f R_f", cls=sympy.Function)
-    V_c_f, E_c_f, I_c_f, R_c_f = sympy.symbols("V_c_f E_c_f I_c_f R_c_f", cls=sympy.Function)
+    A, B, C, D = sympy.symbols("A B C D", cls=sympy.Function)
 
-    # Define constant parameters
-    pi, kappa_c, kappa_f, kappa_c_f = sympy.symbols("pi kappa_c kappa_f kappa_c_f")
-    omega_c, omega_f, omega_c_f = sympy.symbols("omega_c omega_f omega_c_f")
-    nu, mu, lambd = sympy.symbols("nu_c mu lambda")
-    epsilon_c, epsilon_f, epsilon_c_f = sympy.symbols("epsilon_c epsilon_f epsilon_c_f")
-    sigma_c, psi_s, psi_a = sympy.symbols("sigma_c psi_s psi_a")
-    delta_c, theta_c, phi_f = sympy.symbols("delta_c theta_c phi_f")
-    tau_c, gamma_c = sympy.symbols("tau_c gamma_c")
-    kappa_c, kappa_f, kappa_c_f = sympy.symbols("kappa_c kappa_f kappa_c_f")
-    nu_c, nu_f, nu_c_f = sympy.symbols("nu_c nu_f nu_c_f")
-    sigma_f, gamma_f, delta_f, phi_c = sympy.symbols("sigma_f gamma_f delta_f phi_c")
-    sigma_c_f, gamma_c_f, delta_c_f = sympy.symbols("sigma_c_f gamma_c_f delta_c_f")
-    N = sympy.symbols("N")
-
-    beta_c, eta_A, eta_H, beta_f, beta_c_f, beta_f_c = sympy.symbols("beta_c eta_A eta_H beta_f beta_c_f beta_f_c")
-
-    # Define lambda terms
-    lambda_c = (beta_c * eta_A * A_c(t) + eta_H * H_c(t) + I_c(t)) / N
-    lambda_f = (beta_f * I_f(t)) / N
-    lambda_c_f = (beta_c_f * I_c_f(t)) / N
-    lambda_f_c = (beta_f_c * I_c_f(t)) / N
-
-    # Define system of equations
-    equations = [
-        sympy.Eq(S(t).diff(t), (
-                pi + kappa_c * R_c(t) + kappa_f * R_f(t) + kappa_c_f * R_c_f(t) + omega_c * V_c(t) + omega_f * V_f(
-            t) + omega_c_f * V_c_f(t) - (nu + mu + lambd) * S(t)).expand()),
-        sympy.Eq(V_c(t).diff(t), (nu_c * S(t) - epsilon_c * lambd * V_c(t) - (omega_c + mu) * V_c(t)).expand()),
-        sympy.Eq(E_c(t).diff(t), (
-                (lambda_c + lambda_c_f) * S(t) + epsilon_c * (lambda_c + lambda_c_f) * V_c(t) + epsilon_f * (
-                lambda_c + lambda_c_f) * V_f(t) - (sigma_c * psi_s + sigma_c * psi_a + mu) * E_c(t)).expand()),
-        sympy.Eq(A_c(t).diff(t),
-                 (sigma_c * psi_a * E_c(t) - (mu + delta_c + theta_c + phi_f * lambda_f) * A_c(t)).expand()),
-        sympy.Eq(I_c(t).diff(t),
-                 (sigma_c * psi_s * E_c(t) - tau_c * I_c(t) - (mu + delta_c + phi_f * lambda_f) * I_c(t)).expand()),
-        sympy.Eq(H_c(t).diff(t), (tau_c * I_c(t) - (mu + delta_c + gamma_c + phi_f * lambda_f) * H_c(t)).expand()),
-        sympy.Eq(R_c(t).diff(t), (theta_c * A_c(t) + gamma_c * H_c(t) - (kappa_c + mu) * R_c(t)).expand()),
-        sympy.Eq(V_f(t).diff(t), (nu_f * S(t) - epsilon_f * lambd * V_f(t) - (omega_f + mu) * V_f(t)).expand()),
-        sympy.Eq(E_f(t).diff(t), (
-                (lambda_f + lambda_f_c) * S(t) + epsilon_f * (lambda_f + lambda_f_c) * V_f(t) + epsilon_c * (
-                lambda_f + lambda_f_c) * V_c(t) - (sigma_f + mu) * E_f(t)).expand()),
-        sympy.Eq(I_f(t).diff(t), (sigma_f * E_f(t) - (gamma_f + mu + delta_f + phi_c * lambda_c) * I_f(t)).expand()),
-        sympy.Eq(R_f(t).diff(t), (gamma_f * I_f(t) - (kappa_f + mu) * R_f(t)).expand()),
-        sympy.Eq(V_c_f(t).diff(t),
-                 (nu_c_f * S(t) - epsilon_c_f * lambd * V_c_f(t) - (omega_c_f + mu) * V_c_f(t)).expand()),
-        sympy.Eq(E_c_f(t).diff(t), ((A_c(t) + I_c(t) + H_c(t)) * phi_f * lambda_f + phi_c * lambda_c * I_f(t) - (
-                sigma_c_f + mu) * E_c_f(t)).expand()),
-        sympy.Eq(I_c_f(t).diff(t), (sigma_c_f * E_c_f(t) - (gamma_c_f + mu + delta_c_f) * I_c_f(t)).expand()),
-        sympy.Eq(R_c_f(t).diff(t), (gamma_c_f * I_c_f(t) - (kappa_c_f + mu) * R_c_f(t)).expand())
+    # Define the system of ODEs
+    odes = [
+        sympy.Eq(A(t).diff(t), - A(t) * B(t)),
+        sympy.Eq(B(t).diff(t), - A(t) * B(t)),
+        sympy.Eq(C(t).diff(t), A(t) * B(t)),
+        sympy.Eq(D(t).diff(t), A(t) * B(t))
     ]
-    tm = template_model_from_sympy_odes(equations)
-    for t in tm.templates:
-        print(t.rate_law)
+    tm = template_model_from_sympy_odes(odes)
+
+    # Make sure we resolve the ambiguity in some way, without
+    # duplicating templates
+    assert len(tm.templates) == 2
+    assert all(t.type == 'ControlledConversion' for t in tm.templates)
+    assert set(t.subject.name for t in tm.templates) == {'A', 'B'}
+    assert set(t.outcome.name for t in tm.templates) == {'C', 'D'}


### PR DESCRIPTION
This PR fixes #429 by removing ambiguous edges from the hypergraph created during ODE processing. The ambiguity is resolved in a deterministic but arbitrary way - in fact without additional information about the model's high-level structure it's not possible to resolve such ambiguities in a smarter way.