### PR TITLE
Don't expand when parsing expressions

### DIFF
--- a/mira/metamodel/utils.py
+++ b/mira/metamodel/utils.py
@@ -49,7 +49,8 @@ def safe_parse_expr(s: str, local_dict=None) -> sympy.Expr:
     return sympy.parse_expr(get_parseable_expression(s),
                             local_dict={get_parseable_expression(k): v
                                         for k, v in local_dict.items()}
-                                        if local_dict else None)
+                                        if local_dict else None,
+                            evaluate=False)
 
 
 class SympyExprStr(sympy.Expr):

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -344,8 +344,7 @@ class TestModelApi(unittest.TestCase):
         )
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
-
-        assert tm == local
+        assess_template_model_equality(tm, local)
         self.assertEqual(
             sorted_json_str(tm.model_dump()), sorted_json_str(
                 local.model_dump())
@@ -403,7 +402,7 @@ class TestModelApi(unittest.TestCase):
         local = template_model_from_sbml_string(xml_string)
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
-        assert tm_res == local
+        assess_template_model_equality(tm_res, local)
         self.assertEqual(
             sorted_json_str(tm_res.model_dump()), sorted_json_str(
                 local.model_dump())
@@ -705,3 +704,26 @@ class TestModelApi(unittest.TestCase):
         assert len(flux_span_tm.templates) == 10
         assert len(flux_span_tm.parameters) == 11
         assert all(t.rate_law for t in flux_span_tm.templates)
+
+def assess_template_model_equality(tm_0, tm_1):
+    # Helper method to compare template models now
+    # The equality for rate-laws between templates cannot be tested with "=="
+    # Using "==" tests for structural inequality, we need to use expr.equals(expr1)
+    # to test for symbolic equality.
+    # This logic compares two template models using "==" for equality at every level
+    # except for template rate laws
+    for attr in vars(tm_0):
+        tm_0_val = getattr(tm_0, attr)
+        tm_1_val = getattr(tm_1, attr)
+        if attr == "templates":
+            for tm_0_template, tm_1_template in zip(tm_0_val, tm_1_val):
+                for template_attr in vars(tm_0_template):
+                    tm_0_template_value = getattr(tm_0_template, template_attr)
+                    tm_1_template_value = getattr(tm_1_template,
+                                                  template_attr)
+                    if template_attr == "rate_law":
+                        assert tm_0_template_value.equals(tm_1_template_value)
+                    else:
+                        assert tm_0_template_value == tm_1_template_value
+        else:
+            assert tm_0_val == tm_1_val

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -344,7 +344,7 @@ class TestModelApi(unittest.TestCase):
         )
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
-        assess_template_model_equality(tm, local)
+        assert_template_model_equality(tm, local)
         self.assertEqual(
             sorted_json_str(tm.model_dump()), sorted_json_str(
                 local.model_dump())
@@ -402,7 +402,7 @@ class TestModelApi(unittest.TestCase):
         local = template_model_from_sbml_string(xml_string)
         # This assert print a decently readable diff if it fails, but is
         # less restrictive than the string comparison below
-        assess_template_model_equality(tm_res, local)
+        assert_template_model_equality(tm_res, local)
         self.assertEqual(
             sorted_json_str(tm_res.model_dump()), sorted_json_str(
                 local.model_dump())
@@ -705,13 +705,15 @@ class TestModelApi(unittest.TestCase):
         assert len(flux_span_tm.parameters) == 11
         assert all(t.rate_law for t in flux_span_tm.templates)
 
-def assess_template_model_equality(tm_0, tm_1):
+
+def assert_template_model_equality(tm_0, tm_1):
     # Helper method to compare template models now
     # The equality for rate-laws between templates cannot be tested with "=="
-    # Using "==" tests for structural inequality, we need to use expr.equals(expr1)
-    # to test for symbolic equality.
-    # This logic compares two template models using "==" for equality at every level
-    # except for template rate laws
+    # Using "==" tests for structural inequality, we need to use
+    # expr.equals(expr1) to test for symbolic equality.
+    # This logic compares two template models using "==" for equality at every
+    # level except for template rate laws.
+    # TODO: this could be extended to other expressions appearing in models
     for attr in vars(tm_0):
         tm_0_val = getattr(tm_0, attr)
         tm_1_val = getattr(tm_1, attr)
@@ -719,8 +721,7 @@ def assess_template_model_equality(tm_0, tm_1):
             for tm_0_template, tm_1_template in zip(tm_0_val, tm_1_val):
                 for template_attr in vars(tm_0_template):
                     tm_0_template_value = getattr(tm_0_template, template_attr)
-                    tm_1_template_value = getattr(tm_1_template,
-                                                  template_attr)
+                    tm_1_template_value = getattr(tm_1_template, template_attr)
                     if template_attr == "rate_law":
                         assert tm_0_template_value.equals(tm_1_template_value)
                     else:

--- a/tests/test_modeling/test_amr_ops.py
+++ b/tests/test_modeling/test_amr_ops.py
@@ -272,9 +272,9 @@ class TestAskenetOperations(unittest.TestCase):
 
         self.assertEqual(old_param_dict[old_id]['value'], new_param_dict[new_id]['value'])
         self.assertEqual(old_param_dict[old_id]['distribution'], new_param_dict[new_id]['distribution'])
-        self.assertEqual(safe_parse_expr(old_param_dict[old_id]['units']['expression']),
+        self.assertTrue(safe_parse_expr(old_param_dict[old_id]['units']['expression']).equals(
                          safe_parse_expr(new_param_dict[new_id]['units'][
-                                             'expression']))
+                                             'expression'])))
         self.assertEqual(mathml_to_expression(old_param_dict[old_id]['units']['expression_mathml']),
                          mathml_to_expression(new_param_dict[new_id]['units']['expression_mathml']))
 

--- a/tests/test_system_dynamics.py
+++ b/tests/test_system_dynamics.py
@@ -171,9 +171,9 @@ def sir_end_to_end_test(model, amr, is_vensim):
 
     assert safe_parse_expr(
         amr_model["flows"][1]["rate_expression"]
-    ) == safe_parse_expr(
+    ).equals(safe_parse_expr(
         "infectious*susceptible*contact_infectivity/total_population"
-    )
+    ))
 
     assert amr_model["stocks"][0]["name"] == "infectious"
     assert amr_model["stocks"][1]["name"] == "recovered"
@@ -227,9 +227,9 @@ def tea_end_to_end_test(model, amr, is_vensim):
 
     assert safe_parse_expr(
         amr_model["flows"][0]["rate_expression"]
-    ) == safe_parse_expr(
+    ).equals(safe_parse_expr(
         "(teacup_temperature - room_temperature)/characteristic_time"
-    )
+    ))
 
     assert amr_model["stocks"][0]["name"] == "teacup_temperature"
 


### PR DESCRIPTION
This PR changes `safe_parse_expr` to not expand expressions by default. This has implications on the form of expressions in TemplateModels and requires updating various test checks.