### PR TITLE
Implement feature to check effect of model simplification

### DIFF
--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -572,7 +572,7 @@ def simplify_rate_laws(template_model: TemplateModel):
 
 
 def check_simplify_rate_laws(template_model: TemplateModel) -> \
-        Mapping[str, Union[str, int]]:
+        Mapping[str, Union[str, int, TemplateModel]]:
     """Return a summary of what changes upon rate law simplification
 
     Parameters
@@ -593,11 +593,13 @@ def check_simplify_rate_laws(template_model: TemplateModel) -> \
            'max_controller_count': n}: If the model is simplified but the
            maximum number of controllers remains the same so it might not be
            worth doing the simplification. In this case the max controller
-           count in the model is also returned.
+           count in the model is returned. The simplified model
+           itself is also returned.
         - {'result': 'MEANINGFUL_CHANGE',
            'max_controller_decrease': n}: If the model is simplified and the
            maximum number of controllers also meaningfully changes. In this
-           case the decrease in the maximum controller count is also returned.
+           case the decrease in the maximum controller count is returned.
+           The simplified model itself is also returned.
     """
     if not any(isinstance(template, (GroupedControlledConversion,
                                      GroupedControlledProduction,
@@ -623,9 +625,11 @@ def check_simplify_rate_laws(template_model: TemplateModel) -> \
     new_max_count = max_controller_count(simplified_model)
     if old_max_count == new_max_count:
         return {'result': 'NO_CHANGE_IN_MAX_CONTROLLERS',
-                'max_controller_count': old_max_count}
+                'max_controller_count': old_max_count,
+                'simplified_model': simplified_model}
     return {'result': 'MEANINGFUL_CHANGE',
-            'max_controller_decrease': old_max_count - new_max_count}
+            'max_controller_decrease': old_max_count - new_max_count,
+            'simplified_model': simplified_model}
 
 
 def aggregate_parameters(template_model: TemplateModel) -> TemplateModel:

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -1,7 +1,7 @@
 """Operations for template models."""
 import logging
 from copy import deepcopy
-from collections import defaultdict, Counter
+from collections import defaultdict
 import itertools as itt
 from typing import Callable, Collection, Iterable, List, Mapping, Optional, \
     Tuple, Type, Union
@@ -10,13 +10,13 @@ import sympy
 
 from .template_model import TemplateModel, Initial, Parameter, Observable
 from .templates import *
-from .comparison import get_dkg_refinement_closure
 from .units import Unit
 from .utils import SympyExprStr
 
 __all__ = [
     "stratify",
     "simplify_rate_laws",
+    "check_simplify_rate_laws",
     "aggregate_parameters",
     "get_term_roles",
     "counts_to_dimensionless",
@@ -571,6 +571,36 @@ def simplify_rate_laws(template_model: TemplateModel):
     return template_model
 
 
+def check_simplify_rate_laws(template_model: TemplateModel):
+    if not any(isinstance(template, (GroupedControlledConversion,
+                                     GroupedControlledProduction,
+                                     GroupedControlledDegradation))
+               for template in template_model.templates):
+        return {'result': 'NO_GROUP_CONTROLLERS'}
+    simplified_model = simplify_rate_laws(template_model)
+    old_template_count = len(template_model.templates)
+    new_template_count = len(simplified_model.templates)
+    if old_template_count == new_template_count:
+        return {'result': 'NO_CHANGE'}
+
+    def max_controller_count(template_model):
+        max_count = 0
+        for template in template_model.templates:
+            if hasattr(template, 'controllers'):
+                max_count = max(len(template.get_controllers()), max_count)
+            elif hasattr(template, 'controller'):
+                max_count = max(1, max_count)
+        return max_count
+
+    old_max_count = max_controller_count(template_model)
+    new_max_count = max_controller_count(simplified_model)
+    if old_max_count == new_max_count:
+        return {'result': 'NO_CHANGE_IN_MAX_CONTROLLERS',
+                'max_controller_count': old_max_count}
+    return {'result': 'MEANINGFUL_CHANGE',
+            'max_controller_decrease': old_max_count - new_max_count}
+
+
 def aggregate_parameters(template_model: TemplateModel) -> TemplateModel:
     """Return a template model after aggregating parameters for mass-action
     rate laws.
@@ -628,6 +658,7 @@ def aggregate_parameters(template_model: TemplateModel) -> TemplateModel:
         # 4. If the replaced parameters disappear completely then we can remove
         #    them from the model.
     return template_model
+
 
 
 def simplify_rate_law(template: Template,

--- a/mira/metamodel/ops.py
+++ b/mira/metamodel/ops.py
@@ -571,7 +571,34 @@ def simplify_rate_laws(template_model: TemplateModel):
     return template_model
 
 
-def check_simplify_rate_laws(template_model: TemplateModel):
+def check_simplify_rate_laws(template_model: TemplateModel) -> \
+        Mapping[str, Union[str, int]]:
+    """Return a summary of what changes upon rate law simplification
+
+    Parameters
+    ----------
+    template_model :
+        A template model
+
+    Returns
+    -------
+    :
+        A dictionary with the result of the check under the `result` key.
+        The result can be one of the following:
+        - {'result': 'NO_GROUP_CONTROLLERS'}: If there are no templates with
+           grouped controllers
+        - {'result': 'NO_CHANGE'}: If the model does contain templates with
+           grouped controllers but simplification does not change the model.
+        - {'result': 'NO_CHANGE_IN_MAX_CONTROLLERS',
+           'max_controller_count': n}: If the model is simplified but the
+           maximum number of controllers remains the same so it might not be
+           worth doing the simplification. In this case the max controller
+           count in the model is also returned.
+        - {'result': 'MEANINGFUL_CHANGE',
+           'max_controller_decrease': n}: If the model is simplified and the
+           maximum number of controllers also meaningfully changes. In this
+           case the decrease in the maximum controller count is also returned.
+    """
     if not any(isinstance(template, (GroupedControlledConversion,
                                      GroupedControlledProduction,
                                      GroupedControlledDegradation))


### PR DESCRIPTION
This PR adds a new feature to model operations that can report on the effect of model simplification. The result of the simplification is reported, and if simplification is meaningful, metrics related to its effect, as well as the simplified model itself are returned.