### PR TITLE
Handle named functions on RHS of equations when processing ODEs

### DIFF
--- a/mira/sources/sympy_ode/__init__.py
+++ b/mira/sources/sympy_ode/__init__.py
@@ -175,7 +175,11 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
             parameters |= term.free_symbols - {time_variable}
             # Determine potential controllers of the term
             funcs = term.atoms(Function)
-            potential_controllers = {f.name for f in funcs} - {lhs_variable}
+            # Potential controllers are all variables in the term
+            # that are not the LHS variable
+            potential_controllers = \
+                ({f.name for f in funcs if hasattr(f, 'name')}
+                 & set(variables)) - {lhs_variable}
             # Now we add the term as a node to the hypergraph with some
             # further properties needed later
             G.add_node((lhs_variable, term_idx),
@@ -224,7 +228,8 @@ def template_model_from_sympy_odes(odes, concept_data=None, param_data=None):
         data = G.nodes[node]
         term = data['term']
         rate_law = term.subs({f: sympy.Symbol(f.name)
-                              for f in term.atoms(Function)})
+                              for f in term.atoms(Function)
+                              if hasattr(f, 'name') and f.name in variables})
         concept = make_concept(data['lhs_var'], concept_data)
         controllers = data['potential_controllers'] - {data['lhs_var']}
         if data['neg']:

--- a/tests/test_sympy_odes.py
+++ b/tests/test_sympy_odes.py
@@ -301,3 +301,19 @@ def test_extract_static():
     tm = template_model_from_sympy_odes(equation_output)
 
     assert all(isinstance(t, StaticConcept) for t in tm.templates)
+
+
+def test_sympy_named_functions():
+    t = sympy.Symbol('t')
+    S, I, R, V = sympy.symbols('S I R V', cls=sympy.Function)
+    a, b, c, d, g, k = sympy.symbols('a b c d g k')
+
+    odes = [
+        sympy.Eq(S(t).diff(t), - S(t) * (a * I(t) + b * R(t) + c * R(t) + d * V(t))),
+        sympy.Eq(I(t).diff(t), S(t) * (a * I(t) + b * R(t) + c * R(t) + d * V(t)) - g * I(t)),
+        sympy.Eq(R(t).diff(t), k * g * I(t)),
+        sympy.Eq(V(t).diff(t), (1 - k) * g * I(t) - sympy.exp(a) * V(t))
+
+    ]
+
+    model = template_model_from_sympy_odes(odes)


### PR DESCRIPTION
This PR adds handling for named sympy functions on the right hand side of ODEs that are processed into TemplateModels.

Fixes #443